### PR TITLE
fix: fix unit test that could be broken by user's environment

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -103,6 +103,7 @@ class TestClient(unittest.TestCase):
     def _make_one(self, *args, **kwargs):
         return self._get_target_class()(*args, **kwargs)
 
+    @mock.patch("os.environ", {})
     def test_constructor_defaults(self):
         from google.cloud.bigtable.client import _CLIENT_INFO
         from google.cloud.bigtable.client import DATA_SCOPE


### PR DESCRIPTION
Unit test for the `google.cloud.bigtable.Client` constructor was picking
up the project from user's `GOOGLE_CLOUD_PROJECT` environment variable.
