### PR TITLE
tests: 'test_scale_bigtable', backoff when testing cluster node counts

### DIFF
--- a/samples/metricscaler/requirements-test.txt
+++ b/samples/metricscaler/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest==5.3.2
 mock==3.0.5
+google-cloud-testutils


### PR DESCRIPTION
Closes #108
Closes #159
