### PR TITLE
tests: harden 'snippets_table.py' teardown against 429

### DIFF
--- a/docs/snippets_table.py
+++ b/docs/snippets_table.py
@@ -33,6 +33,8 @@ import datetime
 import pytest
 
 from test_utils.system import unique_resource_id
+from test_utils.retry import RetryErrors
+from google.api_core.exceptions import TooManyRequests
 from google.cloud._helpers import UTC
 from google.cloud.bigtable import Client
 from google.cloud.bigtable import enums
@@ -63,6 +65,8 @@ COLUMN_FAMILY_ID2 = "col_fam_id2"
 COL_NAME2 = b"col-name2"
 CELL_VAL2 = b"cell-val2"
 ROW_KEY2 = b"row_key_id2"
+
+retry_429 = RetryErrors(TooManyRequests, max_tries=9)
 
 
 class Config(object):
@@ -102,7 +106,7 @@ def setup_module():
 
 
 def teardown_module():
-    Config.INSTANCE.delete()
+    retry_429(Config.INSTANCE.delete)()
 
 
 def test_bigtable_create_table():


### PR DESCRIPTION
Toward #87.