### PR TITLE
fix: retry if failure occurs on initial call in MutateRows

### DIFF
--- a/google/cloud/bigtable/table.py
+++ b/google/cloud/bigtable/table.py
@@ -14,8 +14,6 @@
 
 """User-friendly container for Google Cloud Bigtable Table."""
 
-from grpc import StatusCode
-
 from google.api_core import timeout
 from google.api_core.exceptions import Aborted
 from google.api_core.exceptions import DeadlineExceeded
@@ -989,14 +987,11 @@ class _RetryableMutateRowsWorker(object):
     are retryable, any subsequent call on this callable will be a no-op.
     """
 
-    # pylint: disable=unsubscriptable-object
     RETRY_CODES = (
-        StatusCode.DEADLINE_EXCEEDED.value[0],
-        StatusCode.ABORTED.value[0],
-        StatusCode.UNAVAILABLE.value[0],
+        Aborted.grpc_status_code.value[0],
+        DeadlineExceeded.grpc_status_code.value[0],
+        ServiceUnavailable.grpc_status_code.value[0],
     )
-
-    # pylint: enable=unsubscriptable-object
 
     def __init__(self, client, table_name, rows, app_profile_id=None, timeout=None):
         self.client = client

--- a/google/cloud/bigtable/table.py
+++ b/google/cloud/bigtable/table.py
@@ -17,8 +17,11 @@
 from grpc import StatusCode
 
 from google.api_core import timeout
-from google.api_core.exceptions import RetryError
+from google.api_core.exceptions import Aborted
+from google.api_core.exceptions import DeadlineExceeded
 from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import RetryError
+from google.api_core.exceptions import ServiceUnavailable
 from google.api_core.retry import if_exception_type
 from google.api_core.retry import Retry
 from google.api_core.gapic_v1.method import wrap_method
@@ -1078,9 +1081,15 @@ class _RetryableMutateRowsWorker(object):
                 client_info=data_client._client_info,
             )
 
-        responses = data_client._inner_api_calls["mutate_rows"](
-            mutate_rows_request, retry=None
-        )
+        try:
+            responses = data_client._inner_api_calls["mutate_rows"](
+                mutate_rows_request, retry=None
+            )
+        except (ServiceUnavailable, DeadlineExceeded, Aborted):
+            # If an exception, considered retryable by `RETRY_CODES`, is
+            # returned from the initial call, consider
+            # it to be retryable. Wrap as a Bigtable Retryable Error.
+            raise _BigtableRetryableError
 
         num_responses = 0
         num_retryable_responses = 0


### PR DESCRIPTION
An issue identified that in certain cases we weren't retrying `ServiceUnavailable`. According the stack trace, it seems to come from the initial call.

I am currently running a stress test against this change to see if the exception path is activated.

Fixes #115