### PR TITLE
feat: backup restore to another Instance

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,7 @@ SYSTEM_TEST_PYTHON_VERSIONS = ["2.7", "3.8"]
 UNIT_TEST_PYTHON_VERSIONS = ["2.7", "3.5", "3.6", "3.7", "3.8"]
 LOCAL_DEPS = ()
 
+
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint(session):
     """Run linters.
@@ -188,6 +189,7 @@ def docs(session):
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
     )
+
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def docfx(session):

--- a/tests/system.py
+++ b/tests/system.py
@@ -876,7 +876,9 @@ class TestTableAdminAPI(unittest.TestCase):
 
         # Testing `Backup.update_expire_time()` method
         expire += 3600  # A one-hour change in the `expire_time` parameter
-        temp_backup.update_expire_time(datetime.datetime.utcfromtimestamp(expire))
+        temp_backup.update_expire_time(
+            datetime.datetime.utcfromtimestamp(expire),
+        )
 
         # Testing `Backup.get()` method
         temp_table_backup = temp_backup.get()
@@ -886,11 +888,36 @@ class TestTableAdminAPI(unittest.TestCase):
         restored_table_id = "test-backup-table-restored"
         restored_table = Config.INSTANCE_DATA.table(restored_table_id)
         temp_table.restore(
-            restored_table_id, cluster_id=CLUSTER_ID_DATA, backup_id=temp_backup_id
+            restored_table_id,
+            cluster_id=CLUSTER_ID_DATA,
+            backup_id=temp_backup_id,
         ).result()
         tables = Config.INSTANCE_DATA.list_tables()
         self.assertIn(restored_table, tables)
         restored_table.delete()
+
+        # Testing `Backup.restore()` into a different instance:
+        # Setting up another instance...
+        alt_instance_id = "gcp-" + UNIQUE_SUFFIX
+        alt_cluster_id = alt_instance_id + "-cluster"
+        alt_instance = Config.CLIENT.instance(alt_instance_id, labels=LABELS)
+        alt_cluster = alt_instance.cluster(
+            cluster_id=alt_cluster_id,
+            location_id="us-east1-c",  # TODO: Change to default `LOCATION_ID`
+            serve_nodes=SERVE_NODES,
+        )
+        if not Config.IN_EMULATOR:
+            alt_instance.create(clusters=[alt_cluster]).result(timeout=10)
+
+        # Testing `reastore()`...
+        temp_backup.restore(restored_table_id, alt_instance_id).result()
+        restored_table = alt_instance.table(restored_table_id)
+        self.assertIn(restored_table, alt_instance.list_tables())
+        restored_table.delete()
+
+        # Tearing down the resources...
+        if not Config.IN_EMULATOR:
+            retry_429(alt_instance.delete)()
 
 
 class TestDataAPI(unittest.TestCase):

--- a/tests/system.py
+++ b/tests/system.py
@@ -909,7 +909,7 @@ class TestTableAdminAPI(unittest.TestCase):
         if not Config.IN_EMULATOR:
             alt_instance.create(clusters=[alt_cluster]).result(timeout=10)
 
-        # Testing `reastore()`...
+        # Testing `restore()`...
         temp_backup.restore(restored_table_id, alt_instance_id).result()
         restored_table = alt_instance.table(restored_table_id)
         self.assertIn(restored_table, alt_instance.list_tables())

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -32,6 +32,11 @@ class TestBackup(unittest.TestCase):
     BACKUP_ID = "backup-id"
     BACKUP_NAME = CLUSTER_NAME + "/backups/" + BACKUP_ID
 
+    ALT_INSTANCE = "other-instance-id"
+    ALT_INSTANCE_NAME = "projects/" + PROJECT_ID + "/instances/" + ALT_INSTANCE
+    ALT_CLUSTER_NAME = ALT_INSTANCE_NAME + "/clusters/" + CLUSTER_ID
+    ALT_BACKUP_NAME = ALT_CLUSTER_NAME + "/backups/" + BACKUP_ID
+
     @staticmethod
     def _get_target_class():
         from google.cloud.bigtable.backup import Backup
@@ -709,7 +714,7 @@ class TestBackup(unittest.TestCase):
         with self.assertRaises(ValueError):
             backup.restore(self.TABLE_ID)
 
-    def test_restore_success(self):
+    def _restore_helper(self, instance_id=None, instance_name=None):
         op_future = object()
         client = _Client()
         api = client.table_admin_client = self._make_table_admin_client()
@@ -724,15 +729,22 @@ class TestBackup(unittest.TestCase):
             expire_time=timestamp,
         )
 
-        future = backup.restore(self.TABLE_ID)
+        future = backup.restore(self.TABLE_ID, instance_id)
         self.assertEqual(backup._cluster, self.CLUSTER_ID)
         self.assertIs(future, op_future)
 
         api.restore_table.assert_called_once_with(
-            parent=self.INSTANCE_NAME,
+            parent=instance_name or self.INSTANCE_NAME,
             table_id=self.TABLE_ID,
             backup=self.BACKUP_NAME,
         )
+        api.restore_table.reset_mock()
+
+    def test_restore_default(self):
+        self._restore_helper()
+
+    def test_restore_to_another_instance(self):
+        self._restore_helper(self.ALT_INSTANCE, self.ALT_INSTANCE_NAME)
 
     def test_get_iam_policy(self):
         from google.cloud.bigtable.client import Client


### PR DESCRIPTION
**The summary of proposed changes:**

- A new optional argument added to `Backup.restore` method, allowing users to specify Instance to restore the backup into, if different from the one the backup was created in.

**ToDo:**

- (edit: kolea2) update region to `LOCATION_ID` global variable.