### PR TITLE
chore: s.remove_staging_dirs() should only be called once

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -30,8 +30,6 @@ for library in s.get_staging_dirs(bigtable_default_version):
     s.move(library / "tests")
     s.move(library / "scripts")
 
-s.remove_staging_dirs()
-
 for library in s.get_staging_dirs(bigtable_admin_default_version):
     s.move(library / "google/cloud/bigtable_admin_v*")
     s.move(library / "tests")


### PR DESCRIPTION
There is [an issue](https://github.com/googleapis/python-bigtable/blob/master/owlbot.py#L33) in the `owlbot.py` file added in #313 in that [s.remove_staging_dirs()](https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L309) should only be called once after all the files are copied over.  [get_staging_dirs()](https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L280) will only return staging directories that exist.