### PR TITLE
docs: switch links to client documentation

### DIFF
--- a/docs/instance-api.rst
+++ b/docs/instance-api.rst
@@ -121,10 +121,10 @@ Now we go down the hierarchy from
 Head next to learn about the :doc:`table-api`.
 
 .. _Instance Admin API: https://cloud.google.com/bigtable/docs/creating-instance
-.. _CreateInstance: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_instance_admin.proto#L41-L47
-.. _GetInstance: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_instance_admin.proto#L50-L54
-.. _UpdateInstance: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_instance_admin.proto#L64-L69
-.. _DeleteInstance: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_instance_admin.proto#L81-L85
-.. _ListInstances: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_instance_admin.proto#L57-L61
-.. _GetOperation: https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto#L77-L82
+.. _CreateInstance: https://googleapis.dev/python/bigtable/latest/instance-api.html#create-a-new-instance
+.. _GetInstance: hhttps://googleapis.dev/python/bigtable/latest/instance-api.html#get-metadata-for-an-existing-instance
+.. _UpdateInstance: https://googleapis.dev/python/bigtable/latest/instance-api.html#update-an-existing-instance
+.. _DeleteInstance: https://googleapis.dev/python/bigtable/latest/instance-api.html#delete-an-existing-instance
+.. _ListInstances: https://googleapis.dev/python/bigtable/latest/instance-api.html#list-instances
+.. _GetOperation: https://googleapis.dev/python/bigtable/latest/instance-api.html#check-on-current-operation
 .. _long-running operation: https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto#L128-L162

--- a/docs/instance-api.rst
+++ b/docs/instance-api.rst
@@ -122,7 +122,7 @@ Head next to learn about the :doc:`table-api`.
 
 .. _Instance Admin API: https://cloud.google.com/bigtable/docs/creating-instance
 .. _CreateInstance: https://googleapis.dev/python/bigtable/latest/instance-api.html#create-a-new-instance
-.. _GetInstance: hhttps://googleapis.dev/python/bigtable/latest/instance-api.html#get-metadata-for-an-existing-instance
+.. _GetInstance: https://googleapis.dev/python/bigtable/latest/instance-api.html#get-metadata-for-an-existing-instance
 .. _UpdateInstance: https://googleapis.dev/python/bigtable/latest/instance-api.html#update-an-existing-instance
 .. _DeleteInstance: https://googleapis.dev/python/bigtable/latest/instance-api.html#delete-an-existing-instance
 .. _ListInstances: https://googleapis.dev/python/bigtable/latest/instance-api.html#list-instances

--- a/docs/row-filters.rst
+++ b/docs/row-filters.rst
@@ -64,4 +64,4 @@ level. For example:
   :members:
   :show-inheritance:
 
-.. _RowFilter definition: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_v2/proto/bigtable_data.proto#L196
+.. _RowFilter definition: https://googleapis.dev/python/bigtable/latest/row-filters.html?highlight=rowfilter#google.cloud.bigtable.row_filters.RowFilter

--- a/docs/table-api.rst
+++ b/docs/table-api.rst
@@ -143,11 +143,11 @@ data directly via a :class:`Table <google.cloud.bigtable.table.Table>`.
 
 Head next to learn about the :doc:`data-api`.
 
-.. _ListTables: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_table_admin.proto#L69-L73
-.. _CreateTable: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_table_admin.proto#L45-L50
-.. _DeleteTable: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_table_admin.proto#L83-L87
-.. _GetTable: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_table_admin.proto#L76-L80
-.. _CreateColumnFamily: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_table_admin.proto#L93-L98
-.. _UpdateColumnFamily: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_table_admin.proto#L93-L98
-.. _DeleteColumnFamily: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_table_admin.proto#L93-L98
+.. _ListTables: https://googleapis.dev/python/bigtable/latest/table-api.html#list-tables
+.. _CreateTable: https://googleapis.dev/python/bigtable/latest/table-api.html#create-a-new-table
+.. _DeleteTable: https://googleapis.dev/python/bigtable/latest/table-api.html#delete-an-existing-table
+.. _GetTable: https://github.com/googleapis/python-bigtable/blob/master/google/cloud/bigtable_admin_v2/proto/bigtable_table_admin.proto#L97-L102
+.. _CreateColumnFamily: https://googleapis.dev/python/bigtable/latest/table-api.html?highlight=gettable#create-a-new-column-family
+.. _UpdateColumnFamily: https://googleapis.dev/python/bigtable/latest/table-api.html?highlight=gettable#update-an-existing-column-family
+.. _DeleteColumnFamily: https://googleapis.dev/python/bigtable/latest/table-api.html?highlight=gettable#delete-an-existing-column-family
 .. _column families: https://cloud.google.com/bigtable/docs/schema-design#column_families_and_column_qualifiers


### PR DESCRIPTION
When we add new API, the line numbers for these docs in github can change. Switching to the client doc links so we don't have to update if line numbers change