### PR TITLE
chore: ignore noxfile in generation

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -55,7 +55,7 @@ templated_files = common.py_library(
     microgenerator=True,
     cov_level=99
 )
-s.move(templated_files, excludes=[".coveragerc"])
+s.move(templated_files, excludes=[".coveragerc", "noxfile.py"])
 
 # ----------------------------------------------------------------------------
 # Samples templates


### PR DESCRIPTION
Need to skip to not overwrite emulator config