### PR TITLE
chore: update owlbot.py to properly copy folders from googleapis-gen

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -20,9 +20,9 @@ deep-remove-regex:
 
 deep-copy-regex:
   - source: /google/bigtable/admin/(v.*)/.*-py/(.*)
-    dest: /owl-bot-staging/admin/$1/$2
+    dest: /owl-bot-staging/bigtable_admin/$1/$2
   - source: /google/bigtable/(v.*)/.*-py/(.*)
-    dest: /owl-bot-staging/$1/$2
+    dest: /owl-bot-staging/bigtable/$1/$2
 
 begin-after-commit-hash: a21f1091413a260393548c1b2ac44b7347923f08
 

--- a/google/cloud/bigtable_admin_v2/__init__.py
+++ b/google/cloud/bigtable_admin_v2/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,10 @@
 #
 
 from .services.bigtable_instance_admin import BigtableInstanceAdminClient
+from .services.bigtable_instance_admin import BigtableInstanceAdminAsyncClient
 from .services.bigtable_table_admin import BigtableTableAdminClient
+from .services.bigtable_table_admin import BigtableTableAdminAsyncClient
+
 from .types.bigtable_instance_admin import CreateAppProfileRequest
 from .types.bigtable_instance_admin import CreateClusterMetadata
 from .types.bigtable_instance_admin import CreateClusterRequest
@@ -79,15 +81,17 @@ from .types.table import ColumnFamily
 from .types.table import EncryptionInfo
 from .types.table import GcRule
 from .types.table import RestoreInfo
-from .types.table import RestoreSourceType
 from .types.table import Snapshot
 from .types.table import Table
-
+from .types.table import RestoreSourceType
 
 __all__ = (
+    "BigtableInstanceAdminAsyncClient",
+    "BigtableTableAdminAsyncClient",
     "AppProfile",
     "Backup",
     "BackupInfo",
+    "BigtableInstanceAdminClient",
     "BigtableTableAdminClient",
     "CheckConsistencyRequest",
     "CheckConsistencyResponse",
@@ -151,5 +155,4 @@ __all__ = (
     "UpdateBackupRequest",
     "UpdateClusterMetadata",
     "UpdateInstanceMetadata",
-    "BigtableInstanceAdminClient",
 )

--- a/google/cloud/bigtable_admin_v2/gapic_metadata.json
+++ b/google/cloud/bigtable_admin_v2/gapic_metadata.json
@@ -1,0 +1,447 @@
+ {
+  "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
+  "language": "python",
+  "libraryPackage": "google.cloud.bigtable_admin_v2",
+  "protoPackage": "google.bigtable.admin.v2",
+  "schema": "1.0",
+  "services": {
+    "BigtableInstanceAdmin": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "BigtableInstanceAdminClient",
+          "rpcs": {
+            "CreateAppProfile": {
+              "methods": [
+                "create_app_profile"
+              ]
+            },
+            "CreateCluster": {
+              "methods": [
+                "create_cluster"
+              ]
+            },
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "DeleteAppProfile": {
+              "methods": [
+                "delete_app_profile"
+              ]
+            },
+            "DeleteCluster": {
+              "methods": [
+                "delete_cluster"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            },
+            "GetAppProfile": {
+              "methods": [
+                "get_app_profile"
+              ]
+            },
+            "GetCluster": {
+              "methods": [
+                "get_cluster"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "ListAppProfiles": {
+              "methods": [
+                "list_app_profiles"
+              ]
+            },
+            "ListClusters": {
+              "methods": [
+                "list_clusters"
+              ]
+            },
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "PartialUpdateInstance": {
+              "methods": [
+                "partial_update_instance"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "UpdateAppProfile": {
+              "methods": [
+                "update_app_profile"
+              ]
+            },
+            "UpdateCluster": {
+              "methods": [
+                "update_cluster"
+              ]
+            },
+            "UpdateInstance": {
+              "methods": [
+                "update_instance"
+              ]
+            }
+          }
+        },
+        "grpc-async": {
+          "libraryClient": "BigtableInstanceAdminAsyncClient",
+          "rpcs": {
+            "CreateAppProfile": {
+              "methods": [
+                "create_app_profile"
+              ]
+            },
+            "CreateCluster": {
+              "methods": [
+                "create_cluster"
+              ]
+            },
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "DeleteAppProfile": {
+              "methods": [
+                "delete_app_profile"
+              ]
+            },
+            "DeleteCluster": {
+              "methods": [
+                "delete_cluster"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            },
+            "GetAppProfile": {
+              "methods": [
+                "get_app_profile"
+              ]
+            },
+            "GetCluster": {
+              "methods": [
+                "get_cluster"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "ListAppProfiles": {
+              "methods": [
+                "list_app_profiles"
+              ]
+            },
+            "ListClusters": {
+              "methods": [
+                "list_clusters"
+              ]
+            },
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "PartialUpdateInstance": {
+              "methods": [
+                "partial_update_instance"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "UpdateAppProfile": {
+              "methods": [
+                "update_app_profile"
+              ]
+            },
+            "UpdateCluster": {
+              "methods": [
+                "update_cluster"
+              ]
+            },
+            "UpdateInstance": {
+              "methods": [
+                "update_instance"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "BigtableTableAdmin": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "BigtableTableAdminClient",
+          "rpcs": {
+            "CheckConsistency": {
+              "methods": [
+                "check_consistency"
+              ]
+            },
+            "CreateBackup": {
+              "methods": [
+                "create_backup"
+              ]
+            },
+            "CreateTable": {
+              "methods": [
+                "create_table"
+              ]
+            },
+            "CreateTableFromSnapshot": {
+              "methods": [
+                "create_table_from_snapshot"
+              ]
+            },
+            "DeleteBackup": {
+              "methods": [
+                "delete_backup"
+              ]
+            },
+            "DeleteSnapshot": {
+              "methods": [
+                "delete_snapshot"
+              ]
+            },
+            "DeleteTable": {
+              "methods": [
+                "delete_table"
+              ]
+            },
+            "DropRowRange": {
+              "methods": [
+                "drop_row_range"
+              ]
+            },
+            "GenerateConsistencyToken": {
+              "methods": [
+                "generate_consistency_token"
+              ]
+            },
+            "GetBackup": {
+              "methods": [
+                "get_backup"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "GetSnapshot": {
+              "methods": [
+                "get_snapshot"
+              ]
+            },
+            "GetTable": {
+              "methods": [
+                "get_table"
+              ]
+            },
+            "ListBackups": {
+              "methods": [
+                "list_backups"
+              ]
+            },
+            "ListSnapshots": {
+              "methods": [
+                "list_snapshots"
+              ]
+            },
+            "ListTables": {
+              "methods": [
+                "list_tables"
+              ]
+            },
+            "ModifyColumnFamilies": {
+              "methods": [
+                "modify_column_families"
+              ]
+            },
+            "RestoreTable": {
+              "methods": [
+                "restore_table"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "SnapshotTable": {
+              "methods": [
+                "snapshot_table"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "UpdateBackup": {
+              "methods": [
+                "update_backup"
+              ]
+            }
+          }
+        },
+        "grpc-async": {
+          "libraryClient": "BigtableTableAdminAsyncClient",
+          "rpcs": {
+            "CheckConsistency": {
+              "methods": [
+                "check_consistency"
+              ]
+            },
+            "CreateBackup": {
+              "methods": [
+                "create_backup"
+              ]
+            },
+            "CreateTable": {
+              "methods": [
+                "create_table"
+              ]
+            },
+            "CreateTableFromSnapshot": {
+              "methods": [
+                "create_table_from_snapshot"
+              ]
+            },
+            "DeleteBackup": {
+              "methods": [
+                "delete_backup"
+              ]
+            },
+            "DeleteSnapshot": {
+              "methods": [
+                "delete_snapshot"
+              ]
+            },
+            "DeleteTable": {
+              "methods": [
+                "delete_table"
+              ]
+            },
+            "DropRowRange": {
+              "methods": [
+                "drop_row_range"
+              ]
+            },
+            "GenerateConsistencyToken": {
+              "methods": [
+                "generate_consistency_token"
+              ]
+            },
+            "GetBackup": {
+              "methods": [
+                "get_backup"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "GetSnapshot": {
+              "methods": [
+                "get_snapshot"
+              ]
+            },
+            "GetTable": {
+              "methods": [
+                "get_table"
+              ]
+            },
+            "ListBackups": {
+              "methods": [
+                "list_backups"
+              ]
+            },
+            "ListSnapshots": {
+              "methods": [
+                "list_snapshots"
+              ]
+            },
+            "ListTables": {
+              "methods": [
+                "list_tables"
+              ]
+            },
+            "ModifyColumnFamilies": {
+              "methods": [
+                "modify_column_families"
+              ]
+            },
+            "RestoreTable": {
+              "methods": [
+                "restore_table"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "SnapshotTable": {
+              "methods": [
+                "snapshot_table"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "UpdateBackup": {
+              "methods": [
+                "update_backup"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/google/cloud/bigtable_admin_v2/services/__init__.py
+++ b/google/cloud/bigtable_admin_v2/services/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/__init__.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from .client import BigtableInstanceAdminClient
 from .async_client import BigtableInstanceAdminAsyncClient
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/async_client.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/async_client.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from collections import OrderedDict
 import functools
 import re
@@ -22,10 +20,10 @@ from typing import Dict, Sequence, Tuple, Type, Union
 import pkg_resources
 
 import google.api_core.client_options as ClientOptions  # type: ignore
-from google.api_core import exceptions  # type: ignore
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
-from google.auth import credentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.oauth2 import service_account  # type: ignore
 
 from google.api_core import operation  # type: ignore
@@ -35,10 +33,9 @@ from google.cloud.bigtable_admin_v2.types import bigtable_instance_admin
 from google.cloud.bigtable_admin_v2.types import common
 from google.cloud.bigtable_admin_v2.types import instance
 from google.cloud.bigtable_admin_v2.types import instance as gba_instance
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.protobuf import field_mask_pb2 as field_mask  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.protobuf import field_mask_pb2  # type: ignore
 from .transports.base import BigtableInstanceAdminTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import BigtableInstanceAdminGrpcAsyncIOTransport
 from .client import BigtableInstanceAdminClient
@@ -68,31 +65,26 @@ class BigtableInstanceAdminAsyncClient:
     )
     instance_path = staticmethod(BigtableInstanceAdminClient.instance_path)
     parse_instance_path = staticmethod(BigtableInstanceAdminClient.parse_instance_path)
-
     common_billing_account_path = staticmethod(
         BigtableInstanceAdminClient.common_billing_account_path
     )
     parse_common_billing_account_path = staticmethod(
         BigtableInstanceAdminClient.parse_common_billing_account_path
     )
-
     common_folder_path = staticmethod(BigtableInstanceAdminClient.common_folder_path)
     parse_common_folder_path = staticmethod(
         BigtableInstanceAdminClient.parse_common_folder_path
     )
-
     common_organization_path = staticmethod(
         BigtableInstanceAdminClient.common_organization_path
     )
     parse_common_organization_path = staticmethod(
         BigtableInstanceAdminClient.parse_common_organization_path
     )
-
     common_project_path = staticmethod(BigtableInstanceAdminClient.common_project_path)
     parse_common_project_path = staticmethod(
         BigtableInstanceAdminClient.parse_common_project_path
     )
-
     common_location_path = staticmethod(
         BigtableInstanceAdminClient.common_location_path
     )
@@ -102,7 +94,8 @@ class BigtableInstanceAdminAsyncClient:
 
     @classmethod
     def from_service_account_info(cls, info: dict, *args, **kwargs):
-        """Creates an instance of this client using the provided credentials info.
+        """Creates an instance of this client using the provided credentials
+            info.
 
         Args:
             info (dict): The service account private key info.
@@ -117,7 +110,7 @@ class BigtableInstanceAdminAsyncClient:
     @classmethod
     def from_service_account_file(cls, filename: str, *args, **kwargs):
         """Creates an instance of this client using the provided credentials
-        file.
+            file.
 
         Args:
             filename (str): The path to the service account private key json
@@ -134,7 +127,7 @@ class BigtableInstanceAdminAsyncClient:
 
     @property
     def transport(self) -> BigtableInstanceAdminTransport:
-        """Return the transport used by the client instance.
+        """Returns the transport used by the client instance.
 
         Returns:
             BigtableInstanceAdminTransport: The transport used by the client instance.
@@ -149,12 +142,12 @@ class BigtableInstanceAdminAsyncClient:
     def __init__(
         self,
         *,
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         transport: Union[str, BigtableInstanceAdminTransport] = "grpc_asyncio",
         client_options: ClientOptions = None,
         client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
     ) -> None:
-        """Instantiate the bigtable instance admin client.
+        """Instantiates the bigtable instance admin client.
 
         Args:
             credentials (Optional[google.auth.credentials.Credentials]): The
@@ -186,7 +179,6 @@ class BigtableInstanceAdminAsyncClient:
             google.auth.exceptions.MutualTlsChannelError: If mutual TLS transport
                 creation failed for any reason.
         """
-
         self._client = BigtableInstanceAdminClient(
             credentials=credentials,
             transport=transport,
@@ -248,7 +240,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``clusters`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -280,7 +271,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
         if instance_id is not None:
@@ -342,7 +332,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -372,7 +361,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -385,7 +373,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -428,7 +417,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -455,7 +443,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
 
@@ -468,7 +455,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -509,7 +497,6 @@ class BigtableInstanceAdminAsyncClient:
                 served from all
                 [Clusters][google.bigtable.admin.v2.Cluster] in the
                 instance.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -526,7 +513,6 @@ class BigtableInstanceAdminAsyncClient:
 
         """
         # Create or coerce a protobuf request object.
-
         request = instance.Instance(request)
 
         # Wrap the RPC method; this adds retry and timeout information,
@@ -538,7 +524,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -563,7 +550,7 @@ class BigtableInstanceAdminAsyncClient:
         request: bigtable_instance_admin.PartialUpdateInstanceRequest = None,
         *,
         instance: gba_instance.Instance = None,
-        update_mask: field_mask.FieldMask = None,
+        update_mask: field_mask_pb2.FieldMask = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -591,7 +578,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -623,7 +609,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if instance is not None:
             request.instance = instance
         if update_mask is not None:
@@ -638,7 +623,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -691,7 +677,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -712,7 +697,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -776,7 +760,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``cluster`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -807,7 +790,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
         if cluster_id is not None:
@@ -866,7 +848,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -895,7 +876,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -908,7 +888,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -953,7 +934,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -980,7 +960,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
 
@@ -993,7 +972,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1029,7 +1009,6 @@ class BigtableInstanceAdminAsyncClient:
                 particular cloud location, capable of serving all
                 [Tables][google.bigtable.admin.v2.Table] in the parent
                 [Instance][google.bigtable.admin.v2.Instance].
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1047,7 +1026,6 @@ class BigtableInstanceAdminAsyncClient:
 
         """
         # Create or coerce a protobuf request object.
-
         request = instance.Cluster(request)
 
         # Wrap the RPC method; this adds retry and timeout information,
@@ -1059,7 +1037,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1110,7 +1089,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1131,7 +1109,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -1195,7 +1172,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``app_profile`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1223,7 +1199,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
         if app_profile_id is not None:
@@ -1274,7 +1249,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1302,7 +1276,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -1315,7 +1288,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1361,7 +1335,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1391,7 +1364,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
 
@@ -1404,7 +1376,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1435,7 +1408,7 @@ class BigtableInstanceAdminAsyncClient:
         request: bigtable_instance_admin.UpdateAppProfileRequest = None,
         *,
         app_profile: instance.AppProfile = None,
-        update_mask: field_mask.FieldMask = None,
+        update_mask: field_mask_pb2.FieldMask = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -1461,7 +1434,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1490,7 +1462,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if app_profile is not None:
             request.app_profile = app_profile
         if update_mask is not None:
@@ -1505,7 +1476,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1558,7 +1530,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1579,7 +1550,6 @@ class BigtableInstanceAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -1604,13 +1574,13 @@ class BigtableInstanceAdminAsyncClient:
 
     async def get_iam_policy(
         self,
-        request: iam_policy.GetIamPolicyRequest = None,
+        request: iam_policy_pb2.GetIamPolicyRequest = None,
         *,
         resource: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> policy.Policy:
+    ) -> policy_pb2.Policy:
         r"""Gets the access control policy for an instance
         resource. Returns an empty policy if an instance exists
         but does not have a policy set.
@@ -1628,7 +1598,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``resource`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1707,10 +1676,9 @@ class BigtableInstanceAdminAsyncClient:
         # The request isn't a proto-plus wrapped type,
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
-            request = iam_policy.GetIamPolicyRequest(**request)
-
+            request = iam_policy_pb2.GetIamPolicyRequest(**request)
         elif not request:
-            request = iam_policy.GetIamPolicyRequest(resource=resource,)
+            request = iam_policy_pb2.GetIamPolicyRequest(resource=resource,)
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
@@ -1721,7 +1689,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1743,13 +1712,13 @@ class BigtableInstanceAdminAsyncClient:
 
     async def set_iam_policy(
         self,
-        request: iam_policy.SetIamPolicyRequest = None,
+        request: iam_policy_pb2.SetIamPolicyRequest = None,
         *,
         resource: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> policy.Policy:
+    ) -> policy_pb2.Policy:
         r"""Sets the access control policy on an instance
         resource. Replaces any existing policy.
 
@@ -1766,7 +1735,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``resource`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1845,10 +1813,9 @@ class BigtableInstanceAdminAsyncClient:
         # The request isn't a proto-plus wrapped type,
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
-            request = iam_policy.SetIamPolicyRequest(**request)
-
+            request = iam_policy_pb2.SetIamPolicyRequest(**request)
         elif not request:
-            request = iam_policy.SetIamPolicyRequest(resource=resource,)
+            request = iam_policy_pb2.SetIamPolicyRequest(resource=resource,)
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
@@ -1872,14 +1839,14 @@ class BigtableInstanceAdminAsyncClient:
 
     async def test_iam_permissions(
         self,
-        request: iam_policy.TestIamPermissionsRequest = None,
+        request: iam_policy_pb2.TestIamPermissionsRequest = None,
         *,
         resource: str = None,
         permissions: Sequence[str] = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> iam_policy.TestIamPermissionsResponse:
+    ) -> iam_policy_pb2.TestIamPermissionsResponse:
         r"""Returns permissions that the caller has on the
         specified instance resource.
 
@@ -1905,7 +1872,6 @@ class BigtableInstanceAdminAsyncClient:
                 This corresponds to the ``permissions`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1929,10 +1895,9 @@ class BigtableInstanceAdminAsyncClient:
         # The request isn't a proto-plus wrapped type,
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
-            request = iam_policy.TestIamPermissionsRequest(**request)
-
+            request = iam_policy_pb2.TestIamPermissionsRequest(**request)
         elif not request:
-            request = iam_policy.TestIamPermissionsRequest(
+            request = iam_policy_pb2.TestIamPermissionsRequest(
                 resource=resource, permissions=permissions,
             )
 
@@ -1945,7 +1910,8 @@ class BigtableInstanceAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),

--- a/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/client.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/client.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from collections import OrderedDict
 from distutils import util
 import os
@@ -23,10 +21,10 @@ from typing import Callable, Dict, Optional, Sequence, Tuple, Type, Union
 import pkg_resources
 
 from google.api_core import client_options as client_options_lib  # type: ignore
-from google.api_core import exceptions  # type: ignore
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
-from google.auth import credentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport import mtls  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
 from google.auth.exceptions import MutualTLSChannelError  # type: ignore
@@ -39,10 +37,9 @@ from google.cloud.bigtable_admin_v2.types import bigtable_instance_admin
 from google.cloud.bigtable_admin_v2.types import common
 from google.cloud.bigtable_admin_v2.types import instance
 from google.cloud.bigtable_admin_v2.types import instance as gba_instance
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.protobuf import field_mask_pb2 as field_mask  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.protobuf import field_mask_pb2  # type: ignore
 from .transports.base import BigtableInstanceAdminTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import BigtableInstanceAdminGrpcTransport
 from .transports.grpc_asyncio import BigtableInstanceAdminGrpcAsyncIOTransport
@@ -65,7 +62,7 @@ class BigtableInstanceAdminClientMeta(type):
     def get_transport_class(
         cls, label: str = None,
     ) -> Type[BigtableInstanceAdminTransport]:
-        """Return an appropriate transport class.
+        """Returns an appropriate transport class.
 
         Args:
             label: The name of the desired transport. If none is
@@ -92,7 +89,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @staticmethod
     def _get_default_mtls_endpoint(api_endpoint):
-        """Convert api endpoint to mTLS endpoint.
+        """Converts api endpoint to mTLS endpoint.
+
         Convert "*.sandbox.googleapis.com" and "*.googleapis.com" to
         "*.mtls.sandbox.googleapis.com" and "*.mtls.googleapis.com" respectively.
         Args:
@@ -126,7 +124,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @classmethod
     def from_service_account_info(cls, info: dict, *args, **kwargs):
-        """Creates an instance of this client using the provided credentials info.
+        """Creates an instance of this client using the provided credentials
+            info.
 
         Args:
             info (dict): The service account private key info.
@@ -143,7 +142,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
     @classmethod
     def from_service_account_file(cls, filename: str, *args, **kwargs):
         """Creates an instance of this client using the provided credentials
-        file.
+            file.
 
         Args:
             filename (str): The path to the service account private key json
@@ -162,23 +161,24 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @property
     def transport(self) -> BigtableInstanceAdminTransport:
-        """Return the transport used by the client instance.
+        """Returns the transport used by the client instance.
 
         Returns:
-            BigtableInstanceAdminTransport: The transport used by the client instance.
+            BigtableInstanceAdminTransport: The transport used by the client
+                instance.
         """
         return self._transport
 
     @staticmethod
     def app_profile_path(project: str, instance: str, app_profile: str,) -> str:
-        """Return a fully-qualified app_profile string."""
+        """Returns a fully-qualified app_profile string."""
         return "projects/{project}/instances/{instance}/appProfiles/{app_profile}".format(
             project=project, instance=instance, app_profile=app_profile,
         )
 
     @staticmethod
     def parse_app_profile_path(path: str) -> Dict[str, str]:
-        """Parse a app_profile path into its component segments."""
+        """Parses a app_profile path into its component segments."""
         m = re.match(
             r"^projects/(?P<project>.+?)/instances/(?P<instance>.+?)/appProfiles/(?P<app_profile>.+?)$",
             path,
@@ -187,14 +187,14 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @staticmethod
     def cluster_path(project: str, instance: str, cluster: str,) -> str:
-        """Return a fully-qualified cluster string."""
+        """Returns a fully-qualified cluster string."""
         return "projects/{project}/instances/{instance}/clusters/{cluster}".format(
             project=project, instance=instance, cluster=cluster,
         )
 
     @staticmethod
     def parse_cluster_path(path: str) -> Dict[str, str]:
-        """Parse a cluster path into its component segments."""
+        """Parses a cluster path into its component segments."""
         m = re.match(
             r"^projects/(?P<project>.+?)/instances/(?P<instance>.+?)/clusters/(?P<cluster>.+?)$",
             path,
@@ -205,7 +205,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
     def crypto_key_path(
         project: str, location: str, key_ring: str, crypto_key: str,
     ) -> str:
-        """Return a fully-qualified crypto_key string."""
+        """Returns a fully-qualified crypto_key string."""
         return "projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}".format(
             project=project,
             location=location,
@@ -215,7 +215,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @staticmethod
     def parse_crypto_key_path(path: str) -> Dict[str, str]:
-        """Parse a crypto_key path into its component segments."""
+        """Parses a crypto_key path into its component segments."""
         m = re.match(
             r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)/keyRings/(?P<key_ring>.+?)/cryptoKeys/(?P<crypto_key>.+?)$",
             path,
@@ -224,20 +224,20 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @staticmethod
     def instance_path(project: str, instance: str,) -> str:
-        """Return a fully-qualified instance string."""
+        """Returns a fully-qualified instance string."""
         return "projects/{project}/instances/{instance}".format(
             project=project, instance=instance,
         )
 
     @staticmethod
     def parse_instance_path(path: str) -> Dict[str, str]:
-        """Parse a instance path into its component segments."""
+        """Parses a instance path into its component segments."""
         m = re.match(r"^projects/(?P<project>.+?)/instances/(?P<instance>.+?)$", path)
         return m.groupdict() if m else {}
 
     @staticmethod
     def common_billing_account_path(billing_account: str,) -> str:
-        """Return a fully-qualified billing_account string."""
+        """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
         )
@@ -250,7 +250,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @staticmethod
     def common_folder_path(folder: str,) -> str:
-        """Return a fully-qualified folder string."""
+        """Returns a fully-qualified folder string."""
         return "folders/{folder}".format(folder=folder,)
 
     @staticmethod
@@ -261,7 +261,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @staticmethod
     def common_organization_path(organization: str,) -> str:
-        """Return a fully-qualified organization string."""
+        """Returns a fully-qualified organization string."""
         return "organizations/{organization}".format(organization=organization,)
 
     @staticmethod
@@ -272,7 +272,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @staticmethod
     def common_project_path(project: str,) -> str:
-        """Return a fully-qualified project string."""
+        """Returns a fully-qualified project string."""
         return "projects/{project}".format(project=project,)
 
     @staticmethod
@@ -283,7 +283,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     @staticmethod
     def common_location_path(project: str, location: str,) -> str:
-        """Return a fully-qualified location string."""
+        """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
             project=project, location=location,
         )
@@ -297,12 +297,12 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
     def __init__(
         self,
         *,
-        credentials: Optional[credentials.Credentials] = None,
+        credentials: Optional[ga_credentials.Credentials] = None,
         transport: Union[str, BigtableInstanceAdminTransport, None] = None,
         client_options: Optional[client_options_lib.ClientOptions] = None,
         client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
     ) -> None:
-        """Instantiate the bigtable instance admin client.
+        """Instantiates the bigtable instance admin client.
 
         Args:
             credentials (Optional[google.auth.credentials.Credentials]): The
@@ -357,9 +357,10 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 client_cert_source_func = client_options.client_cert_source
             else:
                 is_mtls = mtls.has_default_client_cert_source()
-                client_cert_source_func = (
-                    mtls.default_client_cert_source() if is_mtls else None
-                )
+                if is_mtls:
+                    client_cert_source_func = mtls.default_client_cert_source()
+                else:
+                    client_cert_source_func = None
 
         # Figure out which api endpoint to use.
         if client_options.api_endpoint is not None:
@@ -371,12 +372,14 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
             elif use_mtls_env == "always":
                 api_endpoint = self.DEFAULT_MTLS_ENDPOINT
             elif use_mtls_env == "auto":
-                api_endpoint = (
-                    self.DEFAULT_MTLS_ENDPOINT if is_mtls else self.DEFAULT_ENDPOINT
-                )
+                if is_mtls:
+                    api_endpoint = self.DEFAULT_MTLS_ENDPOINT
+                else:
+                    api_endpoint = self.DEFAULT_ENDPOINT
             else:
                 raise MutualTLSChannelError(
-                    "Unsupported GOOGLE_API_USE_MTLS_ENDPOINT value. Accepted values: never, auto, always"
+                    "Unsupported GOOGLE_API_USE_MTLS_ENDPOINT value. Accepted "
+                    "values: never, auto, always"
                 )
 
         # Save or instantiate the transport.
@@ -391,8 +394,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 )
             if client_options.scopes:
                 raise ValueError(
-                    "When providing a transport instance, "
-                    "provide its scopes directly."
+                    "When providing a transport instance, provide its scopes "
+                    "directly."
                 )
             self._transport = transport
         else:
@@ -461,7 +464,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``clusters`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -495,10 +497,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.CreateInstanceRequest):
             request = bigtable_instance_admin.CreateInstanceRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
             if instance_id is not None:
@@ -555,7 +555,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -587,10 +586,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.GetInstanceRequest):
             request = bigtable_instance_admin.GetInstanceRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -633,7 +630,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -662,10 +658,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.ListInstancesRequest):
             request = bigtable_instance_admin.ListInstancesRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
 
@@ -706,7 +700,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 served from all
                 [Clusters][google.bigtable.admin.v2.Cluster] in the
                 instance.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -723,7 +716,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
         """
         # Create or coerce a protobuf request object.
-
         # Minor optimization to avoid making a copy if the user passes
         # in a instance.Instance.
         # There's no risk of modifying the input as we've already verified
@@ -752,7 +744,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         request: bigtable_instance_admin.PartialUpdateInstanceRequest = None,
         *,
         instance: gba_instance.Instance = None,
-        update_mask: field_mask.FieldMask = None,
+        update_mask: field_mask_pb2.FieldMask = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -780,7 +772,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -816,10 +807,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
             request, bigtable_instance_admin.PartialUpdateInstanceRequest
         ):
             request = bigtable_instance_admin.PartialUpdateInstanceRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if instance is not None:
                 request.instance = instance
             if update_mask is not None:
@@ -874,7 +863,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -897,10 +885,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.DeleteInstanceRequest):
             request = bigtable_instance_admin.DeleteInstanceRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -960,7 +946,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``cluster`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -993,10 +978,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.CreateClusterRequest):
             request = bigtable_instance_admin.CreateClusterRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
             if cluster_id is not None:
@@ -1051,7 +1034,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1082,10 +1064,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.GetClusterRequest):
             request = bigtable_instance_admin.GetClusterRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -1130,7 +1110,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1159,10 +1138,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.ListClustersRequest):
             request = bigtable_instance_admin.ListClustersRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
 
@@ -1198,7 +1175,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 particular cloud location, capable of serving all
                 [Tables][google.bigtable.admin.v2.Table] in the parent
                 [Instance][google.bigtable.admin.v2.Instance].
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1216,7 +1192,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
         """
         # Create or coerce a protobuf request object.
-
         # Minor optimization to avoid making a copy if the user passes
         # in a instance.Cluster.
         # There's no risk of modifying the input as we've already verified
@@ -1271,7 +1246,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1294,10 +1268,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.DeleteClusterRequest):
             request = bigtable_instance_admin.DeleteClusterRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -1357,7 +1329,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``app_profile`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1387,10 +1358,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.CreateAppProfileRequest):
             request = bigtable_instance_admin.CreateAppProfileRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
             if app_profile_id is not None:
@@ -1437,7 +1406,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1467,10 +1435,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.GetAppProfileRequest):
             request = bigtable_instance_admin.GetAppProfileRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -1516,7 +1482,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1548,10 +1513,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.ListAppProfilesRequest):
             request = bigtable_instance_admin.ListAppProfilesRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
 
@@ -1582,7 +1545,7 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         request: bigtable_instance_admin.UpdateAppProfileRequest = None,
         *,
         app_profile: instance.AppProfile = None,
-        update_mask: field_mask.FieldMask = None,
+        update_mask: field_mask_pb2.FieldMask = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -1608,7 +1571,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1639,10 +1601,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.UpdateAppProfileRequest):
             request = bigtable_instance_admin.UpdateAppProfileRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if app_profile is not None:
                 request.app_profile = app_profile
             if update_mask is not None:
@@ -1697,7 +1657,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1720,10 +1679,8 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_instance_admin.DeleteAppProfileRequest):
             request = bigtable_instance_admin.DeleteAppProfileRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -1744,13 +1701,13 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     def get_iam_policy(
         self,
-        request: iam_policy.GetIamPolicyRequest = None,
+        request: iam_policy_pb2.GetIamPolicyRequest = None,
         *,
         resource: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> policy.Policy:
+    ) -> policy_pb2.Policy:
         r"""Gets the access control policy for an instance
         resource. Returns an empty policy if an instance exists
         but does not have a policy set.
@@ -1768,7 +1725,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``resource`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1847,11 +1803,10 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         if isinstance(request, dict):
             # The request isn't a proto-plus wrapped type,
             # so it must be constructed via keyword expansion.
-            request = iam_policy.GetIamPolicyRequest(**request)
+            request = iam_policy_pb2.GetIamPolicyRequest(**request)
         elif not request:
             # Null request, just make one.
-            request = iam_policy.GetIamPolicyRequest()
-
+            request = iam_policy_pb2.GetIamPolicyRequest()
             if resource is not None:
                 request.resource = resource
 
@@ -1873,13 +1828,13 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     def set_iam_policy(
         self,
-        request: iam_policy.SetIamPolicyRequest = None,
+        request: iam_policy_pb2.SetIamPolicyRequest = None,
         *,
         resource: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> policy.Policy:
+    ) -> policy_pb2.Policy:
         r"""Sets the access control policy on an instance
         resource. Replaces any existing policy.
 
@@ -1896,7 +1851,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``resource`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1975,11 +1929,10 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         if isinstance(request, dict):
             # The request isn't a proto-plus wrapped type,
             # so it must be constructed via keyword expansion.
-            request = iam_policy.SetIamPolicyRequest(**request)
+            request = iam_policy_pb2.SetIamPolicyRequest(**request)
         elif not request:
             # Null request, just make one.
-            request = iam_policy.SetIamPolicyRequest()
-
+            request = iam_policy_pb2.SetIamPolicyRequest()
             if resource is not None:
                 request.resource = resource
 
@@ -2001,14 +1954,14 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 
     def test_iam_permissions(
         self,
-        request: iam_policy.TestIamPermissionsRequest = None,
+        request: iam_policy_pb2.TestIamPermissionsRequest = None,
         *,
         resource: str = None,
         permissions: Sequence[str] = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> iam_policy.TestIamPermissionsResponse:
+    ) -> iam_policy_pb2.TestIamPermissionsResponse:
         r"""Returns permissions that the caller has on the
         specified instance resource.
 
@@ -2034,7 +1987,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
                 This corresponds to the ``permissions`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2058,14 +2010,12 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
         if isinstance(request, dict):
             # The request isn't a proto-plus wrapped type,
             # so it must be constructed via keyword expansion.
-            request = iam_policy.TestIamPermissionsRequest(**request)
+            request = iam_policy_pb2.TestIamPermissionsRequest(**request)
         elif not request:
             # Null request, just make one.
-            request = iam_policy.TestIamPermissionsRequest()
-
+            request = iam_policy_pb2.TestIamPermissionsRequest()
             if resource is not None:
                 request.resource = resource
-
             if permissions:
                 request.permissions.extend(permissions)
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/pagers.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/pagers.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from typing import (
     Any,
     AsyncIterable,
@@ -120,7 +118,7 @@ class ListAppProfilesAsyncPager:
         *,
         metadata: Sequence[Tuple[str, str]] = ()
     ):
-        """Instantiate the pager.
+        """Instantiates the pager.
 
         Args:
             method (Callable): The method that was originally called, and

--- a/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/__init__.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from collections import OrderedDict
 from typing import Dict, Type
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/base.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/base.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,25 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import abc
-import typing
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+import packaging.version
 import pkg_resources
 
-from google import auth  # type: ignore
-from google.api_core import exceptions  # type: ignore
+import google.auth  # type: ignore
+import google.api_core  # type: ignore
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 from google.api_core import operations_v1  # type: ignore
-from google.auth import credentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 
 from google.cloud.bigtable_admin_v2.types import bigtable_instance_admin
 from google.cloud.bigtable_admin_v2.types import instance
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.longrunning import operations_pb2 as operations  # type: ignore
-from google.protobuf import empty_pb2 as empty  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.longrunning import operations_pb2  # type: ignore
+from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
@@ -42,6 +41,17 @@ try:
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
+
+try:
+    # google.auth.__version__ was added in 1.26.0
+    _GOOGLE_AUTH_VERSION = google.auth.__version__
+except AttributeError:
+    try:  # try pkg_resources if it is available
+        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
+    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
+        _GOOGLE_AUTH_VERSION = None
+
+_API_CORE_VERSION = google.api_core.__version__
 
 
 class BigtableInstanceAdminTransport(abc.ABC):
@@ -57,21 +67,24 @@ class BigtableInstanceAdminTransport(abc.ABC):
         "https://www.googleapis.com/auth/cloud-platform.read-only",
     )
 
+    DEFAULT_HOST: str = "bigtableadmin.googleapis.com"
+
     def __init__(
         self,
         *,
-        host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
-        credentials_file: typing.Optional[str] = None,
-        scopes: typing.Optional[typing.Sequence[str]] = AUTH_SCOPES,
-        quota_project_id: typing.Optional[str] = None,
+        host: str = DEFAULT_HOST,
+        credentials: ga_credentials.Credentials = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        quota_project_id: Optional[str] = None,
         client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
         **kwargs,
     ) -> None:
         """Instantiate the transport.
 
         Args:
-            host (Optional[str]): The hostname to connect to.
+            host (Optional[str]):
+                 The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -80,7 +93,7 @@ class BigtableInstanceAdminTransport(abc.ABC):
             credentials_file (Optional[str]): A file with credentials that can
                 be loaded with :func:`google.auth.load_credentials_from_file`.
                 This argument is mutually exclusive with credentials.
-            scope (Optional[Sequence[str]]): A list of scopes.
+            scopes (Optional[Sequence[str]]): A list of scopes.
             quota_project_id (Optional[str]): An optional project to use for billing
                 and quota.
             client_info (google.api_core.gapic_v1.client_info.ClientInfo):
@@ -94,28 +107,75 @@ class BigtableInstanceAdminTransport(abc.ABC):
             host += ":443"
         self._host = host
 
+        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+
         # Save the scopes.
         self._scopes = scopes or self.AUTH_SCOPES
 
         # If no credentials are provided, then determine the appropriate
         # defaults.
         if credentials and credentials_file:
-            raise exceptions.DuplicateCredentialArgs(
+            raise core_exceptions.DuplicateCredentialArgs(
                 "'credentials_file' and 'credentials' are mutually exclusive"
             )
 
         if credentials_file is not None:
-            credentials, _ = auth.load_credentials_from_file(
-                credentials_file, scopes=self._scopes, quota_project_id=quota_project_id
+            credentials, _ = google.auth.load_credentials_from_file(
+                credentials_file, **scopes_kwargs, quota_project_id=quota_project_id
             )
 
         elif credentials is None:
-            credentials, _ = auth.default(
-                scopes=self._scopes, quota_project_id=quota_project_id
+            credentials, _ = google.auth.default(
+                **scopes_kwargs, quota_project_id=quota_project_id
             )
 
         # Save the credentials.
         self._credentials = credentials
+
+    # TODO(busunkim): These two class methods are in the base transport
+    # to avoid duplicating code across the transport classes. These functions
+    # should be deleted once the minimum required versions of google-api-core
+    # and google-auth are increased.
+
+    # TODO: Remove this function once google-auth >= 1.25.0 is required
+    @classmethod
+    def _get_scopes_kwargs(
+        cls, host: str, scopes: Optional[Sequence[str]]
+    ) -> Dict[str, Optional[Sequence[str]]]:
+        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
+
+        scopes_kwargs = {}
+
+        if _GOOGLE_AUTH_VERSION and (
+            packaging.version.parse(_GOOGLE_AUTH_VERSION)
+            >= packaging.version.parse("1.25.0")
+        ):
+            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
+        else:
+            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
+
+        return scopes_kwargs
+
+    # TODO: Remove this function once google-api-core >= 1.26.0 is required
+    @classmethod
+    def _get_self_signed_jwt_kwargs(
+        cls, host: str, scopes: Optional[Sequence[str]]
+    ) -> Dict[str, Union[Optional[Sequence[str]], str]]:
+        """Returns kwargs to pass to grpc_helpers.create_channel depending on the google-api-core version"""
+
+        self_signed_jwt_kwargs: Dict[str, Union[Optional[Sequence[str]], str]] = {}
+
+        if _API_CORE_VERSION and (
+            packaging.version.parse(_API_CORE_VERSION)
+            >= packaging.version.parse("1.26.0")
+        ):
+            self_signed_jwt_kwargs["default_scopes"] = cls.AUTH_SCOPES
+            self_signed_jwt_kwargs["scopes"] = scopes
+            self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
+        else:
+            self_signed_jwt_kwargs["scopes"] = scopes or cls.AUTH_SCOPES
+
+        return self_signed_jwt_kwargs
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
@@ -130,7 +190,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -144,7 +205,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -158,7 +220,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -172,7 +235,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -192,7 +256,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -206,7 +271,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -220,7 +286,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -240,7 +307,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -254,7 +322,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -268,7 +337,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -285,7 +355,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -302,7 +373,8 @@ class BigtableInstanceAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -319,29 +391,29 @@ class BigtableInstanceAdminTransport(abc.ABC):
     @property
     def create_instance(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.CreateInstanceRequest],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def get_instance(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.GetInstanceRequest],
-        typing.Union[instance.Instance, typing.Awaitable[instance.Instance]],
+        Union[instance.Instance, Awaitable[instance.Instance]],
     ]:
         raise NotImplementedError()
 
     @property
     def list_instances(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.ListInstancesRequest],
-        typing.Union[
+        Union[
             bigtable_instance_admin.ListInstancesResponse,
-            typing.Awaitable[bigtable_instance_admin.ListInstancesResponse],
+            Awaitable[bigtable_instance_admin.ListInstancesResponse],
         ],
     ]:
         raise NotImplementedError()
@@ -349,56 +421,55 @@ class BigtableInstanceAdminTransport(abc.ABC):
     @property
     def update_instance(
         self,
-    ) -> typing.Callable[
-        [instance.Instance],
-        typing.Union[instance.Instance, typing.Awaitable[instance.Instance]],
+    ) -> Callable[
+        [instance.Instance], Union[instance.Instance, Awaitable[instance.Instance]]
     ]:
         raise NotImplementedError()
 
     @property
     def partial_update_instance(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.PartialUpdateInstanceRequest],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def delete_instance(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.DeleteInstanceRequest],
-        typing.Union[empty.Empty, typing.Awaitable[empty.Empty]],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 
     @property
     def create_cluster(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.CreateClusterRequest],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def get_cluster(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.GetClusterRequest],
-        typing.Union[instance.Cluster, typing.Awaitable[instance.Cluster]],
+        Union[instance.Cluster, Awaitable[instance.Cluster]],
     ]:
         raise NotImplementedError()
 
     @property
     def list_clusters(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.ListClustersRequest],
-        typing.Union[
+        Union[
             bigtable_instance_admin.ListClustersResponse,
-            typing.Awaitable[bigtable_instance_admin.ListClustersResponse],
+            Awaitable[bigtable_instance_admin.ListClustersResponse],
         ],
     ]:
         raise NotImplementedError()
@@ -406,47 +477,47 @@ class BigtableInstanceAdminTransport(abc.ABC):
     @property
     def update_cluster(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [instance.Cluster],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def delete_cluster(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.DeleteClusterRequest],
-        typing.Union[empty.Empty, typing.Awaitable[empty.Empty]],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 
     @property
     def create_app_profile(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.CreateAppProfileRequest],
-        typing.Union[instance.AppProfile, typing.Awaitable[instance.AppProfile]],
+        Union[instance.AppProfile, Awaitable[instance.AppProfile]],
     ]:
         raise NotImplementedError()
 
     @property
     def get_app_profile(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.GetAppProfileRequest],
-        typing.Union[instance.AppProfile, typing.Awaitable[instance.AppProfile]],
+        Union[instance.AppProfile, Awaitable[instance.AppProfile]],
     ]:
         raise NotImplementedError()
 
     @property
     def list_app_profiles(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.ListAppProfilesRequest],
-        typing.Union[
+        Union[
             bigtable_instance_admin.ListAppProfilesResponse,
-            typing.Awaitable[bigtable_instance_admin.ListAppProfilesResponse],
+            Awaitable[bigtable_instance_admin.ListAppProfilesResponse],
         ],
     ]:
         raise NotImplementedError()
@@ -454,47 +525,47 @@ class BigtableInstanceAdminTransport(abc.ABC):
     @property
     def update_app_profile(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.UpdateAppProfileRequest],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def delete_app_profile(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_instance_admin.DeleteAppProfileRequest],
-        typing.Union[empty.Empty, typing.Awaitable[empty.Empty]],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 
     @property
     def get_iam_policy(
         self,
-    ) -> typing.Callable[
-        [iam_policy.GetIamPolicyRequest],
-        typing.Union[policy.Policy, typing.Awaitable[policy.Policy]],
+    ) -> Callable[
+        [iam_policy_pb2.GetIamPolicyRequest],
+        Union[policy_pb2.Policy, Awaitable[policy_pb2.Policy]],
     ]:
         raise NotImplementedError()
 
     @property
     def set_iam_policy(
         self,
-    ) -> typing.Callable[
-        [iam_policy.SetIamPolicyRequest],
-        typing.Union[policy.Policy, typing.Awaitable[policy.Policy]],
+    ) -> Callable[
+        [iam_policy_pb2.SetIamPolicyRequest],
+        Union[policy_pb2.Policy, Awaitable[policy_pb2.Policy]],
     ]:
         raise NotImplementedError()
 
     @property
     def test_iam_permissions(
         self,
-    ) -> typing.Callable[
-        [iam_policy.TestIamPermissionsRequest],
-        typing.Union[
-            iam_policy.TestIamPermissionsResponse,
-            typing.Awaitable[iam_policy.TestIamPermissionsResponse],
+    ) -> Callable[
+        [iam_policy_pb2.TestIamPermissionsRequest],
+        Union[
+            iam_policy_pb2.TestIamPermissionsResponse,
+            Awaitable[iam_policy_pb2.TestIamPermissionsResponse],
         ],
     ]:
         raise NotImplementedError()

--- a/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/grpc.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/grpc.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,26 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import warnings
-from typing import Callable, Dict, Optional, Sequence, Tuple
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import grpc_helpers  # type: ignore
 from google.api_core import operations_v1  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
-from google import auth  # type: ignore
-from google.auth import credentials  # type: ignore
+import google.auth  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
 
 import grpc  # type: ignore
 
 from google.cloud.bigtable_admin_v2.types import bigtable_instance_admin
 from google.cloud.bigtable_admin_v2.types import instance
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.longrunning import operations_pb2 as operations  # type: ignore
-from google.protobuf import empty_pb2 as empty  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.longrunning import operations_pb2  # type: ignore
+from google.protobuf import empty_pb2  # type: ignore
 from .base import BigtableInstanceAdminTransport, DEFAULT_CLIENT_INFO
 
 
@@ -59,7 +56,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
         self,
         *,
         host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         credentials_file: str = None,
         scopes: Sequence[str] = None,
         channel: grpc.Channel = None,
@@ -73,7 +70,8 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
         """Instantiate the transport.
 
         Args:
-            host (Optional[str]): The hostname to connect to.
+            host (Optional[str]):
+                 The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -184,7 +182,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
     def create_channel(
         cls,
         host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         credentials_file: str = None,
         scopes: Optional[Sequence[str]] = None,
         quota_project_id: Optional[str] = None,
@@ -215,13 +213,15 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             google.api_core.exceptions.DuplicateCredentialArgs: If both ``credentials``
               and ``credentials_file`` are passed.
         """
-        scopes = scopes or cls.AUTH_SCOPES
+
+        self_signed_jwt_kwargs = cls._get_self_signed_jwt_kwargs(host, scopes)
+
         return grpc_helpers.create_channel(
             host,
             credentials=credentials,
             credentials_file=credentials_file,
-            scopes=scopes,
             quota_project_id=quota_project_id,
+            **self_signed_jwt_kwargs,
             **kwargs,
         )
 
@@ -249,7 +249,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
     def create_instance(
         self,
     ) -> Callable[
-        [bigtable_instance_admin.CreateInstanceRequest], operations.Operation
+        [bigtable_instance_admin.CreateInstanceRequest], operations_pb2.Operation
     ]:
         r"""Return a callable for the create instance method over gRPC.
 
@@ -269,7 +269,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             self._stubs["create_instance"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance",
                 request_serializer=bigtable_instance_admin.CreateInstanceRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["create_instance"]
 
@@ -359,7 +359,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
     def partial_update_instance(
         self,
     ) -> Callable[
-        [bigtable_instance_admin.PartialUpdateInstanceRequest], operations.Operation
+        [bigtable_instance_admin.PartialUpdateInstanceRequest], operations_pb2.Operation
     ]:
         r"""Return a callable for the partial update instance method over gRPC.
 
@@ -381,14 +381,14 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             self._stubs["partial_update_instance"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateInstance",
                 request_serializer=bigtable_instance_admin.PartialUpdateInstanceRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["partial_update_instance"]
 
     @property
     def delete_instance(
         self,
-    ) -> Callable[[bigtable_instance_admin.DeleteInstanceRequest], empty.Empty]:
+    ) -> Callable[[bigtable_instance_admin.DeleteInstanceRequest], empty_pb2.Empty]:
         r"""Return a callable for the delete instance method over gRPC.
 
         Delete an instance from a project.
@@ -407,14 +407,16 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             self._stubs["delete_instance"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteInstance",
                 request_serializer=bigtable_instance_admin.DeleteInstanceRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_instance"]
 
     @property
     def create_cluster(
         self,
-    ) -> Callable[[bigtable_instance_admin.CreateClusterRequest], operations.Operation]:
+    ) -> Callable[
+        [bigtable_instance_admin.CreateClusterRequest], operations_pb2.Operation
+    ]:
         r"""Return a callable for the create cluster method over gRPC.
 
         Creates a cluster within an instance.
@@ -433,7 +435,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             self._stubs["create_cluster"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/CreateCluster",
                 request_serializer=bigtable_instance_admin.CreateClusterRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["create_cluster"]
 
@@ -493,7 +495,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
         return self._stubs["list_clusters"]
 
     @property
-    def update_cluster(self) -> Callable[[instance.Cluster], operations.Operation]:
+    def update_cluster(self) -> Callable[[instance.Cluster], operations_pb2.Operation]:
         r"""Return a callable for the update cluster method over gRPC.
 
         Updates a cluster within an instance.
@@ -512,14 +514,14 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             self._stubs["update_cluster"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/UpdateCluster",
                 request_serializer=instance.Cluster.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["update_cluster"]
 
     @property
     def delete_cluster(
         self,
-    ) -> Callable[[bigtable_instance_admin.DeleteClusterRequest], empty.Empty]:
+    ) -> Callable[[bigtable_instance_admin.DeleteClusterRequest], empty_pb2.Empty]:
         r"""Return a callable for the delete cluster method over gRPC.
 
         Deletes a cluster from an instance.
@@ -538,7 +540,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             self._stubs["delete_cluster"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteCluster",
                 request_serializer=bigtable_instance_admin.DeleteClusterRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_cluster"]
 
@@ -629,7 +631,7 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
     def update_app_profile(
         self,
     ) -> Callable[
-        [bigtable_instance_admin.UpdateAppProfileRequest], operations.Operation
+        [bigtable_instance_admin.UpdateAppProfileRequest], operations_pb2.Operation
     ]:
         r"""Return a callable for the update app profile method over gRPC.
 
@@ -649,14 +651,14 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             self._stubs["update_app_profile"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/UpdateAppProfile",
                 request_serializer=bigtable_instance_admin.UpdateAppProfileRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["update_app_profile"]
 
     @property
     def delete_app_profile(
         self,
-    ) -> Callable[[bigtable_instance_admin.DeleteAppProfileRequest], empty.Empty]:
+    ) -> Callable[[bigtable_instance_admin.DeleteAppProfileRequest], empty_pb2.Empty]:
         r"""Return a callable for the delete app profile method over gRPC.
 
         Deletes an app profile from an instance.
@@ -675,14 +677,14 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
             self._stubs["delete_app_profile"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteAppProfile",
                 request_serializer=bigtable_instance_admin.DeleteAppProfileRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_app_profile"]
 
     @property
     def get_iam_policy(
         self,
-    ) -> Callable[[iam_policy.GetIamPolicyRequest], policy.Policy]:
+    ) -> Callable[[iam_policy_pb2.GetIamPolicyRequest], policy_pb2.Policy]:
         r"""Return a callable for the get iam policy method over gRPC.
 
         Gets the access control policy for an instance
@@ -702,15 +704,15 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
         if "get_iam_policy" not in self._stubs:
             self._stubs["get_iam_policy"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/GetIamPolicy",
-                request_serializer=iam_policy.GetIamPolicyRequest.SerializeToString,
-                response_deserializer=policy.Policy.FromString,
+                request_serializer=iam_policy_pb2.GetIamPolicyRequest.SerializeToString,
+                response_deserializer=policy_pb2.Policy.FromString,
             )
         return self._stubs["get_iam_policy"]
 
     @property
     def set_iam_policy(
         self,
-    ) -> Callable[[iam_policy.SetIamPolicyRequest], policy.Policy]:
+    ) -> Callable[[iam_policy_pb2.SetIamPolicyRequest], policy_pb2.Policy]:
         r"""Return a callable for the set iam policy method over gRPC.
 
         Sets the access control policy on an instance
@@ -729,8 +731,8 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
         if "set_iam_policy" not in self._stubs:
             self._stubs["set_iam_policy"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/SetIamPolicy",
-                request_serializer=iam_policy.SetIamPolicyRequest.SerializeToString,
-                response_deserializer=policy.Policy.FromString,
+                request_serializer=iam_policy_pb2.SetIamPolicyRequest.SerializeToString,
+                response_deserializer=policy_pb2.Policy.FromString,
             )
         return self._stubs["set_iam_policy"]
 
@@ -738,7 +740,8 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
     def test_iam_permissions(
         self,
     ) -> Callable[
-        [iam_policy.TestIamPermissionsRequest], iam_policy.TestIamPermissionsResponse
+        [iam_policy_pb2.TestIamPermissionsRequest],
+        iam_policy_pb2.TestIamPermissionsResponse,
     ]:
         r"""Return a callable for the test iam permissions method over gRPC.
 
@@ -758,8 +761,8 @@ class BigtableInstanceAdminGrpcTransport(BigtableInstanceAdminTransport):
         if "test_iam_permissions" not in self._stubs:
             self._stubs["test_iam_permissions"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/TestIamPermissions",
-                request_serializer=iam_policy.TestIamPermissionsRequest.SerializeToString,
-                response_deserializer=iam_policy.TestIamPermissionsResponse.FromString,
+                request_serializer=iam_policy_pb2.TestIamPermissionsRequest.SerializeToString,
+                response_deserializer=iam_policy_pb2.TestIamPermissionsResponse.FromString,
             )
         return self._stubs["test_iam_permissions"]
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/grpc_asyncio.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/grpc_asyncio.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import warnings
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import grpc_helpers_async  # type: ignore
 from google.api_core import operations_v1  # type: ignore
-from google import auth  # type: ignore
-from google.auth import credentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
+import packaging.version
 
 import grpc  # type: ignore
 from grpc.experimental import aio  # type: ignore
 
 from google.cloud.bigtable_admin_v2.types import bigtable_instance_admin
 from google.cloud.bigtable_admin_v2.types import instance
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.longrunning import operations_pb2 as operations  # type: ignore
-from google.protobuf import empty_pb2 as empty  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.longrunning import operations_pb2  # type: ignore
+from google.protobuf import empty_pb2  # type: ignore
 from .base import BigtableInstanceAdminTransport, DEFAULT_CLIENT_INFO
 from .grpc import BigtableInstanceAdminGrpcTransport
 
@@ -62,7 +59,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
     def create_channel(
         cls,
         host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         credentials_file: Optional[str] = None,
         scopes: Optional[Sequence[str]] = None,
         quota_project_id: Optional[str] = None,
@@ -89,13 +86,15 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
         Returns:
             aio.Channel: A gRPC AsyncIO channel object.
         """
-        scopes = scopes or cls.AUTH_SCOPES
+
+        self_signed_jwt_kwargs = cls._get_self_signed_jwt_kwargs(host, scopes)
+
         return grpc_helpers_async.create_channel(
             host,
             credentials=credentials,
             credentials_file=credentials_file,
-            scopes=scopes,
             quota_project_id=quota_project_id,
+            **self_signed_jwt_kwargs,
             **kwargs,
         )
 
@@ -103,7 +102,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
         self,
         *,
         host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         credentials_file: Optional[str] = None,
         scopes: Optional[Sequence[str]] = None,
         channel: aio.Channel = None,
@@ -117,7 +116,8 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
         """Instantiate the transport.
 
         Args:
-            host (Optional[str]): The hostname to connect to.
+            host (Optional[str]):
+                 The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -176,7 +176,6 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             # If a channel was explicitly provided, set it.
             self._grpc_channel = channel
             self._ssl_channel_credentials = None
-
         else:
             if api_mtls_endpoint:
                 host = api_mtls_endpoint
@@ -255,7 +254,8 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
     def create_instance(
         self,
     ) -> Callable[
-        [bigtable_instance_admin.CreateInstanceRequest], Awaitable[operations.Operation]
+        [bigtable_instance_admin.CreateInstanceRequest],
+        Awaitable[operations_pb2.Operation],
     ]:
         r"""Return a callable for the create instance method over gRPC.
 
@@ -275,7 +275,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             self._stubs["create_instance"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance",
                 request_serializer=bigtable_instance_admin.CreateInstanceRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["create_instance"]
 
@@ -370,7 +370,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
         self,
     ) -> Callable[
         [bigtable_instance_admin.PartialUpdateInstanceRequest],
-        Awaitable[operations.Operation],
+        Awaitable[operations_pb2.Operation],
     ]:
         r"""Return a callable for the partial update instance method over gRPC.
 
@@ -392,7 +392,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             self._stubs["partial_update_instance"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateInstance",
                 request_serializer=bigtable_instance_admin.PartialUpdateInstanceRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["partial_update_instance"]
 
@@ -400,7 +400,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
     def delete_instance(
         self,
     ) -> Callable[
-        [bigtable_instance_admin.DeleteInstanceRequest], Awaitable[empty.Empty]
+        [bigtable_instance_admin.DeleteInstanceRequest], Awaitable[empty_pb2.Empty]
     ]:
         r"""Return a callable for the delete instance method over gRPC.
 
@@ -420,7 +420,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             self._stubs["delete_instance"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteInstance",
                 request_serializer=bigtable_instance_admin.DeleteInstanceRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_instance"]
 
@@ -428,7 +428,8 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
     def create_cluster(
         self,
     ) -> Callable[
-        [bigtable_instance_admin.CreateClusterRequest], Awaitable[operations.Operation]
+        [bigtable_instance_admin.CreateClusterRequest],
+        Awaitable[operations_pb2.Operation],
     ]:
         r"""Return a callable for the create cluster method over gRPC.
 
@@ -448,7 +449,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             self._stubs["create_cluster"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/CreateCluster",
                 request_serializer=bigtable_instance_admin.CreateClusterRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["create_cluster"]
 
@@ -512,7 +513,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
     @property
     def update_cluster(
         self,
-    ) -> Callable[[instance.Cluster], Awaitable[operations.Operation]]:
+    ) -> Callable[[instance.Cluster], Awaitable[operations_pb2.Operation]]:
         r"""Return a callable for the update cluster method over gRPC.
 
         Updates a cluster within an instance.
@@ -531,7 +532,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             self._stubs["update_cluster"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/UpdateCluster",
                 request_serializer=instance.Cluster.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["update_cluster"]
 
@@ -539,7 +540,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
     def delete_cluster(
         self,
     ) -> Callable[
-        [bigtable_instance_admin.DeleteClusterRequest], Awaitable[empty.Empty]
+        [bigtable_instance_admin.DeleteClusterRequest], Awaitable[empty_pb2.Empty]
     ]:
         r"""Return a callable for the delete cluster method over gRPC.
 
@@ -559,7 +560,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             self._stubs["delete_cluster"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteCluster",
                 request_serializer=bigtable_instance_admin.DeleteClusterRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_cluster"]
 
@@ -654,7 +655,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
         self,
     ) -> Callable[
         [bigtable_instance_admin.UpdateAppProfileRequest],
-        Awaitable[operations.Operation],
+        Awaitable[operations_pb2.Operation],
     ]:
         r"""Return a callable for the update app profile method over gRPC.
 
@@ -674,7 +675,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             self._stubs["update_app_profile"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/UpdateAppProfile",
                 request_serializer=bigtable_instance_admin.UpdateAppProfileRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["update_app_profile"]
 
@@ -682,7 +683,7 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
     def delete_app_profile(
         self,
     ) -> Callable[
-        [bigtable_instance_admin.DeleteAppProfileRequest], Awaitable[empty.Empty]
+        [bigtable_instance_admin.DeleteAppProfileRequest], Awaitable[empty_pb2.Empty]
     ]:
         r"""Return a callable for the delete app profile method over gRPC.
 
@@ -702,14 +703,14 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
             self._stubs["delete_app_profile"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/DeleteAppProfile",
                 request_serializer=bigtable_instance_admin.DeleteAppProfileRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_app_profile"]
 
     @property
     def get_iam_policy(
         self,
-    ) -> Callable[[iam_policy.GetIamPolicyRequest], Awaitable[policy.Policy]]:
+    ) -> Callable[[iam_policy_pb2.GetIamPolicyRequest], Awaitable[policy_pb2.Policy]]:
         r"""Return a callable for the get iam policy method over gRPC.
 
         Gets the access control policy for an instance
@@ -729,15 +730,15 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
         if "get_iam_policy" not in self._stubs:
             self._stubs["get_iam_policy"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/GetIamPolicy",
-                request_serializer=iam_policy.GetIamPolicyRequest.SerializeToString,
-                response_deserializer=policy.Policy.FromString,
+                request_serializer=iam_policy_pb2.GetIamPolicyRequest.SerializeToString,
+                response_deserializer=policy_pb2.Policy.FromString,
             )
         return self._stubs["get_iam_policy"]
 
     @property
     def set_iam_policy(
         self,
-    ) -> Callable[[iam_policy.SetIamPolicyRequest], Awaitable[policy.Policy]]:
+    ) -> Callable[[iam_policy_pb2.SetIamPolicyRequest], Awaitable[policy_pb2.Policy]]:
         r"""Return a callable for the set iam policy method over gRPC.
 
         Sets the access control policy on an instance
@@ -756,8 +757,8 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
         if "set_iam_policy" not in self._stubs:
             self._stubs["set_iam_policy"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/SetIamPolicy",
-                request_serializer=iam_policy.SetIamPolicyRequest.SerializeToString,
-                response_deserializer=policy.Policy.FromString,
+                request_serializer=iam_policy_pb2.SetIamPolicyRequest.SerializeToString,
+                response_deserializer=policy_pb2.Policy.FromString,
             )
         return self._stubs["set_iam_policy"]
 
@@ -765,8 +766,8 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
     def test_iam_permissions(
         self,
     ) -> Callable[
-        [iam_policy.TestIamPermissionsRequest],
-        Awaitable[iam_policy.TestIamPermissionsResponse],
+        [iam_policy_pb2.TestIamPermissionsRequest],
+        Awaitable[iam_policy_pb2.TestIamPermissionsResponse],
     ]:
         r"""Return a callable for the test iam permissions method over gRPC.
 
@@ -786,8 +787,8 @@ class BigtableInstanceAdminGrpcAsyncIOTransport(BigtableInstanceAdminTransport):
         if "test_iam_permissions" not in self._stubs:
             self._stubs["test_iam_permissions"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableInstanceAdmin/TestIamPermissions",
-                request_serializer=iam_policy.TestIamPermissionsRequest.SerializeToString,
-                response_deserializer=iam_policy.TestIamPermissionsResponse.FromString,
+                request_serializer=iam_policy_pb2.TestIamPermissionsRequest.SerializeToString,
+                response_deserializer=iam_policy_pb2.TestIamPermissionsResponse.FromString,
             )
         return self._stubs["test_iam_permissions"]
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/__init__.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from .client import BigtableTableAdminClient
 from .async_client import BigtableTableAdminAsyncClient
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/async_client.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/async_client.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from collections import OrderedDict
 import functools
 import re
@@ -22,10 +20,10 @@ from typing import Dict, Sequence, Tuple, Type, Union
 import pkg_resources
 
 import google.api_core.client_options as ClientOptions  # type: ignore
-from google.api_core import exceptions  # type: ignore
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
-from google.auth import credentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.oauth2 import service_account  # type: ignore
 
 from google.api_core import operation  # type: ignore
@@ -34,11 +32,10 @@ from google.cloud.bigtable_admin_v2.services.bigtable_table_admin import pagers
 from google.cloud.bigtable_admin_v2.types import bigtable_table_admin
 from google.cloud.bigtable_admin_v2.types import table
 from google.cloud.bigtable_admin_v2.types import table as gba_table
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.protobuf import field_mask_pb2 as field_mask  # type: ignore
-from google.protobuf import timestamp_pb2 as timestamp  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.protobuf import field_mask_pb2  # type: ignore
+from google.protobuf import timestamp_pb2  # type: ignore
 from .transports.base import BigtableTableAdminTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import BigtableTableAdminGrpcAsyncIOTransport
 from .client import BigtableTableAdminClient
@@ -73,31 +70,26 @@ class BigtableTableAdminAsyncClient:
     parse_snapshot_path = staticmethod(BigtableTableAdminClient.parse_snapshot_path)
     table_path = staticmethod(BigtableTableAdminClient.table_path)
     parse_table_path = staticmethod(BigtableTableAdminClient.parse_table_path)
-
     common_billing_account_path = staticmethod(
         BigtableTableAdminClient.common_billing_account_path
     )
     parse_common_billing_account_path = staticmethod(
         BigtableTableAdminClient.parse_common_billing_account_path
     )
-
     common_folder_path = staticmethod(BigtableTableAdminClient.common_folder_path)
     parse_common_folder_path = staticmethod(
         BigtableTableAdminClient.parse_common_folder_path
     )
-
     common_organization_path = staticmethod(
         BigtableTableAdminClient.common_organization_path
     )
     parse_common_organization_path = staticmethod(
         BigtableTableAdminClient.parse_common_organization_path
     )
-
     common_project_path = staticmethod(BigtableTableAdminClient.common_project_path)
     parse_common_project_path = staticmethod(
         BigtableTableAdminClient.parse_common_project_path
     )
-
     common_location_path = staticmethod(BigtableTableAdminClient.common_location_path)
     parse_common_location_path = staticmethod(
         BigtableTableAdminClient.parse_common_location_path
@@ -105,7 +97,8 @@ class BigtableTableAdminAsyncClient:
 
     @classmethod
     def from_service_account_info(cls, info: dict, *args, **kwargs):
-        """Creates an instance of this client using the provided credentials info.
+        """Creates an instance of this client using the provided credentials
+            info.
 
         Args:
             info (dict): The service account private key info.
@@ -120,7 +113,7 @@ class BigtableTableAdminAsyncClient:
     @classmethod
     def from_service_account_file(cls, filename: str, *args, **kwargs):
         """Creates an instance of this client using the provided credentials
-        file.
+            file.
 
         Args:
             filename (str): The path to the service account private key json
@@ -137,7 +130,7 @@ class BigtableTableAdminAsyncClient:
 
     @property
     def transport(self) -> BigtableTableAdminTransport:
-        """Return the transport used by the client instance.
+        """Returns the transport used by the client instance.
 
         Returns:
             BigtableTableAdminTransport: The transport used by the client instance.
@@ -152,12 +145,12 @@ class BigtableTableAdminAsyncClient:
     def __init__(
         self,
         *,
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         transport: Union[str, BigtableTableAdminTransport] = "grpc_asyncio",
         client_options: ClientOptions = None,
         client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
     ) -> None:
-        """Instantiate the bigtable table admin client.
+        """Instantiates the bigtable table admin client.
 
         Args:
             credentials (Optional[google.auth.credentials.Credentials]): The
@@ -189,7 +182,6 @@ class BigtableTableAdminAsyncClient:
             google.auth.exceptions.MutualTlsChannelError: If mutual TLS transport
                 creation failed for any reason.
         """
-
         self._client = BigtableTableAdminClient(
             credentials=credentials,
             transport=transport,
@@ -238,7 +230,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``table`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -267,7 +258,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
         if table_id is not None:
@@ -351,7 +341,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``source_snapshot`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -381,7 +370,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
         if table_id is not None:
@@ -440,7 +428,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -470,7 +457,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
 
@@ -483,7 +469,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -532,7 +519,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -561,7 +547,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -574,7 +559,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -618,7 +604,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -639,7 +624,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -704,7 +688,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``modifications`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -733,10 +716,8 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
-
         if modifications:
             request.modifications.extend(modifications)
 
@@ -777,7 +758,6 @@ class BigtableTableAdminAsyncClient:
             request (:class:`google.cloud.bigtable_admin_v2.types.DropRowRangeRequest`):
                 The request object. Request message for
                 [google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange][google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange]
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -785,7 +765,6 @@ class BigtableTableAdminAsyncClient:
                 sent along with the request as metadata.
         """
         # Create or coerce a protobuf request object.
-
         request = bigtable_table_admin.DropRowRangeRequest(request)
 
         # Wrap the RPC method; this adds retry and timeout information,
@@ -834,7 +813,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -861,7 +839,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -874,7 +851,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -928,7 +906,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``consistency_token`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -955,7 +932,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
         if consistency_token is not None:
@@ -970,7 +946,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1053,7 +1030,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``description`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1090,7 +1066,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
         if cluster is not None:
@@ -1164,7 +1139,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1201,7 +1175,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -1214,7 +1187,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1273,7 +1247,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1310,7 +1283,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
 
@@ -1323,7 +1295,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1384,7 +1357,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1405,7 +1377,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -1479,7 +1450,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``backup`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1509,7 +1479,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
         if backup_id is not None:
@@ -1568,7 +1537,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1593,7 +1561,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -1606,7 +1573,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1631,7 +1599,7 @@ class BigtableTableAdminAsyncClient:
         request: bigtable_table_admin.UpdateBackupRequest = None,
         *,
         backup: table.Backup = None,
-        update_mask: field_mask.FieldMask = None,
+        update_mask: field_mask_pb2.FieldMask = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -1665,7 +1633,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1690,7 +1657,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if backup is not None:
             request.backup = backup
         if update_mask is not None:
@@ -1741,7 +1707,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1762,7 +1727,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if name is not None:
             request.name = name
 
@@ -1812,7 +1776,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1842,7 +1805,6 @@ class BigtableTableAdminAsyncClient:
 
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-
         if parent is not None:
             request.parent = parent
 
@@ -1855,7 +1817,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -1890,8 +1853,8 @@ class BigtableTableAdminAsyncClient:
         metadata: Sequence[Tuple[str, str]] = (),
     ) -> operation_async.AsyncOperation:
         r"""Create a new table by restoring from a completed backup. The new
-        table must be in the same instance as the instance containing
-        the backup. The returned table [long-running
+        table must be in the same project as the instance containing the
+        backup. The returned table [long-running
         operation][google.longrunning.Operation] can be used to track
         the progress of the operation, and to cancel it. The
         [metadata][google.longrunning.Operation.metadata] field type is
@@ -1903,7 +1866,6 @@ class BigtableTableAdminAsyncClient:
             request (:class:`google.cloud.bigtable_admin_v2.types.RestoreTableRequest`):
                 The request object. The request for
                 [RestoreTable][google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable].
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1920,7 +1882,6 @@ class BigtableTableAdminAsyncClient:
 
         """
         # Create or coerce a protobuf request object.
-
         request = bigtable_table_admin.RestoreTableRequest(request)
 
         # Wrap the RPC method; this adds retry and timeout information,
@@ -1953,13 +1914,13 @@ class BigtableTableAdminAsyncClient:
 
     async def get_iam_policy(
         self,
-        request: iam_policy.GetIamPolicyRequest = None,
+        request: iam_policy_pb2.GetIamPolicyRequest = None,
         *,
         resource: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> policy.Policy:
+    ) -> policy_pb2.Policy:
         r"""Gets the access control policy for a Table or Backup
         resource. Returns an empty policy if the resource exists
         but does not have a policy set.
@@ -1977,7 +1938,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``resource`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2056,10 +2016,9 @@ class BigtableTableAdminAsyncClient:
         # The request isn't a proto-plus wrapped type,
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
-            request = iam_policy.GetIamPolicyRequest(**request)
-
+            request = iam_policy_pb2.GetIamPolicyRequest(**request)
         elif not request:
-            request = iam_policy.GetIamPolicyRequest(resource=resource,)
+            request = iam_policy_pb2.GetIamPolicyRequest(resource=resource,)
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
@@ -2070,7 +2029,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),
@@ -2092,13 +2052,13 @@ class BigtableTableAdminAsyncClient:
 
     async def set_iam_policy(
         self,
-        request: iam_policy.SetIamPolicyRequest = None,
+        request: iam_policy_pb2.SetIamPolicyRequest = None,
         *,
         resource: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> policy.Policy:
+    ) -> policy_pb2.Policy:
         r"""Sets the access control policy on a Table or Backup
         resource. Replaces any existing policy.
 
@@ -2115,7 +2075,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``resource`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2194,10 +2153,9 @@ class BigtableTableAdminAsyncClient:
         # The request isn't a proto-plus wrapped type,
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
-            request = iam_policy.SetIamPolicyRequest(**request)
-
+            request = iam_policy_pb2.SetIamPolicyRequest(**request)
         elif not request:
-            request = iam_policy.SetIamPolicyRequest(resource=resource,)
+            request = iam_policy_pb2.SetIamPolicyRequest(resource=resource,)
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
@@ -2221,14 +2179,14 @@ class BigtableTableAdminAsyncClient:
 
     async def test_iam_permissions(
         self,
-        request: iam_policy.TestIamPermissionsRequest = None,
+        request: iam_policy_pb2.TestIamPermissionsRequest = None,
         *,
         resource: str = None,
         permissions: Sequence[str] = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> iam_policy.TestIamPermissionsResponse:
+    ) -> iam_policy_pb2.TestIamPermissionsResponse:
         r"""Returns permissions that the caller has on the
         specified Table or Backup resource.
 
@@ -2254,7 +2212,6 @@ class BigtableTableAdminAsyncClient:
                 This corresponds to the ``permissions`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2278,10 +2235,9 @@ class BigtableTableAdminAsyncClient:
         # The request isn't a proto-plus wrapped type,
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
-            request = iam_policy.TestIamPermissionsRequest(**request)
-
+            request = iam_policy_pb2.TestIamPermissionsRequest(**request)
         elif not request:
-            request = iam_policy.TestIamPermissionsRequest(
+            request = iam_policy_pb2.TestIamPermissionsRequest(
                 resource=resource, permissions=permissions,
             )
 
@@ -2294,7 +2250,8 @@ class BigtableTableAdminAsyncClient:
                 maximum=60.0,
                 multiplier=2,
                 predicate=retries.if_exception_type(
-                    exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                    core_exceptions.DeadlineExceeded,
+                    core_exceptions.ServiceUnavailable,
                 ),
                 deadline=60.0,
             ),

--- a/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/client.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/client.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from collections import OrderedDict
 from distutils import util
 import os
@@ -23,10 +21,10 @@ from typing import Callable, Dict, Optional, Sequence, Tuple, Type, Union
 import pkg_resources
 
 from google.api_core import client_options as client_options_lib  # type: ignore
-from google.api_core import exceptions  # type: ignore
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
-from google.auth import credentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport import mtls  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
 from google.auth.exceptions import MutualTLSChannelError  # type: ignore
@@ -38,11 +36,10 @@ from google.cloud.bigtable_admin_v2.services.bigtable_table_admin import pagers
 from google.cloud.bigtable_admin_v2.types import bigtable_table_admin
 from google.cloud.bigtable_admin_v2.types import table
 from google.cloud.bigtable_admin_v2.types import table as gba_table
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.protobuf import field_mask_pb2 as field_mask  # type: ignore
-from google.protobuf import timestamp_pb2 as timestamp  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.protobuf import field_mask_pb2  # type: ignore
+from google.protobuf import timestamp_pb2  # type: ignore
 from .transports.base import BigtableTableAdminTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import BigtableTableAdminGrpcTransport
 from .transports.grpc_asyncio import BigtableTableAdminGrpcAsyncIOTransport
@@ -65,7 +62,7 @@ class BigtableTableAdminClientMeta(type):
     def get_transport_class(
         cls, label: str = None,
     ) -> Type[BigtableTableAdminTransport]:
-        """Return an appropriate transport class.
+        """Returns an appropriate transport class.
 
         Args:
             label: The name of the desired transport. If none is
@@ -93,7 +90,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def _get_default_mtls_endpoint(api_endpoint):
-        """Convert api endpoint to mTLS endpoint.
+        """Converts api endpoint to mTLS endpoint.
+
         Convert "*.sandbox.googleapis.com" and "*.googleapis.com" to
         "*.mtls.sandbox.googleapis.com" and "*.mtls.googleapis.com" respectively.
         Args:
@@ -127,7 +125,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @classmethod
     def from_service_account_info(cls, info: dict, *args, **kwargs):
-        """Creates an instance of this client using the provided credentials info.
+        """Creates an instance of this client using the provided credentials
+            info.
 
         Args:
             info (dict): The service account private key info.
@@ -144,7 +143,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
     @classmethod
     def from_service_account_file(cls, filename: str, *args, **kwargs):
         """Creates an instance of this client using the provided credentials
-        file.
+            file.
 
         Args:
             filename (str): The path to the service account private key json
@@ -163,23 +162,24 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @property
     def transport(self) -> BigtableTableAdminTransport:
-        """Return the transport used by the client instance.
+        """Returns the transport used by the client instance.
 
         Returns:
-            BigtableTableAdminTransport: The transport used by the client instance.
+            BigtableTableAdminTransport: The transport used by the client
+                instance.
         """
         return self._transport
 
     @staticmethod
     def backup_path(project: str, instance: str, cluster: str, backup: str,) -> str:
-        """Return a fully-qualified backup string."""
+        """Returns a fully-qualified backup string."""
         return "projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}".format(
             project=project, instance=instance, cluster=cluster, backup=backup,
         )
 
     @staticmethod
     def parse_backup_path(path: str) -> Dict[str, str]:
-        """Parse a backup path into its component segments."""
+        """Parses a backup path into its component segments."""
         m = re.match(
             r"^projects/(?P<project>.+?)/instances/(?P<instance>.+?)/clusters/(?P<cluster>.+?)/backups/(?P<backup>.+?)$",
             path,
@@ -188,14 +188,14 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def cluster_path(project: str, instance: str, cluster: str,) -> str:
-        """Return a fully-qualified cluster string."""
+        """Returns a fully-qualified cluster string."""
         return "projects/{project}/instances/{instance}/clusters/{cluster}".format(
             project=project, instance=instance, cluster=cluster,
         )
 
     @staticmethod
     def parse_cluster_path(path: str) -> Dict[str, str]:
-        """Parse a cluster path into its component segments."""
+        """Parses a cluster path into its component segments."""
         m = re.match(
             r"^projects/(?P<project>.+?)/instances/(?P<instance>.+?)/clusters/(?P<cluster>.+?)$",
             path,
@@ -210,7 +210,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         crypto_key: str,
         crypto_key_version: str,
     ) -> str:
-        """Return a fully-qualified crypto_key_version string."""
+        """Returns a fully-qualified crypto_key_version string."""
         return "projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}/cryptoKeyVersions/{crypto_key_version}".format(
             project=project,
             location=location,
@@ -221,7 +221,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def parse_crypto_key_version_path(path: str) -> Dict[str, str]:
-        """Parse a crypto_key_version path into its component segments."""
+        """Parses a crypto_key_version path into its component segments."""
         m = re.match(
             r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)/keyRings/(?P<key_ring>.+?)/cryptoKeys/(?P<crypto_key>.+?)/cryptoKeyVersions/(?P<crypto_key_version>.+?)$",
             path,
@@ -230,27 +230,27 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def instance_path(project: str, instance: str,) -> str:
-        """Return a fully-qualified instance string."""
+        """Returns a fully-qualified instance string."""
         return "projects/{project}/instances/{instance}".format(
             project=project, instance=instance,
         )
 
     @staticmethod
     def parse_instance_path(path: str) -> Dict[str, str]:
-        """Parse a instance path into its component segments."""
+        """Parses a instance path into its component segments."""
         m = re.match(r"^projects/(?P<project>.+?)/instances/(?P<instance>.+?)$", path)
         return m.groupdict() if m else {}
 
     @staticmethod
     def snapshot_path(project: str, instance: str, cluster: str, snapshot: str,) -> str:
-        """Return a fully-qualified snapshot string."""
+        """Returns a fully-qualified snapshot string."""
         return "projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}".format(
             project=project, instance=instance, cluster=cluster, snapshot=snapshot,
         )
 
     @staticmethod
     def parse_snapshot_path(path: str) -> Dict[str, str]:
-        """Parse a snapshot path into its component segments."""
+        """Parses a snapshot path into its component segments."""
         m = re.match(
             r"^projects/(?P<project>.+?)/instances/(?P<instance>.+?)/clusters/(?P<cluster>.+?)/snapshots/(?P<snapshot>.+?)$",
             path,
@@ -259,14 +259,14 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def table_path(project: str, instance: str, table: str,) -> str:
-        """Return a fully-qualified table string."""
+        """Returns a fully-qualified table string."""
         return "projects/{project}/instances/{instance}/tables/{table}".format(
             project=project, instance=instance, table=table,
         )
 
     @staticmethod
     def parse_table_path(path: str) -> Dict[str, str]:
-        """Parse a table path into its component segments."""
+        """Parses a table path into its component segments."""
         m = re.match(
             r"^projects/(?P<project>.+?)/instances/(?P<instance>.+?)/tables/(?P<table>.+?)$",
             path,
@@ -275,7 +275,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def common_billing_account_path(billing_account: str,) -> str:
-        """Return a fully-qualified billing_account string."""
+        """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
         )
@@ -288,7 +288,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def common_folder_path(folder: str,) -> str:
-        """Return a fully-qualified folder string."""
+        """Returns a fully-qualified folder string."""
         return "folders/{folder}".format(folder=folder,)
 
     @staticmethod
@@ -299,7 +299,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def common_organization_path(organization: str,) -> str:
-        """Return a fully-qualified organization string."""
+        """Returns a fully-qualified organization string."""
         return "organizations/{organization}".format(organization=organization,)
 
     @staticmethod
@@ -310,7 +310,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def common_project_path(project: str,) -> str:
-        """Return a fully-qualified project string."""
+        """Returns a fully-qualified project string."""
         return "projects/{project}".format(project=project,)
 
     @staticmethod
@@ -321,7 +321,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     @staticmethod
     def common_location_path(project: str, location: str,) -> str:
-        """Return a fully-qualified location string."""
+        """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
             project=project, location=location,
         )
@@ -335,12 +335,12 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
     def __init__(
         self,
         *,
-        credentials: Optional[credentials.Credentials] = None,
+        credentials: Optional[ga_credentials.Credentials] = None,
         transport: Union[str, BigtableTableAdminTransport, None] = None,
         client_options: Optional[client_options_lib.ClientOptions] = None,
         client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
     ) -> None:
-        """Instantiate the bigtable table admin client.
+        """Instantiates the bigtable table admin client.
 
         Args:
             credentials (Optional[google.auth.credentials.Credentials]): The
@@ -395,9 +395,10 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 client_cert_source_func = client_options.client_cert_source
             else:
                 is_mtls = mtls.has_default_client_cert_source()
-                client_cert_source_func = (
-                    mtls.default_client_cert_source() if is_mtls else None
-                )
+                if is_mtls:
+                    client_cert_source_func = mtls.default_client_cert_source()
+                else:
+                    client_cert_source_func = None
 
         # Figure out which api endpoint to use.
         if client_options.api_endpoint is not None:
@@ -409,12 +410,14 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
             elif use_mtls_env == "always":
                 api_endpoint = self.DEFAULT_MTLS_ENDPOINT
             elif use_mtls_env == "auto":
-                api_endpoint = (
-                    self.DEFAULT_MTLS_ENDPOINT if is_mtls else self.DEFAULT_ENDPOINT
-                )
+                if is_mtls:
+                    api_endpoint = self.DEFAULT_MTLS_ENDPOINT
+                else:
+                    api_endpoint = self.DEFAULT_ENDPOINT
             else:
                 raise MutualTLSChannelError(
-                    "Unsupported GOOGLE_API_USE_MTLS_ENDPOINT value. Accepted values: never, auto, always"
+                    "Unsupported GOOGLE_API_USE_MTLS_ENDPOINT value. Accepted "
+                    "values: never, auto, always"
                 )
 
         # Save or instantiate the transport.
@@ -429,8 +432,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 )
             if client_options.scopes:
                 raise ValueError(
-                    "When providing a transport instance, "
-                    "provide its scopes directly."
+                    "When providing a transport instance, provide its scopes "
+                    "directly."
                 )
             self._transport = transport
         else:
@@ -486,7 +489,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``table`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -517,10 +519,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.CreateTableRequest):
             request = bigtable_table_admin.CreateTableRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
             if table_id is not None:
@@ -600,7 +600,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``source_snapshot`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -632,10 +631,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.CreateTableFromSnapshotRequest):
             request = bigtable_table_admin.CreateTableFromSnapshotRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
             if table_id is not None:
@@ -692,7 +689,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -724,10 +720,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.ListTablesRequest):
             request = bigtable_table_admin.ListTablesRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
 
@@ -776,7 +770,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -807,10 +800,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.GetTableRequest):
             request = bigtable_table_admin.GetTableRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -854,7 +845,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -877,10 +867,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.DeleteTableRequest):
             request = bigtable_table_admin.DeleteTableRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -941,7 +929,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``modifications`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -972,10 +959,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.ModifyColumnFamiliesRequest):
             request = bigtable_table_admin.ModifyColumnFamiliesRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
             if modifications is not None:
@@ -1014,7 +999,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
             request (google.cloud.bigtable_admin_v2.types.DropRowRangeRequest):
                 The request object. Request message for
                 [google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange][google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange]
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1022,7 +1006,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 sent along with the request as metadata.
         """
         # Create or coerce a protobuf request object.
-
         # Minor optimization to avoid making a copy if the user passes
         # in a bigtable_table_admin.DropRowRangeRequest.
         # There's no risk of modifying the input as we've already verified
@@ -1072,7 +1055,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1103,10 +1085,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
             request, bigtable_table_admin.GenerateConsistencyTokenRequest
         ):
             request = bigtable_table_admin.GenerateConsistencyTokenRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -1162,7 +1142,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``consistency_token`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1191,10 +1170,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.CheckConsistencyRequest):
             request = bigtable_table_admin.CheckConsistencyRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
             if consistency_token is not None:
@@ -1279,7 +1256,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``description`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1318,10 +1294,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.SnapshotTableRequest):
             request = bigtable_table_admin.SnapshotTableRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
             if cluster is not None:
@@ -1391,7 +1365,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1430,10 +1403,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.GetSnapshotRequest):
             request = bigtable_table_admin.GetSnapshotRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -1492,7 +1463,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1531,10 +1501,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.ListSnapshotsRequest):
             request = bigtable_table_admin.ListSnapshotsRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
 
@@ -1595,7 +1563,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1618,10 +1585,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.DeleteSnapshotRequest):
             request = bigtable_table_admin.DeleteSnapshotRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -1691,7 +1656,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``backup`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1723,10 +1687,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.CreateBackupRequest):
             request = bigtable_table_admin.CreateBackupRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
             if backup_id is not None:
@@ -1781,7 +1743,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1808,10 +1769,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.GetBackupRequest):
             request = bigtable_table_admin.GetBackupRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -1836,7 +1795,7 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         request: bigtable_table_admin.UpdateBackupRequest = None,
         *,
         backup: table.Backup = None,
-        update_mask: field_mask.FieldMask = None,
+        update_mask: field_mask_pb2.FieldMask = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -1870,7 +1829,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1897,10 +1855,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.UpdateBackupRequest):
             request = bigtable_table_admin.UpdateBackupRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if backup is not None:
                 request.backup = backup
             if update_mask is not None:
@@ -1947,7 +1903,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``name`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -1970,10 +1925,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.DeleteBackupRequest):
             request = bigtable_table_admin.DeleteBackupRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if name is not None:
                 request.name = name
 
@@ -2019,7 +1972,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``parent`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2051,10 +2003,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         # there are no flattened fields.
         if not isinstance(request, bigtable_table_admin.ListBackupsRequest):
             request = bigtable_table_admin.ListBackupsRequest(request)
-
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-
             if parent is not None:
                 request.parent = parent
 
@@ -2089,8 +2039,8 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         metadata: Sequence[Tuple[str, str]] = (),
     ) -> operation.Operation:
         r"""Create a new table by restoring from a completed backup. The new
-        table must be in the same instance as the instance containing
-        the backup. The returned table [long-running
+        table must be in the same project as the instance containing the
+        backup. The returned table [long-running
         operation][google.longrunning.Operation] can be used to track
         the progress of the operation, and to cancel it. The
         [metadata][google.longrunning.Operation.metadata] field type is
@@ -2102,7 +2052,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
             request (google.cloud.bigtable_admin_v2.types.RestoreTableRequest):
                 The request object. The request for
                 [RestoreTable][google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable].
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2119,7 +2068,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
         """
         # Create or coerce a protobuf request object.
-
         # Minor optimization to avoid making a copy if the user passes
         # in a bigtable_table_admin.RestoreTableRequest.
         # There's no risk of modifying the input as we've already verified
@@ -2153,13 +2101,13 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     def get_iam_policy(
         self,
-        request: iam_policy.GetIamPolicyRequest = None,
+        request: iam_policy_pb2.GetIamPolicyRequest = None,
         *,
         resource: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> policy.Policy:
+    ) -> policy_pb2.Policy:
         r"""Gets the access control policy for a Table or Backup
         resource. Returns an empty policy if the resource exists
         but does not have a policy set.
@@ -2177,7 +2125,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``resource`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2256,11 +2203,10 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         if isinstance(request, dict):
             # The request isn't a proto-plus wrapped type,
             # so it must be constructed via keyword expansion.
-            request = iam_policy.GetIamPolicyRequest(**request)
+            request = iam_policy_pb2.GetIamPolicyRequest(**request)
         elif not request:
             # Null request, just make one.
-            request = iam_policy.GetIamPolicyRequest()
-
+            request = iam_policy_pb2.GetIamPolicyRequest()
             if resource is not None:
                 request.resource = resource
 
@@ -2282,13 +2228,13 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     def set_iam_policy(
         self,
-        request: iam_policy.SetIamPolicyRequest = None,
+        request: iam_policy_pb2.SetIamPolicyRequest = None,
         *,
         resource: str = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> policy.Policy:
+    ) -> policy_pb2.Policy:
         r"""Sets the access control policy on a Table or Backup
         resource. Replaces any existing policy.
 
@@ -2305,7 +2251,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``resource`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2384,11 +2329,10 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         if isinstance(request, dict):
             # The request isn't a proto-plus wrapped type,
             # so it must be constructed via keyword expansion.
-            request = iam_policy.SetIamPolicyRequest(**request)
+            request = iam_policy_pb2.SetIamPolicyRequest(**request)
         elif not request:
             # Null request, just make one.
-            request = iam_policy.SetIamPolicyRequest()
-
+            request = iam_policy_pb2.SetIamPolicyRequest()
             if resource is not None:
                 request.resource = resource
 
@@ -2410,14 +2354,14 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
 
     def test_iam_permissions(
         self,
-        request: iam_policy.TestIamPermissionsRequest = None,
+        request: iam_policy_pb2.TestIamPermissionsRequest = None,
         *,
         resource: str = None,
         permissions: Sequence[str] = None,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
-    ) -> iam_policy.TestIamPermissionsResponse:
+    ) -> iam_policy_pb2.TestIamPermissionsResponse:
         r"""Returns permissions that the caller has on the
         specified Table or Backup resource.
 
@@ -2443,7 +2387,6 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
                 This corresponds to the ``permissions`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -2467,14 +2410,12 @@ class BigtableTableAdminClient(metaclass=BigtableTableAdminClientMeta):
         if isinstance(request, dict):
             # The request isn't a proto-plus wrapped type,
             # so it must be constructed via keyword expansion.
-            request = iam_policy.TestIamPermissionsRequest(**request)
+            request = iam_policy_pb2.TestIamPermissionsRequest(**request)
         elif not request:
             # Null request, just make one.
-            request = iam_policy.TestIamPermissionsRequest()
-
+            request = iam_policy_pb2.TestIamPermissionsRequest()
             if resource is not None:
                 request.resource = resource
-
             if permissions:
                 request.permissions.extend(permissions)
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/pagers.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/pagers.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from typing import (
     Any,
     AsyncIterable,
@@ -118,7 +116,7 @@ class ListTablesAsyncPager:
         *,
         metadata: Sequence[Tuple[str, str]] = ()
     ):
-        """Instantiate the pager.
+        """Instantiates the pager.
 
         Args:
             method (Callable): The method that was originally called, and
@@ -246,7 +244,7 @@ class ListSnapshotsAsyncPager:
         *,
         metadata: Sequence[Tuple[str, str]] = ()
     ):
-        """Instantiate the pager.
+        """Instantiates the pager.
 
         Args:
             method (Callable): The method that was originally called, and
@@ -374,7 +372,7 @@ class ListBackupsAsyncPager:
         *,
         metadata: Sequence[Tuple[str, str]] = ()
     ):
-        """Instantiate the pager.
+        """Instantiates the pager.
 
         Args:
             method (Callable): The method that was originally called, and

--- a/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/__init__.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from collections import OrderedDict
 from typing import Dict, Type
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/base.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/base.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,26 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import abc
-import typing
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+import packaging.version
 import pkg_resources
 
-from google import auth  # type: ignore
-from google.api_core import exceptions  # type: ignore
+import google.auth  # type: ignore
+import google.api_core  # type: ignore
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 from google.api_core import operations_v1  # type: ignore
-from google.auth import credentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 
 from google.cloud.bigtable_admin_v2.types import bigtable_table_admin
 from google.cloud.bigtable_admin_v2.types import table
 from google.cloud.bigtable_admin_v2.types import table as gba_table
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.longrunning import operations_pb2 as operations  # type: ignore
-from google.protobuf import empty_pb2 as empty  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.longrunning import operations_pb2  # type: ignore
+from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
@@ -43,6 +42,17 @@ try:
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
+
+try:
+    # google.auth.__version__ was added in 1.26.0
+    _GOOGLE_AUTH_VERSION = google.auth.__version__
+except AttributeError:
+    try:  # try pkg_resources if it is available
+        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
+    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
+        _GOOGLE_AUTH_VERSION = None
+
+_API_CORE_VERSION = google.api_core.__version__
 
 
 class BigtableTableAdminTransport(abc.ABC):
@@ -57,21 +67,24 @@ class BigtableTableAdminTransport(abc.ABC):
         "https://www.googleapis.com/auth/cloud-platform.read-only",
     )
 
+    DEFAULT_HOST: str = "bigtableadmin.googleapis.com"
+
     def __init__(
         self,
         *,
-        host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
-        credentials_file: typing.Optional[str] = None,
-        scopes: typing.Optional[typing.Sequence[str]] = AUTH_SCOPES,
-        quota_project_id: typing.Optional[str] = None,
+        host: str = DEFAULT_HOST,
+        credentials: ga_credentials.Credentials = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        quota_project_id: Optional[str] = None,
         client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
         **kwargs,
     ) -> None:
         """Instantiate the transport.
 
         Args:
-            host (Optional[str]): The hostname to connect to.
+            host (Optional[str]):
+                 The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -80,7 +93,7 @@ class BigtableTableAdminTransport(abc.ABC):
             credentials_file (Optional[str]): A file with credentials that can
                 be loaded with :func:`google.auth.load_credentials_from_file`.
                 This argument is mutually exclusive with credentials.
-            scope (Optional[Sequence[str]]): A list of scopes.
+            scopes (Optional[Sequence[str]]): A list of scopes.
             quota_project_id (Optional[str]): An optional project to use for billing
                 and quota.
             client_info (google.api_core.gapic_v1.client_info.ClientInfo):
@@ -94,28 +107,75 @@ class BigtableTableAdminTransport(abc.ABC):
             host += ":443"
         self._host = host
 
+        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+
         # Save the scopes.
         self._scopes = scopes or self.AUTH_SCOPES
 
         # If no credentials are provided, then determine the appropriate
         # defaults.
         if credentials and credentials_file:
-            raise exceptions.DuplicateCredentialArgs(
+            raise core_exceptions.DuplicateCredentialArgs(
                 "'credentials_file' and 'credentials' are mutually exclusive"
             )
 
         if credentials_file is not None:
-            credentials, _ = auth.load_credentials_from_file(
-                credentials_file, scopes=self._scopes, quota_project_id=quota_project_id
+            credentials, _ = google.auth.load_credentials_from_file(
+                credentials_file, **scopes_kwargs, quota_project_id=quota_project_id
             )
 
         elif credentials is None:
-            credentials, _ = auth.default(
-                scopes=self._scopes, quota_project_id=quota_project_id
+            credentials, _ = google.auth.default(
+                **scopes_kwargs, quota_project_id=quota_project_id
             )
 
         # Save the credentials.
         self._credentials = credentials
+
+    # TODO(busunkim): These two class methods are in the base transport
+    # to avoid duplicating code across the transport classes. These functions
+    # should be deleted once the minimum required versions of google-api-core
+    # and google-auth are increased.
+
+    # TODO: Remove this function once google-auth >= 1.25.0 is required
+    @classmethod
+    def _get_scopes_kwargs(
+        cls, host: str, scopes: Optional[Sequence[str]]
+    ) -> Dict[str, Optional[Sequence[str]]]:
+        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
+
+        scopes_kwargs = {}
+
+        if _GOOGLE_AUTH_VERSION and (
+            packaging.version.parse(_GOOGLE_AUTH_VERSION)
+            >= packaging.version.parse("1.25.0")
+        ):
+            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
+        else:
+            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
+
+        return scopes_kwargs
+
+    # TODO: Remove this function once google-api-core >= 1.26.0 is required
+    @classmethod
+    def _get_self_signed_jwt_kwargs(
+        cls, host: str, scopes: Optional[Sequence[str]]
+    ) -> Dict[str, Union[Optional[Sequence[str]], str]]:
+        """Returns kwargs to pass to grpc_helpers.create_channel depending on the google-api-core version"""
+
+        self_signed_jwt_kwargs: Dict[str, Union[Optional[Sequence[str]], str]] = {}
+
+        if _API_CORE_VERSION and (
+            packaging.version.parse(_API_CORE_VERSION)
+            >= packaging.version.parse("1.26.0")
+        ):
+            self_signed_jwt_kwargs["default_scopes"] = cls.AUTH_SCOPES
+            self_signed_jwt_kwargs["scopes"] = scopes
+            self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
+        else:
+            self_signed_jwt_kwargs["scopes"] = scopes or cls.AUTH_SCOPES
+
+        return self_signed_jwt_kwargs
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
@@ -135,7 +195,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -149,7 +210,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -174,7 +236,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -188,7 +251,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -205,7 +269,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -219,7 +284,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -239,7 +305,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -259,7 +326,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -276,7 +344,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -293,7 +362,8 @@ class BigtableTableAdminTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=2,
                     predicate=retries.if_exception_type(
-                        exceptions.DeadlineExceeded, exceptions.ServiceUnavailable,
+                        core_exceptions.DeadlineExceeded,
+                        core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
                 ),
@@ -310,29 +380,29 @@ class BigtableTableAdminTransport(abc.ABC):
     @property
     def create_table(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.CreateTableRequest],
-        typing.Union[gba_table.Table, typing.Awaitable[gba_table.Table]],
+        Union[gba_table.Table, Awaitable[gba_table.Table]],
     ]:
         raise NotImplementedError()
 
     @property
     def create_table_from_snapshot(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.CreateTableFromSnapshotRequest],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def list_tables(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.ListTablesRequest],
-        typing.Union[
+        Union[
             bigtable_table_admin.ListTablesResponse,
-            typing.Awaitable[bigtable_table_admin.ListTablesResponse],
+            Awaitable[bigtable_table_admin.ListTablesResponse],
         ],
     ]:
         raise NotImplementedError()
@@ -340,47 +410,47 @@ class BigtableTableAdminTransport(abc.ABC):
     @property
     def get_table(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.GetTableRequest],
-        typing.Union[table.Table, typing.Awaitable[table.Table]],
+        Union[table.Table, Awaitable[table.Table]],
     ]:
         raise NotImplementedError()
 
     @property
     def delete_table(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.DeleteTableRequest],
-        typing.Union[empty.Empty, typing.Awaitable[empty.Empty]],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 
     @property
     def modify_column_families(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.ModifyColumnFamiliesRequest],
-        typing.Union[table.Table, typing.Awaitable[table.Table]],
+        Union[table.Table, Awaitable[table.Table]],
     ]:
         raise NotImplementedError()
 
     @property
     def drop_row_range(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.DropRowRangeRequest],
-        typing.Union[empty.Empty, typing.Awaitable[empty.Empty]],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 
     @property
     def generate_consistency_token(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.GenerateConsistencyTokenRequest],
-        typing.Union[
+        Union[
             bigtable_table_admin.GenerateConsistencyTokenResponse,
-            typing.Awaitable[bigtable_table_admin.GenerateConsistencyTokenResponse],
+            Awaitable[bigtable_table_admin.GenerateConsistencyTokenResponse],
         ],
     ]:
         raise NotImplementedError()
@@ -388,11 +458,11 @@ class BigtableTableAdminTransport(abc.ABC):
     @property
     def check_consistency(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.CheckConsistencyRequest],
-        typing.Union[
+        Union[
             bigtable_table_admin.CheckConsistencyResponse,
-            typing.Awaitable[bigtable_table_admin.CheckConsistencyResponse],
+            Awaitable[bigtable_table_admin.CheckConsistencyResponse],
         ],
     ]:
         raise NotImplementedError()
@@ -400,29 +470,29 @@ class BigtableTableAdminTransport(abc.ABC):
     @property
     def snapshot_table(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.SnapshotTableRequest],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def get_snapshot(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.GetSnapshotRequest],
-        typing.Union[table.Snapshot, typing.Awaitable[table.Snapshot]],
+        Union[table.Snapshot, Awaitable[table.Snapshot]],
     ]:
         raise NotImplementedError()
 
     @property
     def list_snapshots(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.ListSnapshotsRequest],
-        typing.Union[
+        Union[
             bigtable_table_admin.ListSnapshotsResponse,
-            typing.Awaitable[bigtable_table_admin.ListSnapshotsResponse],
+            Awaitable[bigtable_table_admin.ListSnapshotsResponse],
         ],
     ]:
         raise NotImplementedError()
@@ -430,56 +500,56 @@ class BigtableTableAdminTransport(abc.ABC):
     @property
     def delete_snapshot(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.DeleteSnapshotRequest],
-        typing.Union[empty.Empty, typing.Awaitable[empty.Empty]],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 
     @property
     def create_backup(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.CreateBackupRequest],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def get_backup(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.GetBackupRequest],
-        typing.Union[table.Backup, typing.Awaitable[table.Backup]],
+        Union[table.Backup, Awaitable[table.Backup]],
     ]:
         raise NotImplementedError()
 
     @property
     def update_backup(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.UpdateBackupRequest],
-        typing.Union[table.Backup, typing.Awaitable[table.Backup]],
+        Union[table.Backup, Awaitable[table.Backup]],
     ]:
         raise NotImplementedError()
 
     @property
     def delete_backup(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.DeleteBackupRequest],
-        typing.Union[empty.Empty, typing.Awaitable[empty.Empty]],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 
     @property
     def list_backups(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.ListBackupsRequest],
-        typing.Union[
+        Union[
             bigtable_table_admin.ListBackupsResponse,
-            typing.Awaitable[bigtable_table_admin.ListBackupsResponse],
+            Awaitable[bigtable_table_admin.ListBackupsResponse],
         ],
     ]:
         raise NotImplementedError()
@@ -487,38 +557,38 @@ class BigtableTableAdminTransport(abc.ABC):
     @property
     def restore_table(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [bigtable_table_admin.RestoreTableRequest],
-        typing.Union[operations.Operation, typing.Awaitable[operations.Operation]],
+        Union[operations_pb2.Operation, Awaitable[operations_pb2.Operation]],
     ]:
         raise NotImplementedError()
 
     @property
     def get_iam_policy(
         self,
-    ) -> typing.Callable[
-        [iam_policy.GetIamPolicyRequest],
-        typing.Union[policy.Policy, typing.Awaitable[policy.Policy]],
+    ) -> Callable[
+        [iam_policy_pb2.GetIamPolicyRequest],
+        Union[policy_pb2.Policy, Awaitable[policy_pb2.Policy]],
     ]:
         raise NotImplementedError()
 
     @property
     def set_iam_policy(
         self,
-    ) -> typing.Callable[
-        [iam_policy.SetIamPolicyRequest],
-        typing.Union[policy.Policy, typing.Awaitable[policy.Policy]],
+    ) -> Callable[
+        [iam_policy_pb2.SetIamPolicyRequest],
+        Union[policy_pb2.Policy, Awaitable[policy_pb2.Policy]],
     ]:
         raise NotImplementedError()
 
     @property
     def test_iam_permissions(
         self,
-    ) -> typing.Callable[
-        [iam_policy.TestIamPermissionsRequest],
-        typing.Union[
-            iam_policy.TestIamPermissionsResponse,
-            typing.Awaitable[iam_policy.TestIamPermissionsResponse],
+    ) -> Callable[
+        [iam_policy_pb2.TestIamPermissionsRequest],
+        Union[
+            iam_policy_pb2.TestIamPermissionsResponse,
+            Awaitable[iam_policy_pb2.TestIamPermissionsResponse],
         ],
     ]:
         raise NotImplementedError()

--- a/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/grpc.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/grpc.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import warnings
-from typing import Callable, Dict, Optional, Sequence, Tuple
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import grpc_helpers  # type: ignore
 from google.api_core import operations_v1  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
-from google import auth  # type: ignore
-from google.auth import credentials  # type: ignore
+import google.auth  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
 
 import grpc  # type: ignore
@@ -30,11 +28,10 @@ import grpc  # type: ignore
 from google.cloud.bigtable_admin_v2.types import bigtable_table_admin
 from google.cloud.bigtable_admin_v2.types import table
 from google.cloud.bigtable_admin_v2.types import table as gba_table
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.longrunning import operations_pb2 as operations  # type: ignore
-from google.protobuf import empty_pb2 as empty  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.longrunning import operations_pb2  # type: ignore
+from google.protobuf import empty_pb2  # type: ignore
 from .base import BigtableTableAdminTransport, DEFAULT_CLIENT_INFO
 
 
@@ -61,7 +58,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
         self,
         *,
         host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         credentials_file: str = None,
         scopes: Sequence[str] = None,
         channel: grpc.Channel = None,
@@ -75,7 +72,8 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
         """Instantiate the transport.
 
         Args:
-            host (Optional[str]): The hostname to connect to.
+            host (Optional[str]):
+                 The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -186,7 +184,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     def create_channel(
         cls,
         host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         credentials_file: str = None,
         scopes: Optional[Sequence[str]] = None,
         quota_project_id: Optional[str] = None,
@@ -217,13 +215,15 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             google.api_core.exceptions.DuplicateCredentialArgs: If both ``credentials``
               and ``credentials_file`` are passed.
         """
-        scopes = scopes or cls.AUTH_SCOPES
+
+        self_signed_jwt_kwargs = cls._get_self_signed_jwt_kwargs(host, scopes)
+
         return grpc_helpers.create_channel(
             host,
             credentials=credentials,
             credentials_file=credentials_file,
-            scopes=scopes,
             quota_project_id=quota_project_id,
+            **self_signed_jwt_kwargs,
             **kwargs,
         )
 
@@ -279,7 +279,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     def create_table_from_snapshot(
         self,
     ) -> Callable[
-        [bigtable_table_admin.CreateTableFromSnapshotRequest], operations.Operation
+        [bigtable_table_admin.CreateTableFromSnapshotRequest], operations_pb2.Operation
     ]:
         r"""Return a callable for the create table from snapshot method over gRPC.
 
@@ -307,7 +307,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             self._stubs["create_table_from_snapshot"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/CreateTableFromSnapshot",
                 request_serializer=bigtable_table_admin.CreateTableFromSnapshotRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["create_table_from_snapshot"]
 
@@ -369,7 +369,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     @property
     def delete_table(
         self,
-    ) -> Callable[[bigtable_table_admin.DeleteTableRequest], empty.Empty]:
+    ) -> Callable[[bigtable_table_admin.DeleteTableRequest], empty_pb2.Empty]:
         r"""Return a callable for the delete table method over gRPC.
 
         Permanently deletes a specified table and all of its
@@ -389,7 +389,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             self._stubs["delete_table"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteTable",
                 request_serializer=bigtable_table_admin.DeleteTableRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_table"]
 
@@ -426,7 +426,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     @property
     def drop_row_range(
         self,
-    ) -> Callable[[bigtable_table_admin.DropRowRangeRequest], empty.Empty]:
+    ) -> Callable[[bigtable_table_admin.DropRowRangeRequest], empty_pb2.Empty]:
         r"""Return a callable for the drop row range method over gRPC.
 
         Permanently drop/delete a row range from a specified
@@ -448,7 +448,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             self._stubs["drop_row_range"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/DropRowRange",
                 request_serializer=bigtable_table_admin.DropRowRangeRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["drop_row_range"]
 
@@ -520,7 +520,9 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     @property
     def snapshot_table(
         self,
-    ) -> Callable[[bigtable_table_admin.SnapshotTableRequest], operations.Operation]:
+    ) -> Callable[
+        [bigtable_table_admin.SnapshotTableRequest], operations_pb2.Operation
+    ]:
         r"""Return a callable for the snapshot table method over gRPC.
 
         Creates a new snapshot in the specified cluster from
@@ -547,7 +549,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             self._stubs["snapshot_table"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/SnapshotTable",
                 request_serializer=bigtable_table_admin.SnapshotTableRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["snapshot_table"]
 
@@ -623,7 +625,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     @property
     def delete_snapshot(
         self,
-    ) -> Callable[[bigtable_table_admin.DeleteSnapshotRequest], empty.Empty]:
+    ) -> Callable[[bigtable_table_admin.DeleteSnapshotRequest], empty_pb2.Empty]:
         r"""Return a callable for the delete snapshot method over gRPC.
 
         Permanently deletes the specified snapshot.
@@ -648,14 +650,14 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             self._stubs["delete_snapshot"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteSnapshot",
                 request_serializer=bigtable_table_admin.DeleteSnapshotRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_snapshot"]
 
     @property
     def create_backup(
         self,
-    ) -> Callable[[bigtable_table_admin.CreateBackupRequest], operations.Operation]:
+    ) -> Callable[[bigtable_table_admin.CreateBackupRequest], operations_pb2.Operation]:
         r"""Return a callable for the create backup method over gRPC.
 
         Starts creating a new Cloud Bigtable Backup. The returned backup
@@ -682,7 +684,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             self._stubs["create_backup"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/CreateBackup",
                 request_serializer=bigtable_table_admin.CreateBackupRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["create_backup"]
 
@@ -742,7 +744,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     @property
     def delete_backup(
         self,
-    ) -> Callable[[bigtable_table_admin.DeleteBackupRequest], empty.Empty]:
+    ) -> Callable[[bigtable_table_admin.DeleteBackupRequest], empty_pb2.Empty]:
         r"""Return a callable for the delete backup method over gRPC.
 
         Deletes a pending or completed Cloud Bigtable backup.
@@ -761,7 +763,7 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             self._stubs["delete_backup"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteBackup",
                 request_serializer=bigtable_table_admin.DeleteBackupRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_backup"]
 
@@ -798,12 +800,12 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     @property
     def restore_table(
         self,
-    ) -> Callable[[bigtable_table_admin.RestoreTableRequest], operations.Operation]:
+    ) -> Callable[[bigtable_table_admin.RestoreTableRequest], operations_pb2.Operation]:
         r"""Return a callable for the restore table method over gRPC.
 
         Create a new table by restoring from a completed backup. The new
-        table must be in the same instance as the instance containing
-        the backup. The returned table [long-running
+        table must be in the same project as the instance containing the
+        backup. The returned table [long-running
         operation][google.longrunning.Operation] can be used to track
         the progress of the operation, and to cancel it. The
         [metadata][google.longrunning.Operation.metadata] field type is
@@ -825,14 +827,14 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
             self._stubs["restore_table"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/RestoreTable",
                 request_serializer=bigtable_table_admin.RestoreTableRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["restore_table"]
 
     @property
     def get_iam_policy(
         self,
-    ) -> Callable[[iam_policy.GetIamPolicyRequest], policy.Policy]:
+    ) -> Callable[[iam_policy_pb2.GetIamPolicyRequest], policy_pb2.Policy]:
         r"""Return a callable for the get iam policy method over gRPC.
 
         Gets the access control policy for a Table or Backup
@@ -852,15 +854,15 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
         if "get_iam_policy" not in self._stubs:
             self._stubs["get_iam_policy"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/GetIamPolicy",
-                request_serializer=iam_policy.GetIamPolicyRequest.SerializeToString,
-                response_deserializer=policy.Policy.FromString,
+                request_serializer=iam_policy_pb2.GetIamPolicyRequest.SerializeToString,
+                response_deserializer=policy_pb2.Policy.FromString,
             )
         return self._stubs["get_iam_policy"]
 
     @property
     def set_iam_policy(
         self,
-    ) -> Callable[[iam_policy.SetIamPolicyRequest], policy.Policy]:
+    ) -> Callable[[iam_policy_pb2.SetIamPolicyRequest], policy_pb2.Policy]:
         r"""Return a callable for the set iam policy method over gRPC.
 
         Sets the access control policy on a Table or Backup
@@ -879,8 +881,8 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
         if "set_iam_policy" not in self._stubs:
             self._stubs["set_iam_policy"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/SetIamPolicy",
-                request_serializer=iam_policy.SetIamPolicyRequest.SerializeToString,
-                response_deserializer=policy.Policy.FromString,
+                request_serializer=iam_policy_pb2.SetIamPolicyRequest.SerializeToString,
+                response_deserializer=policy_pb2.Policy.FromString,
             )
         return self._stubs["set_iam_policy"]
 
@@ -888,7 +890,8 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
     def test_iam_permissions(
         self,
     ) -> Callable[
-        [iam_policy.TestIamPermissionsRequest], iam_policy.TestIamPermissionsResponse
+        [iam_policy_pb2.TestIamPermissionsRequest],
+        iam_policy_pb2.TestIamPermissionsResponse,
     ]:
         r"""Return a callable for the test iam permissions method over gRPC.
 
@@ -908,8 +911,8 @@ class BigtableTableAdminGrpcTransport(BigtableTableAdminTransport):
         if "test_iam_permissions" not in self._stubs:
             self._stubs["test_iam_permissions"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/TestIamPermissions",
-                request_serializer=iam_policy.TestIamPermissionsRequest.SerializeToString,
-                response_deserializer=iam_policy.TestIamPermissionsResponse.FromString,
+                request_serializer=iam_policy_pb2.TestIamPermissionsRequest.SerializeToString,
+                response_deserializer=iam_policy_pb2.TestIamPermissionsResponse.FromString,
             )
         return self._stubs["test_iam_permissions"]
 

--- a/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/grpc_asyncio.py
+++ b/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/grpc_asyncio.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import warnings
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import grpc_helpers_async  # type: ignore
 from google.api_core import operations_v1  # type: ignore
-from google import auth  # type: ignore
-from google.auth import credentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
+import packaging.version
 
 import grpc  # type: ignore
 from grpc.experimental import aio  # type: ignore
@@ -31,11 +29,10 @@ from grpc.experimental import aio  # type: ignore
 from google.cloud.bigtable_admin_v2.types import bigtable_table_admin
 from google.cloud.bigtable_admin_v2.types import table
 from google.cloud.bigtable_admin_v2.types import table as gba_table
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
-from google.longrunning import operations_pb2 as operations  # type: ignore
-from google.protobuf import empty_pb2 as empty  # type: ignore
-
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.longrunning import operations_pb2  # type: ignore
+from google.protobuf import empty_pb2  # type: ignore
 from .base import BigtableTableAdminTransport, DEFAULT_CLIENT_INFO
 from .grpc import BigtableTableAdminGrpcTransport
 
@@ -64,7 +61,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     def create_channel(
         cls,
         host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         credentials_file: Optional[str] = None,
         scopes: Optional[Sequence[str]] = None,
         quota_project_id: Optional[str] = None,
@@ -91,13 +88,15 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
         Returns:
             aio.Channel: A gRPC AsyncIO channel object.
         """
-        scopes = scopes or cls.AUTH_SCOPES
+
+        self_signed_jwt_kwargs = cls._get_self_signed_jwt_kwargs(host, scopes)
+
         return grpc_helpers_async.create_channel(
             host,
             credentials=credentials,
             credentials_file=credentials_file,
-            scopes=scopes,
             quota_project_id=quota_project_id,
+            **self_signed_jwt_kwargs,
             **kwargs,
         )
 
@@ -105,7 +104,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
         self,
         *,
         host: str = "bigtableadmin.googleapis.com",
-        credentials: credentials.Credentials = None,
+        credentials: ga_credentials.Credentials = None,
         credentials_file: Optional[str] = None,
         scopes: Optional[Sequence[str]] = None,
         channel: aio.Channel = None,
@@ -119,7 +118,8 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
         """Instantiate the transport.
 
         Args:
-            host (Optional[str]): The hostname to connect to.
+            host (Optional[str]):
+                 The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -178,7 +178,6 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             # If a channel was explicitly provided, set it.
             self._grpc_channel = channel
             self._ssl_channel_credentials = None
-
         else:
             if api_mtls_endpoint:
                 host = api_mtls_endpoint
@@ -288,7 +287,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
         self,
     ) -> Callable[
         [bigtable_table_admin.CreateTableFromSnapshotRequest],
-        Awaitable[operations.Operation],
+        Awaitable[operations_pb2.Operation],
     ]:
         r"""Return a callable for the create table from snapshot method over gRPC.
 
@@ -316,7 +315,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             self._stubs["create_table_from_snapshot"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/CreateTableFromSnapshot",
                 request_serializer=bigtable_table_admin.CreateTableFromSnapshotRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["create_table_from_snapshot"]
 
@@ -378,7 +377,9 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     @property
     def delete_table(
         self,
-    ) -> Callable[[bigtable_table_admin.DeleteTableRequest], Awaitable[empty.Empty]]:
+    ) -> Callable[
+        [bigtable_table_admin.DeleteTableRequest], Awaitable[empty_pb2.Empty]
+    ]:
         r"""Return a callable for the delete table method over gRPC.
 
         Permanently deletes a specified table and all of its
@@ -398,7 +399,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             self._stubs["delete_table"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteTable",
                 request_serializer=bigtable_table_admin.DeleteTableRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_table"]
 
@@ -437,7 +438,9 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     @property
     def drop_row_range(
         self,
-    ) -> Callable[[bigtable_table_admin.DropRowRangeRequest], Awaitable[empty.Empty]]:
+    ) -> Callable[
+        [bigtable_table_admin.DropRowRangeRequest], Awaitable[empty_pb2.Empty]
+    ]:
         r"""Return a callable for the drop row range method over gRPC.
 
         Permanently drop/delete a row range from a specified
@@ -459,7 +462,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             self._stubs["drop_row_range"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/DropRowRange",
                 request_serializer=bigtable_table_admin.DropRowRangeRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["drop_row_range"]
 
@@ -532,7 +535,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     def snapshot_table(
         self,
     ) -> Callable[
-        [bigtable_table_admin.SnapshotTableRequest], Awaitable[operations.Operation]
+        [bigtable_table_admin.SnapshotTableRequest], Awaitable[operations_pb2.Operation]
     ]:
         r"""Return a callable for the snapshot table method over gRPC.
 
@@ -560,7 +563,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             self._stubs["snapshot_table"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/SnapshotTable",
                 request_serializer=bigtable_table_admin.SnapshotTableRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["snapshot_table"]
 
@@ -636,7 +639,9 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     @property
     def delete_snapshot(
         self,
-    ) -> Callable[[bigtable_table_admin.DeleteSnapshotRequest], Awaitable[empty.Empty]]:
+    ) -> Callable[
+        [bigtable_table_admin.DeleteSnapshotRequest], Awaitable[empty_pb2.Empty]
+    ]:
         r"""Return a callable for the delete snapshot method over gRPC.
 
         Permanently deletes the specified snapshot.
@@ -661,7 +666,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             self._stubs["delete_snapshot"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteSnapshot",
                 request_serializer=bigtable_table_admin.DeleteSnapshotRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_snapshot"]
 
@@ -669,7 +674,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     def create_backup(
         self,
     ) -> Callable[
-        [bigtable_table_admin.CreateBackupRequest], Awaitable[operations.Operation]
+        [bigtable_table_admin.CreateBackupRequest], Awaitable[operations_pb2.Operation]
     ]:
         r"""Return a callable for the create backup method over gRPC.
 
@@ -697,7 +702,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             self._stubs["create_backup"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/CreateBackup",
                 request_serializer=bigtable_table_admin.CreateBackupRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["create_backup"]
 
@@ -757,7 +762,9 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     @property
     def delete_backup(
         self,
-    ) -> Callable[[bigtable_table_admin.DeleteBackupRequest], Awaitable[empty.Empty]]:
+    ) -> Callable[
+        [bigtable_table_admin.DeleteBackupRequest], Awaitable[empty_pb2.Empty]
+    ]:
         r"""Return a callable for the delete backup method over gRPC.
 
         Deletes a pending or completed Cloud Bigtable backup.
@@ -776,7 +783,7 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             self._stubs["delete_backup"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/DeleteBackup",
                 request_serializer=bigtable_table_admin.DeleteBackupRequest.serialize,
-                response_deserializer=empty.Empty.FromString,
+                response_deserializer=empty_pb2.Empty.FromString,
             )
         return self._stubs["delete_backup"]
 
@@ -814,13 +821,13 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     def restore_table(
         self,
     ) -> Callable[
-        [bigtable_table_admin.RestoreTableRequest], Awaitable[operations.Operation]
+        [bigtable_table_admin.RestoreTableRequest], Awaitable[operations_pb2.Operation]
     ]:
         r"""Return a callable for the restore table method over gRPC.
 
         Create a new table by restoring from a completed backup. The new
-        table must be in the same instance as the instance containing
-        the backup. The returned table [long-running
+        table must be in the same project as the instance containing the
+        backup. The returned table [long-running
         operation][google.longrunning.Operation] can be used to track
         the progress of the operation, and to cancel it. The
         [metadata][google.longrunning.Operation.metadata] field type is
@@ -842,14 +849,14 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
             self._stubs["restore_table"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/RestoreTable",
                 request_serializer=bigtable_table_admin.RestoreTableRequest.serialize,
-                response_deserializer=operations.Operation.FromString,
+                response_deserializer=operations_pb2.Operation.FromString,
             )
         return self._stubs["restore_table"]
 
     @property
     def get_iam_policy(
         self,
-    ) -> Callable[[iam_policy.GetIamPolicyRequest], Awaitable[policy.Policy]]:
+    ) -> Callable[[iam_policy_pb2.GetIamPolicyRequest], Awaitable[policy_pb2.Policy]]:
         r"""Return a callable for the get iam policy method over gRPC.
 
         Gets the access control policy for a Table or Backup
@@ -869,15 +876,15 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
         if "get_iam_policy" not in self._stubs:
             self._stubs["get_iam_policy"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/GetIamPolicy",
-                request_serializer=iam_policy.GetIamPolicyRequest.SerializeToString,
-                response_deserializer=policy.Policy.FromString,
+                request_serializer=iam_policy_pb2.GetIamPolicyRequest.SerializeToString,
+                response_deserializer=policy_pb2.Policy.FromString,
             )
         return self._stubs["get_iam_policy"]
 
     @property
     def set_iam_policy(
         self,
-    ) -> Callable[[iam_policy.SetIamPolicyRequest], Awaitable[policy.Policy]]:
+    ) -> Callable[[iam_policy_pb2.SetIamPolicyRequest], Awaitable[policy_pb2.Policy]]:
         r"""Return a callable for the set iam policy method over gRPC.
 
         Sets the access control policy on a Table or Backup
@@ -896,8 +903,8 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
         if "set_iam_policy" not in self._stubs:
             self._stubs["set_iam_policy"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/SetIamPolicy",
-                request_serializer=iam_policy.SetIamPolicyRequest.SerializeToString,
-                response_deserializer=policy.Policy.FromString,
+                request_serializer=iam_policy_pb2.SetIamPolicyRequest.SerializeToString,
+                response_deserializer=policy_pb2.Policy.FromString,
             )
         return self._stubs["set_iam_policy"]
 
@@ -905,8 +912,8 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
     def test_iam_permissions(
         self,
     ) -> Callable[
-        [iam_policy.TestIamPermissionsRequest],
-        Awaitable[iam_policy.TestIamPermissionsResponse],
+        [iam_policy_pb2.TestIamPermissionsRequest],
+        Awaitable[iam_policy_pb2.TestIamPermissionsResponse],
     ]:
         r"""Return a callable for the test iam permissions method over gRPC.
 
@@ -926,8 +933,8 @@ class BigtableTableAdminGrpcAsyncIOTransport(BigtableTableAdminTransport):
         if "test_iam_permissions" not in self._stubs:
             self._stubs["test_iam_permissions"] = self.grpc_channel.unary_unary(
                 "/google.bigtable.admin.v2.BigtableTableAdmin/TestIamPermissions",
-                request_serializer=iam_policy.TestIamPermissionsRequest.SerializeToString,
-                response_deserializer=iam_policy.TestIamPermissionsResponse.FromString,
+                request_serializer=iam_policy_pb2.TestIamPermissionsRequest.SerializeToString,
+                response_deserializer=iam_policy_pb2.TestIamPermissionsResponse.FromString,
             )
         return self._stubs["test_iam_permissions"]
 

--- a/google/cloud/bigtable_admin_v2/types/__init__.py
+++ b/google/cloud/bigtable_admin_v2/types/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from .bigtable_instance_admin import (
     CreateAppProfileRequest,
     CreateClusterMetadata,

--- a/google/cloud/bigtable_admin_v2/types/bigtable_instance_admin.py
+++ b/google/cloud/bigtable_admin_v2/types/bigtable_instance_admin.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import proto  # type: ignore
 
-
 from google.cloud.bigtable_admin_v2.types import instance as gba_instance
-from google.protobuf import field_mask_pb2 as field_mask  # type: ignore
-from google.protobuf import timestamp_pb2 as timestamp  # type: ignore
+from google.protobuf import field_mask_pb2  # type: ignore
+from google.protobuf import timestamp_pb2  # type: ignore
 
 
 __protobuf__ = proto.module(
@@ -54,7 +51,6 @@ __protobuf__ = proto.module(
 
 class CreateInstanceRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.CreateInstance.
-
     Attributes:
         parent (str):
             Required. The unique name of the project in which to create
@@ -76,12 +72,9 @@ class CreateInstanceRequest(proto.Message):
             at most four clusters can be specified.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    instance_id = proto.Field(proto.STRING, number=2)
-
+    parent = proto.Field(proto.STRING, number=1,)
+    instance_id = proto.Field(proto.STRING, number=2,)
     instance = proto.Field(proto.MESSAGE, number=3, message=gba_instance.Instance,)
-
     clusters = proto.MapField(
         proto.STRING, proto.MESSAGE, number=4, message=gba_instance.Cluster,
     )
@@ -89,19 +82,17 @@ class CreateInstanceRequest(proto.Message):
 
 class GetInstanceRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.GetInstance.
-
     Attributes:
         name (str):
             Required. The unique name of the requested instance. Values
             are of the form ``projects/{project}/instances/{instance}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class ListInstancesRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.ListInstances.
-
     Attributes:
         parent (str):
             Required. The unique name of the project for which a list of
@@ -111,14 +102,12 @@ class ListInstancesRequest(proto.Message):
             DEPRECATED: This field is unused and ignored.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    page_token = proto.Field(proto.STRING, number=2)
+    parent = proto.Field(proto.STRING, number=1,)
+    page_token = proto.Field(proto.STRING, number=2,)
 
 
 class ListInstancesResponse(proto.Message):
     r"""Response message for BigtableInstanceAdmin.ListInstances.
-
     Attributes:
         instances (Sequence[google.cloud.bigtable_admin_v2.types.Instance]):
             The list of requested instances.
@@ -141,10 +130,8 @@ class ListInstancesResponse(proto.Message):
     instances = proto.RepeatedField(
         proto.MESSAGE, number=1, message=gba_instance.Instance,
     )
-
-    failed_locations = proto.RepeatedField(proto.STRING, number=2)
-
-    next_page_token = proto.Field(proto.STRING, number=3)
+    failed_locations = proto.RepeatedField(proto.STRING, number=2,)
+    next_page_token = proto.Field(proto.STRING, number=3,)
 
 
 class PartialUpdateInstanceRequest(proto.Message):
@@ -161,13 +148,13 @@ class PartialUpdateInstanceRequest(proto.Message):
     """
 
     instance = proto.Field(proto.MESSAGE, number=1, message=gba_instance.Instance,)
-
-    update_mask = proto.Field(proto.MESSAGE, number=2, message=field_mask.FieldMask,)
+    update_mask = proto.Field(
+        proto.MESSAGE, number=2, message=field_mask_pb2.FieldMask,
+    )
 
 
 class DeleteInstanceRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.DeleteInstance.
-
     Attributes:
         name (str):
             Required. The unique name of the instance to be deleted.
@@ -175,12 +162,11 @@ class DeleteInstanceRequest(proto.Message):
             ``projects/{project}/instances/{instance}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class CreateClusterRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.CreateCluster.
-
     Attributes:
         parent (str):
             Required. The unique name of the instance in which to create
@@ -196,16 +182,13 @@ class CreateClusterRequest(proto.Message):
             ``OutputOnly`` must be left blank.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    cluster_id = proto.Field(proto.STRING, number=2)
-
+    parent = proto.Field(proto.STRING, number=1,)
+    cluster_id = proto.Field(proto.STRING, number=2,)
     cluster = proto.Field(proto.MESSAGE, number=3, message=gba_instance.Cluster,)
 
 
 class GetClusterRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.GetCluster.
-
     Attributes:
         name (str):
             Required. The unique name of the requested cluster. Values
@@ -213,12 +196,11 @@ class GetClusterRequest(proto.Message):
             ``projects/{project}/instances/{instance}/clusters/{cluster}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class ListClustersRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.ListClusters.
-
     Attributes:
         parent (str):
             Required. The unique name of the instance for which a list
@@ -230,14 +212,12 @@ class ListClustersRequest(proto.Message):
             DEPRECATED: This field is unused and ignored.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    page_token = proto.Field(proto.STRING, number=2)
+    parent = proto.Field(proto.STRING, number=1,)
+    page_token = proto.Field(proto.STRING, number=2,)
 
 
 class ListClustersResponse(proto.Message):
     r"""Response message for BigtableInstanceAdmin.ListClusters.
-
     Attributes:
         clusters (Sequence[google.cloud.bigtable_admin_v2.types.Cluster]):
             The list of requested clusters.
@@ -259,15 +239,12 @@ class ListClustersResponse(proto.Message):
     clusters = proto.RepeatedField(
         proto.MESSAGE, number=1, message=gba_instance.Cluster,
     )
-
-    failed_locations = proto.RepeatedField(proto.STRING, number=2)
-
-    next_page_token = proto.Field(proto.STRING, number=3)
+    failed_locations = proto.RepeatedField(proto.STRING, number=2,)
+    next_page_token = proto.Field(proto.STRING, number=3,)
 
 
 class DeleteClusterRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.DeleteCluster.
-
     Attributes:
         name (str):
             Required. The unique name of the cluster to be deleted.
@@ -275,12 +252,11 @@ class DeleteClusterRequest(proto.Message):
             ``projects/{project}/instances/{instance}/clusters/{cluster}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class CreateInstanceMetadata(proto.Message):
     r"""The metadata for the Operation returned by CreateInstance.
-
     Attributes:
         original_request (google.cloud.bigtable_admin_v2.types.CreateInstanceRequest):
             The request that prompted the initiation of
@@ -296,15 +272,14 @@ class CreateInstanceMetadata(proto.Message):
     original_request = proto.Field(
         proto.MESSAGE, number=1, message="CreateInstanceRequest",
     )
-
-    request_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
-
-    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    request_time = proto.Field(
+        proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp,
+    )
+    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
 
 
 class UpdateInstanceMetadata(proto.Message):
     r"""The metadata for the Operation returned by UpdateInstance.
-
     Attributes:
         original_request (google.cloud.bigtable_admin_v2.types.PartialUpdateInstanceRequest):
             The request that prompted the initiation of
@@ -320,15 +295,14 @@ class UpdateInstanceMetadata(proto.Message):
     original_request = proto.Field(
         proto.MESSAGE, number=1, message="PartialUpdateInstanceRequest",
     )
-
-    request_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
-
-    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    request_time = proto.Field(
+        proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp,
+    )
+    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
 
 
 class CreateClusterMetadata(proto.Message):
     r"""The metadata for the Operation returned by CreateCluster.
-
     Attributes:
         original_request (google.cloud.bigtable_admin_v2.types.CreateClusterRequest):
             The request that prompted the initiation of
@@ -344,15 +318,14 @@ class CreateClusterMetadata(proto.Message):
     original_request = proto.Field(
         proto.MESSAGE, number=1, message="CreateClusterRequest",
     )
-
-    request_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
-
-    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    request_time = proto.Field(
+        proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp,
+    )
+    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
 
 
 class UpdateClusterMetadata(proto.Message):
     r"""The metadata for the Operation returned by UpdateCluster.
-
     Attributes:
         original_request (google.cloud.bigtable_admin_v2.types.Cluster):
             The request that prompted the initiation of
@@ -368,15 +341,14 @@ class UpdateClusterMetadata(proto.Message):
     original_request = proto.Field(
         proto.MESSAGE, number=1, message=gba_instance.Cluster,
     )
-
-    request_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
-
-    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    request_time = proto.Field(
+        proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp,
+    )
+    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
 
 
 class CreateAppProfileRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.CreateAppProfile.
-
     Attributes:
         parent (str):
             Required. The unique name of the instance in which to create
@@ -395,18 +367,14 @@ class CreateAppProfileRequest(proto.Message):
             the app profile.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    app_profile_id = proto.Field(proto.STRING, number=2)
-
+    parent = proto.Field(proto.STRING, number=1,)
+    app_profile_id = proto.Field(proto.STRING, number=2,)
     app_profile = proto.Field(proto.MESSAGE, number=3, message=gba_instance.AppProfile,)
-
-    ignore_warnings = proto.Field(proto.BOOL, number=4)
+    ignore_warnings = proto.Field(proto.BOOL, number=4,)
 
 
 class GetAppProfileRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.GetAppProfile.
-
     Attributes:
         name (str):
             Required. The unique name of the requested app profile.
@@ -414,12 +382,11 @@ class GetAppProfileRequest(proto.Message):
             ``projects/{project}/instances/{instance}/appProfiles/{app_profile}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class ListAppProfilesRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.ListAppProfiles.
-
     Attributes:
         parent (str):
             Required. The unique name of the instance for which a list
@@ -444,16 +411,13 @@ class ListAppProfilesRequest(proto.Message):
             call.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    page_size = proto.Field(proto.INT32, number=3)
-
-    page_token = proto.Field(proto.STRING, number=2)
+    parent = proto.Field(proto.STRING, number=1,)
+    page_size = proto.Field(proto.INT32, number=3,)
+    page_token = proto.Field(proto.STRING, number=2,)
 
 
 class ListAppProfilesResponse(proto.Message):
     r"""Response message for BigtableInstanceAdmin.ListAppProfiles.
-
     Attributes:
         app_profiles (Sequence[google.cloud.bigtable_admin_v2.types.AppProfile]):
             The list of requested app profiles.
@@ -476,15 +440,12 @@ class ListAppProfilesResponse(proto.Message):
     app_profiles = proto.RepeatedField(
         proto.MESSAGE, number=1, message=gba_instance.AppProfile,
     )
-
-    next_page_token = proto.Field(proto.STRING, number=2)
-
-    failed_locations = proto.RepeatedField(proto.STRING, number=3)
+    next_page_token = proto.Field(proto.STRING, number=2,)
+    failed_locations = proto.RepeatedField(proto.STRING, number=3,)
 
 
 class UpdateAppProfileRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.UpdateAppProfile.
-
     Attributes:
         app_profile (google.cloud.bigtable_admin_v2.types.AppProfile):
             Required. The app profile which will
@@ -499,15 +460,14 @@ class UpdateAppProfileRequest(proto.Message):
     """
 
     app_profile = proto.Field(proto.MESSAGE, number=1, message=gba_instance.AppProfile,)
-
-    update_mask = proto.Field(proto.MESSAGE, number=2, message=field_mask.FieldMask,)
-
-    ignore_warnings = proto.Field(proto.BOOL, number=3)
+    update_mask = proto.Field(
+        proto.MESSAGE, number=2, message=field_mask_pb2.FieldMask,
+    )
+    ignore_warnings = proto.Field(proto.BOOL, number=3,)
 
 
 class DeleteAppProfileRequest(proto.Message):
     r"""Request message for BigtableInstanceAdmin.DeleteAppProfile.
-
     Attributes:
         name (str):
             Required. The unique name of the app profile to be deleted.
@@ -518,13 +478,12 @@ class DeleteAppProfileRequest(proto.Message):
             deleting the app profile.
     """
 
-    name = proto.Field(proto.STRING, number=1)
-
-    ignore_warnings = proto.Field(proto.BOOL, number=2)
+    name = proto.Field(proto.STRING, number=1,)
+    ignore_warnings = proto.Field(proto.BOOL, number=2,)
 
 
 class UpdateAppProfileMetadata(proto.Message):
-    r"""The metadata for the Operation returned by UpdateAppProfile."""
+    r"""The metadata for the Operation returned by UpdateAppProfile.    """
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/bigtable_admin_v2/types/bigtable_table_admin.py
+++ b/google/cloud/bigtable_admin_v2/types/bigtable_table_admin.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import proto  # type: ignore
-
 
 from google.cloud.bigtable_admin_v2.types import common
 from google.cloud.bigtable_admin_v2.types import table as gba_table
-from google.protobuf import duration_pb2 as duration  # type: ignore
-from google.protobuf import field_mask_pb2 as field_mask  # type: ignore
-from google.protobuf import timestamp_pb2 as timestamp  # type: ignore
+from google.protobuf import duration_pb2  # type: ignore
+from google.protobuf import field_mask_pb2  # type: ignore
+from google.protobuf import timestamp_pb2  # type: ignore
 
 
 __protobuf__ = proto.module(
@@ -68,8 +65,8 @@ class RestoreTableRequest(proto.Message):
     Attributes:
         parent (str):
             Required. The name of the instance in which to create the
-            restored table. This instance must be the parent of the
-            source backup. Values are of the form
+            restored table. This instance must be in the same project as
+            the source backup. Values are of the form
             ``projects/<project>/instances/<instance>``.
         table_id (str):
             Required. The id of the table to create and restore to. This
@@ -82,11 +79,9 @@ class RestoreTableRequest(proto.Message):
             ``projects/<project>/instances/<instance>/clusters/<cluster>/backups/<backup>``.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    table_id = proto.Field(proto.STRING, number=2)
-
-    backup = proto.Field(proto.STRING, number=3, oneof="source")
+    parent = proto.Field(proto.STRING, number=1,)
+    table_id = proto.Field(proto.STRING, number=2,)
+    backup = proto.Field(proto.STRING, number=3, oneof="source",)
 
 
 class RestoreTableMetadata(proto.Message):
@@ -118,16 +113,12 @@ class RestoreTableMetadata(proto.Message):
             operation.
     """
 
-    name = proto.Field(proto.STRING, number=1)
-
+    name = proto.Field(proto.STRING, number=1,)
     source_type = proto.Field(proto.ENUM, number=2, enum=gba_table.RestoreSourceType,)
-
     backup_info = proto.Field(
         proto.MESSAGE, number=3, oneof="source_info", message=gba_table.BackupInfo,
     )
-
-    optimize_table_operation_name = proto.Field(proto.STRING, number=4)
-
+    optimize_table_operation_name = proto.Field(proto.STRING, number=4,)
     progress = proto.Field(proto.MESSAGE, number=5, message=common.OperationProgress,)
 
 
@@ -146,8 +137,7 @@ class OptimizeRestoredTableMetadata(proto.Message):
             optimizations.
     """
 
-    name = proto.Field(proto.STRING, number=1)
-
+    name = proto.Field(proto.STRING, number=1,)
     progress = proto.Field(proto.MESSAGE, number=2, message=common.OperationProgress,)
 
 
@@ -193,20 +183,16 @@ class CreateTableRequest(proto.Message):
 
     class Split(proto.Message):
         r"""An initial split point for a newly created table.
-
         Attributes:
             key (bytes):
                 Row key to use as an initial tablet boundary.
         """
 
-        key = proto.Field(proto.BYTES, number=1)
+        key = proto.Field(proto.BYTES, number=1,)
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    table_id = proto.Field(proto.STRING, number=2)
-
+    parent = proto.Field(proto.STRING, number=1,)
+    table_id = proto.Field(proto.STRING, number=2,)
     table = proto.Field(proto.MESSAGE, number=3, message=gba_table.Table,)
-
     initial_splits = proto.RepeatedField(proto.MESSAGE, number=4, message=Split,)
 
 
@@ -236,11 +222,9 @@ class CreateTableFromSnapshotRequest(proto.Message):
             ``projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}``.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    table_id = proto.Field(proto.STRING, number=2)
-
-    source_snapshot = proto.Field(proto.STRING, number=3)
+    parent = proto.Field(proto.STRING, number=1,)
+    table_id = proto.Field(proto.STRING, number=2,)
+    source_snapshot = proto.Field(proto.STRING, number=3,)
 
 
 class DropRowRangeRequest(proto.Message):
@@ -260,11 +244,9 @@ class DropRowRangeRequest(proto.Message):
             false is a no-op.
     """
 
-    name = proto.Field(proto.STRING, number=1)
-
-    row_key_prefix = proto.Field(proto.BYTES, number=2, oneof="target")
-
-    delete_all_data_from_table = proto.Field(proto.BOOL, number=3, oneof="target")
+    name = proto.Field(proto.STRING, number=1,)
+    row_key_prefix = proto.Field(proto.BYTES, number=2, oneof="target",)
+    delete_all_data_from_table = proto.Field(proto.BOOL, number=3, oneof="target",)
 
 
 class ListTablesRequest(proto.Message):
@@ -296,13 +278,10 @@ class ListTablesRequest(proto.Message):
             call.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
+    parent = proto.Field(proto.STRING, number=1,)
     view = proto.Field(proto.ENUM, number=2, enum=gba_table.Table.View,)
-
-    page_size = proto.Field(proto.INT32, number=4)
-
-    page_token = proto.Field(proto.STRING, number=3)
+    page_size = proto.Field(proto.INT32, number=4,)
+    page_token = proto.Field(proto.STRING, number=3,)
 
 
 class ListTablesResponse(proto.Message):
@@ -323,8 +302,7 @@ class ListTablesResponse(proto.Message):
         return self
 
     tables = proto.RepeatedField(proto.MESSAGE, number=1, message=gba_table.Table,)
-
-    next_page_token = proto.Field(proto.STRING, number=2)
+    next_page_token = proto.Field(proto.STRING, number=2,)
 
 
 class GetTableRequest(proto.Message):
@@ -341,8 +319,7 @@ class GetTableRequest(proto.Message):
             Defaults to ``SCHEMA_VIEW`` if unspecified.
     """
 
-    name = proto.Field(proto.STRING, number=1)
-
+    name = proto.Field(proto.STRING, number=1,)
     view = proto.Field(proto.ENUM, number=2, enum=gba_table.Table.View,)
 
 
@@ -357,7 +334,7 @@ class DeleteTableRequest(proto.Message):
             ``projects/{project}/instances/{instance}/tables/{table}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class ModifyColumnFamiliesRequest(proto.Message):
@@ -380,7 +357,6 @@ class ModifyColumnFamiliesRequest(proto.Message):
 
     class Modification(proto.Message):
         r"""A create, update, or delete of a particular column family.
-
         Attributes:
             id (str):
                 The ID of the column family to be modified.
@@ -397,20 +373,16 @@ class ModifyColumnFamiliesRequest(proto.Message):
                 given ID, or fail if no such family exists.
         """
 
-        id = proto.Field(proto.STRING, number=1)
-
+        id = proto.Field(proto.STRING, number=1,)
         create = proto.Field(
             proto.MESSAGE, number=2, oneof="mod", message=gba_table.ColumnFamily,
         )
-
         update = proto.Field(
             proto.MESSAGE, number=3, oneof="mod", message=gba_table.ColumnFamily,
         )
+        drop = proto.Field(proto.BOOL, number=4, oneof="mod",)
 
-        drop = proto.Field(proto.BOOL, number=4, oneof="mod")
-
-    name = proto.Field(proto.STRING, number=1)
-
+    name = proto.Field(proto.STRING, number=1,)
     modifications = proto.RepeatedField(proto.MESSAGE, number=2, message=Modification,)
 
 
@@ -425,7 +397,7 @@ class GenerateConsistencyTokenRequest(proto.Message):
             ``projects/{project}/instances/{instance}/tables/{table}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class GenerateConsistencyTokenResponse(proto.Message):
@@ -437,7 +409,7 @@ class GenerateConsistencyTokenResponse(proto.Message):
             The generated consistency token.
     """
 
-    consistency_token = proto.Field(proto.STRING, number=1)
+    consistency_token = proto.Field(proto.STRING, number=1,)
 
 
 class CheckConsistencyRequest(proto.Message):
@@ -454,9 +426,8 @@ class CheckConsistencyRequest(proto.Message):
             GenerateConsistencyToken for the Table.
     """
 
-    name = proto.Field(proto.STRING, number=1)
-
-    consistency_token = proto.Field(proto.STRING, number=2)
+    name = proto.Field(proto.STRING, number=1,)
+    consistency_token = proto.Field(proto.STRING, number=2,)
 
 
 class CheckConsistencyResponse(proto.Message):
@@ -470,7 +441,7 @@ class CheckConsistencyResponse(proto.Message):
             the restrictions specified in the request.
     """
 
-    consistent = proto.Field(proto.BOOL, number=1)
+    consistent = proto.Field(proto.BOOL, number=1,)
 
 
 class SnapshotTableRequest(proto.Message):
@@ -508,15 +479,11 @@ class SnapshotTableRequest(proto.Message):
             Description of the snapshot.
     """
 
-    name = proto.Field(proto.STRING, number=1)
-
-    cluster = proto.Field(proto.STRING, number=2)
-
-    snapshot_id = proto.Field(proto.STRING, number=3)
-
-    ttl = proto.Field(proto.MESSAGE, number=4, message=duration.Duration,)
-
-    description = proto.Field(proto.STRING, number=5)
+    name = proto.Field(proto.STRING, number=1,)
+    cluster = proto.Field(proto.STRING, number=2,)
+    snapshot_id = proto.Field(proto.STRING, number=3,)
+    ttl = proto.Field(proto.MESSAGE, number=4, message=duration_pb2.Duration,)
+    description = proto.Field(proto.STRING, number=5,)
 
 
 class GetSnapshotRequest(proto.Message):
@@ -536,7 +503,7 @@ class GetSnapshotRequest(proto.Message):
             ``projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class ListSnapshotsRequest(proto.Message):
@@ -565,11 +532,9 @@ class ListSnapshotsRequest(proto.Message):
             call.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    page_size = proto.Field(proto.INT32, number=2)
-
-    page_token = proto.Field(proto.STRING, number=3)
+    parent = proto.Field(proto.STRING, number=1,)
+    page_size = proto.Field(proto.INT32, number=2,)
+    page_token = proto.Field(proto.STRING, number=3,)
 
 
 class ListSnapshotsResponse(proto.Message):
@@ -599,8 +564,7 @@ class ListSnapshotsResponse(proto.Message):
     snapshots = proto.RepeatedField(
         proto.MESSAGE, number=1, message=gba_table.Snapshot,
     )
-
-    next_page_token = proto.Field(proto.STRING, number=2)
+    next_page_token = proto.Field(proto.STRING, number=2,)
 
 
 class DeleteSnapshotRequest(proto.Message):
@@ -620,7 +584,7 @@ class DeleteSnapshotRequest(proto.Message):
             ``projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class SnapshotTableMetadata(proto.Message):
@@ -646,10 +610,10 @@ class SnapshotTableMetadata(proto.Message):
     original_request = proto.Field(
         proto.MESSAGE, number=1, message="SnapshotTableRequest",
     )
-
-    request_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
-
-    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    request_time = proto.Field(
+        proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp,
+    )
+    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
 
 
 class CreateTableFromSnapshotMetadata(proto.Message):
@@ -676,10 +640,10 @@ class CreateTableFromSnapshotMetadata(proto.Message):
     original_request = proto.Field(
         proto.MESSAGE, number=1, message="CreateTableFromSnapshotRequest",
     )
-
-    request_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
-
-    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    request_time = proto.Field(
+        proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp,
+    )
+    finish_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
 
 
 class CreateBackupRequest(proto.Message):
@@ -704,10 +668,8 @@ class CreateBackupRequest(proto.Message):
             Required. The backup to create.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    backup_id = proto.Field(proto.STRING, number=2)
-
+    parent = proto.Field(proto.STRING, number=1,)
+    backup_id = proto.Field(proto.STRING, number=2,)
     backup = proto.Field(proto.MESSAGE, number=3, message=gba_table.Backup,)
 
 
@@ -728,13 +690,10 @@ class CreateBackupMetadata(proto.Message):
             finished or was cancelled.
     """
 
-    name = proto.Field(proto.STRING, number=1)
-
-    source_table = proto.Field(proto.STRING, number=2)
-
-    start_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
-
-    end_time = proto.Field(proto.MESSAGE, number=4, message=timestamp.Timestamp,)
+    name = proto.Field(proto.STRING, number=1,)
+    source_table = proto.Field(proto.STRING, number=2,)
+    start_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
+    end_time = proto.Field(proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,)
 
 
 class UpdateBackupRequest(proto.Message):
@@ -759,8 +718,9 @@ class UpdateBackupRequest(proto.Message):
     """
 
     backup = proto.Field(proto.MESSAGE, number=1, message=gba_table.Backup,)
-
-    update_mask = proto.Field(proto.MESSAGE, number=2, message=field_mask.FieldMask,)
+    update_mask = proto.Field(
+        proto.MESSAGE, number=2, message=field_mask_pb2.FieldMask,
+    )
 
 
 class GetBackupRequest(proto.Message):
@@ -773,7 +733,7 @@ class GetBackupRequest(proto.Message):
             ``projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class DeleteBackupRequest(proto.Message):
@@ -787,7 +747,7 @@ class DeleteBackupRequest(proto.Message):
             ``projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}``.
     """
 
-    name = proto.Field(proto.STRING, number=1)
+    name = proto.Field(proto.STRING, number=1,)
 
 
 class ListBackupsRequest(proto.Message):
@@ -876,15 +836,11 @@ class ListBackupsRequest(proto.Message):
             to the same ``parent`` and with the same ``filter``.
     """
 
-    parent = proto.Field(proto.STRING, number=1)
-
-    filter = proto.Field(proto.STRING, number=2)
-
-    order_by = proto.Field(proto.STRING, number=3)
-
-    page_size = proto.Field(proto.INT32, number=4)
-
-    page_token = proto.Field(proto.STRING, number=5)
+    parent = proto.Field(proto.STRING, number=1,)
+    filter = proto.Field(proto.STRING, number=2,)
+    order_by = proto.Field(proto.STRING, number=3,)
+    page_size = proto.Field(proto.INT32, number=4,)
+    page_token = proto.Field(proto.STRING, number=5,)
 
 
 class ListBackupsResponse(proto.Message):
@@ -905,8 +861,7 @@ class ListBackupsResponse(proto.Message):
         return self
 
     backups = proto.RepeatedField(proto.MESSAGE, number=1, message=gba_table.Backup,)
-
-    next_page_token = proto.Field(proto.STRING, number=2)
+    next_page_token = proto.Field(proto.STRING, number=2,)
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/bigtable_admin_v2/types/common.py
+++ b/google/cloud/bigtable_admin_v2/types/common.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import proto  # type: ignore
 
-
-from google.protobuf import timestamp_pb2 as timestamp  # type: ignore
+from google.protobuf import timestamp_pb2  # type: ignore
 
 
 __protobuf__ = proto.module(
@@ -48,11 +45,9 @@ class OperationProgress(proto.Message):
             failed or was completed successfully.
     """
 
-    progress_percent = proto.Field(proto.INT32, number=1)
-
-    start_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
-
-    end_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    progress_percent = proto.Field(proto.INT32, number=1,)
+    start_time = proto.Field(proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp,)
+    end_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/bigtable_admin_v2/types/instance.py
+++ b/google/cloud/bigtable_admin_v2/types/instance.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import proto  # type: ignore
-
 
 from google.cloud.bigtable_admin_v2.types import common
 
@@ -74,15 +71,11 @@ class Instance(proto.Message):
         PRODUCTION = 1
         DEVELOPMENT = 2
 
-    name = proto.Field(proto.STRING, number=1)
-
-    display_name = proto.Field(proto.STRING, number=2)
-
+    name = proto.Field(proto.STRING, number=1,)
+    display_name = proto.Field(proto.STRING, number=2,)
     state = proto.Field(proto.ENUM, number=3, enum=State,)
-
     type_ = proto.Field(proto.ENUM, number=4, enum=Type,)
-
-    labels = proto.MapField(proto.STRING, proto.STRING, number=5)
+    labels = proto.MapField(proto.STRING, proto.STRING, number=5,)
 
 
 class Cluster(proto.Message):
@@ -143,18 +136,13 @@ class Cluster(proto.Message):
                    key.
         """
 
-        kms_key_name = proto.Field(proto.STRING, number=1)
+        kms_key_name = proto.Field(proto.STRING, number=1,)
 
-    name = proto.Field(proto.STRING, number=1)
-
-    location = proto.Field(proto.STRING, number=2)
-
+    name = proto.Field(proto.STRING, number=1,)
+    location = proto.Field(proto.STRING, number=2,)
     state = proto.Field(proto.ENUM, number=3, enum=State,)
-
-    serve_nodes = proto.Field(proto.INT32, number=4)
-
+    serve_nodes = proto.Field(proto.INT32, number=4,)
     default_storage_type = proto.Field(proto.ENUM, number=5, enum=common.StorageType,)
-
     encryption_config = proto.Field(proto.MESSAGE, number=6, message=EncryptionConfig,)
 
 
@@ -193,7 +181,7 @@ class AppProfile(proto.Message):
         available in the event of transient errors or delays. Clusters
         in a region are considered equidistant. Choosing this option
         sacrifices read-your-writes consistency to improve availability.
-        """
+            """
 
     class SingleClusterRouting(proto.Message):
         r"""Unconditionally routes all read/write requests to a specific
@@ -211,23 +199,18 @@ class AppProfile(proto.Message):
                 table/row/column in multiple clusters.
         """
 
-        cluster_id = proto.Field(proto.STRING, number=1)
+        cluster_id = proto.Field(proto.STRING, number=1,)
+        allow_transactional_writes = proto.Field(proto.BOOL, number=2,)
 
-        allow_transactional_writes = proto.Field(proto.BOOL, number=2)
-
-    name = proto.Field(proto.STRING, number=1)
-
-    etag = proto.Field(proto.STRING, number=2)
-
-    description = proto.Field(proto.STRING, number=3)
-
+    name = proto.Field(proto.STRING, number=1,)
+    etag = proto.Field(proto.STRING, number=2,)
+    description = proto.Field(proto.STRING, number=3,)
     multi_cluster_routing_use_any = proto.Field(
         proto.MESSAGE,
         number=5,
         oneof="routing_policy",
         message=MultiClusterRoutingUseAny,
     )
-
     single_cluster_routing = proto.Field(
         proto.MESSAGE, number=6, oneof="routing_policy", message=SingleClusterRouting,
     )

--- a/google/cloud/bigtable_admin_v2/types/table.py
+++ b/google/cloud/bigtable_admin_v2/types/table.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import proto  # type: ignore
 
-
-from google.protobuf import duration_pb2 as duration  # type: ignore
-from google.protobuf import timestamp_pb2 as timestamp  # type: ignore
-from google.rpc import status_pb2 as status  # type: ignore
+from google.protobuf import duration_pb2  # type: ignore
+from google.protobuf import timestamp_pb2  # type: ignore
+from google.rpc import status_pb2  # type: ignore
 
 
 __protobuf__ = proto.module(
@@ -47,7 +44,6 @@ class RestoreSourceType(proto.Enum):
 
 class RestoreInfo(proto.Message):
     r"""Information about a table restore.
-
     Attributes:
         source_type (google.cloud.bigtable_admin_v2.types.RestoreSourceType):
             The type of the restore source.
@@ -57,7 +53,6 @@ class RestoreInfo(proto.Message):
     """
 
     source_type = proto.Field(proto.ENUM, number=1, enum="RestoreSourceType",)
-
     backup_info = proto.Field(
         proto.MESSAGE, number=2, oneof="source_info", message="BackupInfo",
     )
@@ -116,7 +111,6 @@ class Table(proto.Message):
 
     class ClusterState(proto.Message):
         r"""The state of a table's data in a particular cluster.
-
         Attributes:
             replication_state (google.cloud.bigtable_admin_v2.types.Table.ClusterState.ReplicationState):
                 Output only. The state of replication for the
@@ -144,23 +138,18 @@ class Table(proto.Message):
         replication_state = proto.Field(
             proto.ENUM, number=1, enum="Table.ClusterState.ReplicationState",
         )
-
         encryption_info = proto.RepeatedField(
             proto.MESSAGE, number=2, message="EncryptionInfo",
         )
 
-    name = proto.Field(proto.STRING, number=1)
-
+    name = proto.Field(proto.STRING, number=1,)
     cluster_states = proto.MapField(
         proto.STRING, proto.MESSAGE, number=2, message=ClusterState,
     )
-
     column_families = proto.MapField(
         proto.STRING, proto.MESSAGE, number=3, message="ColumnFamily",
     )
-
     granularity = proto.Field(proto.ENUM, number=4, enum=TimestampGranularity,)
-
     restore_info = proto.Field(proto.MESSAGE, number=6, message="RestoreInfo",)
 
 
@@ -204,7 +193,6 @@ class GcRule(proto.Message):
 
     class Intersection(proto.Message):
         r"""A GcRule which deletes cells matching all of the given rules.
-
         Attributes:
             rules (Sequence[google.cloud.bigtable_admin_v2.types.GcRule]):
                 Only delete cells which would be deleted by every element of
@@ -215,7 +203,6 @@ class GcRule(proto.Message):
 
     class Union(proto.Message):
         r"""A GcRule which deletes cells matching any of the given rules.
-
         Attributes:
             rules (Sequence[google.cloud.bigtable_admin_v2.types.GcRule]):
                 Delete cells which would be deleted by any element of
@@ -224,16 +211,13 @@ class GcRule(proto.Message):
 
         rules = proto.RepeatedField(proto.MESSAGE, number=1, message="GcRule",)
 
-    max_num_versions = proto.Field(proto.INT32, number=1, oneof="rule")
-
+    max_num_versions = proto.Field(proto.INT32, number=1, oneof="rule",)
     max_age = proto.Field(
-        proto.MESSAGE, number=2, oneof="rule", message=duration.Duration,
+        proto.MESSAGE, number=2, oneof="rule", message=duration_pb2.Duration,
     )
-
     intersection = proto.Field(
         proto.MESSAGE, number=3, oneof="rule", message=Intersection,
     )
-
     union = proto.Field(proto.MESSAGE, number=4, oneof="rule", message=Union,)
 
 
@@ -265,10 +249,8 @@ class EncryptionInfo(proto.Message):
         CUSTOMER_MANAGED_ENCRYPTION = 2
 
     encryption_type = proto.Field(proto.ENUM, number=3, enum=EncryptionType,)
-
-    encryption_status = proto.Field(proto.MESSAGE, number=4, message=status.Status,)
-
-    kms_key_version = proto.Field(proto.STRING, number=2)
+    encryption_status = proto.Field(proto.MESSAGE, number=4, message=status_pb2.Status,)
+    kms_key_version = proto.Field(proto.STRING, number=2,)
 
 
 class Snapshot(proto.Message):
@@ -317,24 +299,17 @@ class Snapshot(proto.Message):
         READY = 1
         CREATING = 2
 
-    name = proto.Field(proto.STRING, number=1)
-
+    name = proto.Field(proto.STRING, number=1,)
     source_table = proto.Field(proto.MESSAGE, number=2, message="Table",)
-
-    data_size_bytes = proto.Field(proto.INT64, number=3)
-
-    create_time = proto.Field(proto.MESSAGE, number=4, message=timestamp.Timestamp,)
-
-    delete_time = proto.Field(proto.MESSAGE, number=5, message=timestamp.Timestamp,)
-
+    data_size_bytes = proto.Field(proto.INT64, number=3,)
+    create_time = proto.Field(proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,)
+    delete_time = proto.Field(proto.MESSAGE, number=5, message=timestamp_pb2.Timestamp,)
     state = proto.Field(proto.ENUM, number=6, enum=State,)
-
-    description = proto.Field(proto.STRING, number=7)
+    description = proto.Field(proto.STRING, number=7,)
 
 
 class Backup(proto.Message):
     r"""A backup of a Cloud Bigtable table.
-
     Attributes:
         name (str):
             Output only. A globally unique identifier for the backup
@@ -382,26 +357,18 @@ class Backup(proto.Message):
         CREATING = 1
         READY = 2
 
-    name = proto.Field(proto.STRING, number=1)
-
-    source_table = proto.Field(proto.STRING, number=2)
-
-    expire_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
-
-    start_time = proto.Field(proto.MESSAGE, number=4, message=timestamp.Timestamp,)
-
-    end_time = proto.Field(proto.MESSAGE, number=5, message=timestamp.Timestamp,)
-
-    size_bytes = proto.Field(proto.INT64, number=6)
-
+    name = proto.Field(proto.STRING, number=1,)
+    source_table = proto.Field(proto.STRING, number=2,)
+    expire_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
+    start_time = proto.Field(proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,)
+    end_time = proto.Field(proto.MESSAGE, number=5, message=timestamp_pb2.Timestamp,)
+    size_bytes = proto.Field(proto.INT64, number=6,)
     state = proto.Field(proto.ENUM, number=7, enum=State,)
-
     encryption_info = proto.Field(proto.MESSAGE, number=9, message="EncryptionInfo",)
 
 
 class BackupInfo(proto.Message):
     r"""Information about a backup.
-
     Attributes:
         backup (str):
             Output only. Name of the backup.
@@ -418,13 +385,10 @@ class BackupInfo(proto.Message):
             created from.
     """
 
-    backup = proto.Field(proto.STRING, number=1)
-
-    start_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
-
-    end_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
-
-    source_table = proto.Field(proto.STRING, number=4)
+    backup = proto.Field(proto.STRING, number=1,)
+    start_time = proto.Field(proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp,)
+    end_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
+    source_table = proto.Field(proto.STRING, number=4,)
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/owlbot.py
+++ b/owlbot.py
@@ -14,23 +14,66 @@
 
 """This script is used to synthesize generated parts of this library."""
 
+from pathlib import Path
+from typing import List, Optional
+
 import synthtool as s
 from synthtool import gcp
 from synthtool.languages import python
 
 common = gcp.CommonTemplates()
 
+# This is a customized version of the s.get_staging_dirs() function from synthtool to
+# cater for copying 2 different folders from googleapis-gen
+# which are bigtable and bigtable/admin.
+# Source https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L280
+def get_staging_dirs(
+    default_version: Optional[str] = None, sub_directory: Optional[str] = None
+) -> List[Path]:
+    """Returns the list of directories, one per version, copied from
+    https://github.com/googleapis/googleapis-gen. Will return in lexical sorting
+    order with the exception of the default_version which will be last (if specified).
+
+    Args:
+      default_version (str): the default version of the API. The directory for this version
+        will be the last item in the returned list if specified.
+      sub_directory (str): if a `sub_directory` is provided, only the directories within the
+        specified `sub_directory` will be returned.
+
+    Returns: the empty list if no file were copied.
+    """
+
+    staging = Path("owl-bot-staging")
+
+    if sub_directory:
+        staging /= sub_directory
+
+    if staging.is_dir():
+        # Collect the subdirectories of the staging directory.
+        versions = [v.name for v in staging.iterdir() if v.is_dir()]
+        # Reorder the versions so the default version always comes last.
+        versions = [v for v in versions if v != default_version]
+        versions.sort()
+        if default_version is not None:
+            versions += [default_version]
+        dirs = [staging / v for v in versions]
+        for dir in dirs:
+            s._tracked_paths.add(dir)
+        return dirs
+    else:
+        return []
+
 # This library ships clients for two different APIs,
 # BigTable and BigTable Admin
 bigtable_default_version = "v2"
 bigtable_admin_default_version = "v2"
 
-for library in s.get_staging_dirs(bigtable_default_version):
+for library in get_staging_dirs(bigtable_default_version, "bigtable"):
     s.move(library / "google/cloud/bigtable_v*")
     s.move(library / "tests")
     s.move(library / "scripts")
 
-for library in s.get_staging_dirs(bigtable_admin_default_version):
+for library in get_staging_dirs(bigtable_admin_default_version, "bigtable_admin"):
     s.move(library / "google/cloud/bigtable_admin_v*")
     s.move(library / "tests")
     s.move(library / "scripts")

--- a/scripts/fixup_bigtable_admin_v2_keywords.py
+++ b/scripts/fixup_bigtable_admin_v2_keywords.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import argparse
 import os
 import libcst as cst
@@ -41,45 +39,44 @@ def partition(
 class bigtable_adminCallTransformer(cst.CSTTransformer):
     CTRL_PARAMS: Tuple[str] = ('retry', 'timeout', 'metadata')
     METHOD_TO_PARAMS: Dict[str, Tuple[str]] = {
-    'check_consistency': ('name', 'consistency_token', ),
-    'create_app_profile': ('parent', 'app_profile_id', 'app_profile', 'ignore_warnings', ),
-    'create_backup': ('parent', 'backup_id', 'backup', ),
-    'create_cluster': ('parent', 'cluster_id', 'cluster', ),
-    'create_instance': ('parent', 'instance_id', 'instance', 'clusters', ),
-    'create_table': ('parent', 'table_id', 'table', 'initial_splits', ),
-    'create_table_from_snapshot': ('parent', 'table_id', 'source_snapshot', ),
-    'delete_app_profile': ('name', 'ignore_warnings', ),
-    'delete_backup': ('name', ),
-    'delete_cluster': ('name', ),
-    'delete_instance': ('name', ),
-    'delete_snapshot': ('name', ),
-    'delete_table': ('name', ),
-    'drop_row_range': ('name', 'row_key_prefix', 'delete_all_data_from_table', ),
-    'generate_consistency_token': ('name', ),
-    'get_app_profile': ('name', ),
-    'get_backup': ('name', ),
-    'get_cluster': ('name', ),
-    'get_iam_policy': ('resource', 'options', ),
-    'get_instance': ('name', ),
-    'get_snapshot': ('name', ),
-    'get_table': ('name', 'view', ),
-    'list_app_profiles': ('parent', 'page_size', 'page_token', ),
-    'list_backups': ('parent', 'filter', 'order_by', 'page_size', 'page_token', ),
-    'list_clusters': ('parent', 'page_token', ),
-    'list_instances': ('parent', 'page_token', ),
-    'list_snapshots': ('parent', 'page_size', 'page_token', ),
-    'list_tables': ('parent', 'view', 'page_size', 'page_token', ),
-    'modify_column_families': ('name', 'modifications', ),
-    'partial_update_instance': ('instance', 'update_mask', ),
-    'restore_table': ('parent', 'table_id', 'backup', ),
-    'set_iam_policy': ('resource', 'policy', ),
-    'snapshot_table': ('name', 'cluster', 'snapshot_id', 'ttl', 'description', ),
-    'test_iam_permissions': ('resource', 'permissions', ),
-    'update_app_profile': ('app_profile', 'update_mask', 'ignore_warnings', ),
-    'update_backup': ('backup', 'update_mask', ),
-    'update_cluster': ('serve_nodes', 'name', 'location', 'state', 'default_storage_type', 'encryption_config', ),
-    'update_instance': ('display_name', 'name', 'state', 'type_', 'labels', ),
-
+          'check_consistency': ('name', 'consistency_token', ),
+          'create_app_profile': ('parent', 'app_profile_id', 'app_profile', 'ignore_warnings', ),
+          'create_backup': ('parent', 'backup_id', 'backup', ),
+          'create_cluster': ('parent', 'cluster_id', 'cluster', ),
+          'create_instance': ('parent', 'instance_id', 'instance', 'clusters', ),
+          'create_table': ('parent', 'table_id', 'table', 'initial_splits', ),
+          'create_table_from_snapshot': ('parent', 'table_id', 'source_snapshot', ),
+          'delete_app_profile': ('name', 'ignore_warnings', ),
+          'delete_backup': ('name', ),
+          'delete_cluster': ('name', ),
+          'delete_instance': ('name', ),
+          'delete_snapshot': ('name', ),
+          'delete_table': ('name', ),
+          'drop_row_range': ('name', 'row_key_prefix', 'delete_all_data_from_table', ),
+          'generate_consistency_token': ('name', ),
+          'get_app_profile': ('name', ),
+          'get_backup': ('name', ),
+          'get_cluster': ('name', ),
+          'get_iam_policy': ('resource', 'options', ),
+          'get_instance': ('name', ),
+          'get_snapshot': ('name', ),
+          'get_table': ('name', 'view', ),
+          'list_app_profiles': ('parent', 'page_size', 'page_token', ),
+          'list_backups': ('parent', 'filter', 'order_by', 'page_size', 'page_token', ),
+          'list_clusters': ('parent', 'page_token', ),
+          'list_instances': ('parent', 'page_token', ),
+          'list_snapshots': ('parent', 'page_size', 'page_token', ),
+          'list_tables': ('parent', 'view', 'page_size', 'page_token', ),
+          'modify_column_families': ('name', 'modifications', ),
+          'partial_update_instance': ('instance', 'update_mask', ),
+          'restore_table': ('parent', 'table_id', 'backup', ),
+          'set_iam_policy': ('resource', 'policy', ),
+          'snapshot_table': ('name', 'cluster', 'snapshot_id', 'ttl', 'description', ),
+          'test_iam_permissions': ('resource', 'permissions', ),
+          'update_app_profile': ('app_profile', 'update_mask', 'ignore_warnings', ),
+          'update_backup': ('backup', 'update_mask', ),
+          'update_cluster': ('serve_nodes', 'name', 'location', 'state', 'default_storage_type', 'encryption_config', ),
+          'update_instance': ('display_name', 'name', 'state', 'type_', 'labels', ),
     }
 
     def leave_Call(self, original: cst.Call, updated: cst.Call) -> cst.CSTNode:
@@ -110,7 +107,7 @@ class bigtable_adminCallTransformer(cst.CSTTransformer):
             value=cst.Dict([
                 cst.DictElement(
                     cst.SimpleString("'{}'".format(name)),
-                    cst.Element(value=arg.value)
+cst.Element(value=arg.value)
                 )
                 # Note: the args + kwargs looks silly, but keep in mind that
                 # the control parameters had to be stripped out, and that

--- a/tests/unit/gapic/bigtable_admin_v2/__init__.py
+++ b/tests/unit/gapic/bigtable_admin_v2/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/gapic/bigtable_admin_v2/test_bigtable_instance_admin.py
+++ b/tests/unit/gapic/bigtable_admin_v2/test_bigtable_instance_admin.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import os
 import mock
+import packaging.version
 
 import grpc
 from grpc.experimental import aio
@@ -24,16 +23,16 @@ import math
 import pytest
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 
-from google import auth
+
 from google.api_core import client_options
-from google.api_core import exceptions
+from google.api_core import exceptions as core_exceptions
 from google.api_core import future
 from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
-from google.auth import credentials
+from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.bigtable_admin_v2.services.bigtable_instance_admin import (
     BigtableInstanceAdminAsyncClient,
@@ -43,17 +42,47 @@ from google.cloud.bigtable_admin_v2.services.bigtable_instance_admin import (
 )
 from google.cloud.bigtable_admin_v2.services.bigtable_instance_admin import pagers
 from google.cloud.bigtable_admin_v2.services.bigtable_instance_admin import transports
+from google.cloud.bigtable_admin_v2.services.bigtable_instance_admin.transports.base import (
+    _API_CORE_VERSION,
+)
+from google.cloud.bigtable_admin_v2.services.bigtable_instance_admin.transports.base import (
+    _GOOGLE_AUTH_VERSION,
+)
 from google.cloud.bigtable_admin_v2.types import bigtable_instance_admin
 from google.cloud.bigtable_admin_v2.types import common
 from google.cloud.bigtable_admin_v2.types import instance
 from google.cloud.bigtable_admin_v2.types import instance as gba_instance
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import options_pb2 as options  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import options_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
 from google.longrunning import operations_pb2
 from google.oauth2 import service_account
-from google.protobuf import field_mask_pb2 as field_mask  # type: ignore
-from google.type import expr_pb2 as expr  # type: ignore
+from google.protobuf import field_mask_pb2  # type: ignore
+from google.type import expr_pb2  # type: ignore
+import google.auth
+
+
+# TODO(busunkim): Once google-api-core >= 1.26.0 is required:
+# - Delete all the api-core and auth "less than" test cases
+# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
+requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
+    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
+    reason="This test requires google-auth < 1.25.0",
+)
+requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
+    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
+    reason="This test requires google-auth >= 1.25.0",
+)
+
+requires_api_core_lt_1_26_0 = pytest.mark.skipif(
+    packaging.version.parse(_API_CORE_VERSION) >= packaging.version.parse("1.26.0"),
+    reason="This test requires google-api-core < 1.26.0",
+)
+
+requires_api_core_gte_1_26_0 = pytest.mark.skipif(
+    packaging.version.parse(_API_CORE_VERSION) < packaging.version.parse("1.26.0"),
+    reason="This test requires google-api-core >= 1.26.0",
+)
 
 
 def client_cert_source_callback():
@@ -105,7 +134,7 @@ def test__get_default_mtls_endpoint():
     "client_class", [BigtableInstanceAdminClient, BigtableInstanceAdminAsyncClient,]
 )
 def test_bigtable_instance_admin_client_from_service_account_info(client_class):
-    creds = credentials.AnonymousCredentials()
+    creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_info"
     ) as factory:
@@ -122,7 +151,7 @@ def test_bigtable_instance_admin_client_from_service_account_info(client_class):
     "client_class", [BigtableInstanceAdminClient, BigtableInstanceAdminAsyncClient,]
 )
 def test_bigtable_instance_admin_client_from_service_account_file(client_class):
-    creds = credentials.AnonymousCredentials()
+    creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_file"
     ) as factory:
@@ -179,7 +208,7 @@ def test_bigtable_instance_admin_client_client_options(
 ):
     # Check that if channel is provided we won't create a new one.
     with mock.patch.object(BigtableInstanceAdminClient, "get_transport_class") as gtc:
-        transport = transport_class(credentials=credentials.AnonymousCredentials())
+        transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
         client = client_class(transport=transport)
         gtc.assert_not_called()
 
@@ -485,7 +514,7 @@ def test_create_instance(
     transport: str = "grpc", request_type=bigtable_instance_admin.CreateInstanceRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -496,13 +525,11 @@ def test_create_instance(
     with mock.patch.object(type(client.transport.create_instance), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.create_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateInstanceRequest()
 
     # Establish that the response is the type that we expect.
@@ -517,7 +544,7 @@ def test_create_instance_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -525,7 +552,6 @@ def test_create_instance_empty_call():
         client.create_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateInstanceRequest()
 
 
@@ -535,7 +561,7 @@ async def test_create_instance_async(
     request_type=bigtable_instance_admin.CreateInstanceRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -548,13 +574,11 @@ async def test_create_instance_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.create_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateInstanceRequest()
 
     # Establish that the response is the type that we expect.
@@ -568,18 +592,18 @@ async def test_create_instance_async_from_dict():
 
 def test_create_instance_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.CreateInstanceRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_instance), "__call__") as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.create_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -595,12 +619,13 @@ def test_create_instance_field_headers():
 @pytest.mark.asyncio
 async def test_create_instance_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.CreateInstanceRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -608,7 +633,6 @@ async def test_create_instance_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.create_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -623,14 +647,13 @@ async def test_create_instance_field_headers_async():
 
 def test_create_instance_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_instance), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.create_instance(
@@ -644,13 +667,9 @@ def test_create_instance_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].instance_id == "instance_id_value"
-
         assert args[0].instance == gba_instance.Instance(name="name_value")
-
         assert args[0].clusters == {
             "key_value": gba_instance.Cluster(name="name_value")
         }
@@ -658,7 +677,7 @@ def test_create_instance_flattened():
 
 def test_create_instance_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -676,7 +695,7 @@ def test_create_instance_flattened_error():
 @pytest.mark.asyncio
 async def test_create_instance_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -700,13 +719,9 @@ async def test_create_instance_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].instance_id == "instance_id_value"
-
         assert args[0].instance == gba_instance.Instance(name="name_value")
-
         assert args[0].clusters == {
             "key_value": gba_instance.Cluster(name="name_value")
         }
@@ -715,7 +730,7 @@ async def test_create_instance_flattened_async():
 @pytest.mark.asyncio
 async def test_create_instance_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -734,7 +749,7 @@ def test_get_instance(
     transport: str = "grpc", request_type=bigtable_instance_admin.GetInstanceRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -750,25 +765,18 @@ def test_get_instance(
             state=instance.Instance.State.READY,
             type_=instance.Instance.Type.PRODUCTION,
         )
-
         response = client.get_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetInstanceRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, instance.Instance)
-
     assert response.name == "name_value"
-
     assert response.display_name == "display_name_value"
-
     assert response.state == instance.Instance.State.READY
-
     assert response.type_ == instance.Instance.Type.PRODUCTION
 
 
@@ -780,7 +788,7 @@ def test_get_instance_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -788,7 +796,6 @@ def test_get_instance_empty_call():
         client.get_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetInstanceRequest()
 
 
@@ -798,7 +805,7 @@ async def test_get_instance_async(
     request_type=bigtable_instance_admin.GetInstanceRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -816,24 +823,18 @@ async def test_get_instance_async(
                 type_=instance.Instance.Type.PRODUCTION,
             )
         )
-
         response = await client.get_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetInstanceRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, instance.Instance)
-
     assert response.name == "name_value"
-
     assert response.display_name == "display_name_value"
-
     assert response.state == instance.Instance.State.READY
-
     assert response.type_ == instance.Instance.Type.PRODUCTION
 
 
@@ -844,18 +845,18 @@ async def test_get_instance_async_from_dict():
 
 def test_get_instance_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.GetInstanceRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_instance), "__call__") as call:
         call.return_value = instance.Instance()
-
         client.get_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -871,18 +872,18 @@ def test_get_instance_field_headers():
 @pytest.mark.asyncio
 async def test_get_instance_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.GetInstanceRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_instance), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(instance.Instance())
-
         await client.get_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -897,14 +898,13 @@ async def test_get_instance_field_headers_async():
 
 def test_get_instance_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_instance), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = instance.Instance()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_instance(name="name_value",)
@@ -913,13 +913,12 @@ def test_get_instance_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_get_instance_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -933,7 +932,7 @@ def test_get_instance_flattened_error():
 @pytest.mark.asyncio
 async def test_get_instance_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -950,14 +949,13 @@ async def test_get_instance_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_get_instance_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -972,7 +970,7 @@ def test_list_instances(
     transport: str = "grpc", request_type=bigtable_instance_admin.ListInstancesRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -986,23 +984,17 @@ def test_list_instances(
             failed_locations=["failed_locations_value"],
             next_page_token="next_page_token_value",
         )
-
         response = client.list_instances(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListInstancesRequest()
 
     # Establish that the response is the type that we expect.
-
     assert response.raw_page is response
-
     assert isinstance(response, bigtable_instance_admin.ListInstancesResponse)
-
     assert response.failed_locations == ["failed_locations_value"]
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -1014,7 +1006,7 @@ def test_list_instances_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1022,7 +1014,6 @@ def test_list_instances_empty_call():
         client.list_instances()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListInstancesRequest()
 
 
@@ -1032,7 +1023,7 @@ async def test_list_instances_async(
     request_type=bigtable_instance_admin.ListInstancesRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1048,20 +1039,16 @@ async def test_list_instances_async(
                 next_page_token="next_page_token_value",
             )
         )
-
         response = await client.list_instances(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListInstancesRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, bigtable_instance_admin.ListInstancesResponse)
-
     assert response.failed_locations == ["failed_locations_value"]
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -1072,18 +1059,18 @@ async def test_list_instances_async_from_dict():
 
 def test_list_instances_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.ListInstancesRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_instances), "__call__") as call:
         call.return_value = bigtable_instance_admin.ListInstancesResponse()
-
         client.list_instances(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1099,12 +1086,13 @@ def test_list_instances_field_headers():
 @pytest.mark.asyncio
 async def test_list_instances_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.ListInstancesRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1112,7 +1100,6 @@ async def test_list_instances_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_instance_admin.ListInstancesResponse()
         )
-
         await client.list_instances(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1127,14 +1114,13 @@ async def test_list_instances_field_headers_async():
 
 def test_list_instances_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_instances), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = bigtable_instance_admin.ListInstancesResponse()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_instances(parent="parent_value",)
@@ -1143,13 +1129,12 @@ def test_list_instances_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 def test_list_instances_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1163,7 +1148,7 @@ def test_list_instances_flattened_error():
 @pytest.mark.asyncio
 async def test_list_instances_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1182,14 +1167,13 @@ async def test_list_instances_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 @pytest.mark.asyncio
 async def test_list_instances_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1202,7 +1186,7 @@ async def test_list_instances_flattened_error_async():
 
 def test_update_instance(transport: str = "grpc", request_type=instance.Instance):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1218,25 +1202,18 @@ def test_update_instance(transport: str = "grpc", request_type=instance.Instance
             state=instance.Instance.State.READY,
             type_=instance.Instance.Type.PRODUCTION,
         )
-
         response = client.update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == instance.Instance()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, instance.Instance)
-
     assert response.name == "name_value"
-
     assert response.display_name == "display_name_value"
-
     assert response.state == instance.Instance.State.READY
-
     assert response.type_ == instance.Instance.Type.PRODUCTION
 
 
@@ -1248,7 +1225,7 @@ def test_update_instance_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1256,7 +1233,6 @@ def test_update_instance_empty_call():
         client.update_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == instance.Instance()
 
 
@@ -1265,7 +1241,7 @@ async def test_update_instance_async(
     transport: str = "grpc_asyncio", request_type=instance.Instance
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1283,24 +1259,18 @@ async def test_update_instance_async(
                 type_=instance.Instance.Type.PRODUCTION,
             )
         )
-
         response = await client.update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == instance.Instance()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, instance.Instance)
-
     assert response.name == "name_value"
-
     assert response.display_name == "display_name_value"
-
     assert response.state == instance.Instance.State.READY
-
     assert response.type_ == instance.Instance.Type.PRODUCTION
 
 
@@ -1311,18 +1281,18 @@ async def test_update_instance_async_from_dict():
 
 def test_update_instance_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = instance.Instance()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_instance), "__call__") as call:
         call.return_value = instance.Instance()
-
         client.update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1338,18 +1308,18 @@ def test_update_instance_field_headers():
 @pytest.mark.asyncio
 async def test_update_instance_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = instance.Instance()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_instance), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(instance.Instance())
-
         await client.update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1367,7 +1337,7 @@ def test_partial_update_instance(
     request_type=bigtable_instance_admin.PartialUpdateInstanceRequest,
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1380,13 +1350,11 @@ def test_partial_update_instance(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.partial_update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.PartialUpdateInstanceRequest()
 
     # Establish that the response is the type that we expect.
@@ -1401,7 +1369,7 @@ def test_partial_update_instance_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1411,7 +1379,6 @@ def test_partial_update_instance_empty_call():
         client.partial_update_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.PartialUpdateInstanceRequest()
 
 
@@ -1421,7 +1388,7 @@ async def test_partial_update_instance_async(
     request_type=bigtable_instance_admin.PartialUpdateInstanceRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1436,13 +1403,11 @@ async def test_partial_update_instance_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.partial_update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.PartialUpdateInstanceRequest()
 
     # Establish that the response is the type that we expect.
@@ -1456,12 +1421,13 @@ async def test_partial_update_instance_async_from_dict():
 
 def test_partial_update_instance_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.PartialUpdateInstanceRequest()
+
     request.instance.name = "instance.name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1469,7 +1435,6 @@ def test_partial_update_instance_field_headers():
         type(client.transport.partial_update_instance), "__call__"
     ) as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.partial_update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1487,12 +1452,13 @@ def test_partial_update_instance_field_headers():
 @pytest.mark.asyncio
 async def test_partial_update_instance_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.PartialUpdateInstanceRequest()
+
     request.instance.name = "instance.name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1502,7 +1468,6 @@ async def test_partial_update_instance_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.partial_update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1519,7 +1484,7 @@ async def test_partial_update_instance_field_headers_async():
 
 def test_partial_update_instance_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1528,27 +1493,24 @@ def test_partial_update_instance_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.partial_update_instance(
             instance=gba_instance.Instance(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].instance == gba_instance.Instance(name="name_value")
-
-        assert args[0].update_mask == field_mask.FieldMask(paths=["paths_value"])
+        assert args[0].update_mask == field_mask_pb2.FieldMask(paths=["paths_value"])
 
 
 def test_partial_update_instance_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1557,14 +1519,14 @@ def test_partial_update_instance_flattened_error():
         client.partial_update_instance(
             bigtable_instance_admin.PartialUpdateInstanceRequest(),
             instance=gba_instance.Instance(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
 
 @pytest.mark.asyncio
 async def test_partial_update_instance_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1581,23 +1543,21 @@ async def test_partial_update_instance_flattened_async():
         # using the keyword arguments to the method.
         response = await client.partial_update_instance(
             instance=gba_instance.Instance(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].instance == gba_instance.Instance(name="name_value")
-
-        assert args[0].update_mask == field_mask.FieldMask(paths=["paths_value"])
+        assert args[0].update_mask == field_mask_pb2.FieldMask(paths=["paths_value"])
 
 
 @pytest.mark.asyncio
 async def test_partial_update_instance_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1606,7 +1566,7 @@ async def test_partial_update_instance_flattened_error_async():
         await client.partial_update_instance(
             bigtable_instance_admin.PartialUpdateInstanceRequest(),
             instance=gba_instance.Instance(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
 
@@ -1614,7 +1574,7 @@ def test_delete_instance(
     transport: str = "grpc", request_type=bigtable_instance_admin.DeleteInstanceRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1625,13 +1585,11 @@ def test_delete_instance(
     with mock.patch.object(type(client.transport.delete_instance), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         response = client.delete_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteInstanceRequest()
 
     # Establish that the response is the type that we expect.
@@ -1646,7 +1604,7 @@ def test_delete_instance_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1654,7 +1612,6 @@ def test_delete_instance_empty_call():
         client.delete_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteInstanceRequest()
 
 
@@ -1664,7 +1621,7 @@ async def test_delete_instance_async(
     request_type=bigtable_instance_admin.DeleteInstanceRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1675,13 +1632,11 @@ async def test_delete_instance_async(
     with mock.patch.object(type(client.transport.delete_instance), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         response = await client.delete_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteInstanceRequest()
 
     # Establish that the response is the type that we expect.
@@ -1695,18 +1650,18 @@ async def test_delete_instance_async_from_dict():
 
 def test_delete_instance_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.DeleteInstanceRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_instance), "__call__") as call:
         call.return_value = None
-
         client.delete_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1722,18 +1677,18 @@ def test_delete_instance_field_headers():
 @pytest.mark.asyncio
 async def test_delete_instance_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.DeleteInstanceRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_instance), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         await client.delete_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1748,14 +1703,13 @@ async def test_delete_instance_field_headers_async():
 
 def test_delete_instance_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_instance), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.delete_instance(name="name_value",)
@@ -1764,13 +1718,12 @@ def test_delete_instance_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_delete_instance_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1784,7 +1737,7 @@ def test_delete_instance_flattened_error():
 @pytest.mark.asyncio
 async def test_delete_instance_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1801,14 +1754,13 @@ async def test_delete_instance_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_delete_instance_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1823,7 +1775,7 @@ def test_create_cluster(
     transport: str = "grpc", request_type=bigtable_instance_admin.CreateClusterRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1834,13 +1786,11 @@ def test_create_cluster(
     with mock.patch.object(type(client.transport.create_cluster), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.create_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateClusterRequest()
 
     # Establish that the response is the type that we expect.
@@ -1855,7 +1805,7 @@ def test_create_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1863,7 +1813,6 @@ def test_create_cluster_empty_call():
         client.create_cluster()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateClusterRequest()
 
 
@@ -1873,7 +1822,7 @@ async def test_create_cluster_async(
     request_type=bigtable_instance_admin.CreateClusterRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1886,13 +1835,11 @@ async def test_create_cluster_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.create_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateClusterRequest()
 
     # Establish that the response is the type that we expect.
@@ -1906,18 +1853,18 @@ async def test_create_cluster_async_from_dict():
 
 def test_create_cluster_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.CreateClusterRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_cluster), "__call__") as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.create_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1933,12 +1880,13 @@ def test_create_cluster_field_headers():
 @pytest.mark.asyncio
 async def test_create_cluster_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.CreateClusterRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1946,7 +1894,6 @@ async def test_create_cluster_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.create_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1961,14 +1908,13 @@ async def test_create_cluster_field_headers_async():
 
 def test_create_cluster_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_cluster), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.create_cluster(
@@ -1981,17 +1927,14 @@ def test_create_cluster_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].cluster_id == "cluster_id_value"
-
         assert args[0].cluster == instance.Cluster(name="name_value")
 
 
 def test_create_cluster_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2008,7 +1951,7 @@ def test_create_cluster_flattened_error():
 @pytest.mark.asyncio
 async def test_create_cluster_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2031,18 +1974,15 @@ async def test_create_cluster_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].cluster_id == "cluster_id_value"
-
         assert args[0].cluster == instance.Cluster(name="name_value")
 
 
 @pytest.mark.asyncio
 async def test_create_cluster_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2060,7 +2000,7 @@ def test_get_cluster(
     transport: str = "grpc", request_type=bigtable_instance_admin.GetClusterRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2077,27 +2017,19 @@ def test_get_cluster(
             serve_nodes=1181,
             default_storage_type=common.StorageType.SSD,
         )
-
         response = client.get_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetClusterRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, instance.Cluster)
-
     assert response.name == "name_value"
-
     assert response.location == "location_value"
-
     assert response.state == instance.Cluster.State.READY
-
     assert response.serve_nodes == 1181
-
     assert response.default_storage_type == common.StorageType.SSD
 
 
@@ -2109,7 +2041,7 @@ def test_get_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2117,7 +2049,6 @@ def test_get_cluster_empty_call():
         client.get_cluster()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetClusterRequest()
 
 
@@ -2127,7 +2058,7 @@ async def test_get_cluster_async(
     request_type=bigtable_instance_admin.GetClusterRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2146,26 +2077,19 @@ async def test_get_cluster_async(
                 default_storage_type=common.StorageType.SSD,
             )
         )
-
         response = await client.get_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetClusterRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, instance.Cluster)
-
     assert response.name == "name_value"
-
     assert response.location == "location_value"
-
     assert response.state == instance.Cluster.State.READY
-
     assert response.serve_nodes == 1181
-
     assert response.default_storage_type == common.StorageType.SSD
 
 
@@ -2176,18 +2100,18 @@ async def test_get_cluster_async_from_dict():
 
 def test_get_cluster_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.GetClusterRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_cluster), "__call__") as call:
         call.return_value = instance.Cluster()
-
         client.get_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2203,18 +2127,18 @@ def test_get_cluster_field_headers():
 @pytest.mark.asyncio
 async def test_get_cluster_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.GetClusterRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_cluster), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(instance.Cluster())
-
         await client.get_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2229,14 +2153,13 @@ async def test_get_cluster_field_headers_async():
 
 def test_get_cluster_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_cluster), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = instance.Cluster()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_cluster(name="name_value",)
@@ -2245,13 +2168,12 @@ def test_get_cluster_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_get_cluster_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2265,7 +2187,7 @@ def test_get_cluster_flattened_error():
 @pytest.mark.asyncio
 async def test_get_cluster_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2282,14 +2204,13 @@ async def test_get_cluster_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_get_cluster_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2304,7 +2225,7 @@ def test_list_clusters(
     transport: str = "grpc", request_type=bigtable_instance_admin.ListClustersRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2318,23 +2239,17 @@ def test_list_clusters(
             failed_locations=["failed_locations_value"],
             next_page_token="next_page_token_value",
         )
-
         response = client.list_clusters(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListClustersRequest()
 
     # Establish that the response is the type that we expect.
-
     assert response.raw_page is response
-
     assert isinstance(response, bigtable_instance_admin.ListClustersResponse)
-
     assert response.failed_locations == ["failed_locations_value"]
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -2346,7 +2261,7 @@ def test_list_clusters_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2354,7 +2269,6 @@ def test_list_clusters_empty_call():
         client.list_clusters()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListClustersRequest()
 
 
@@ -2364,7 +2278,7 @@ async def test_list_clusters_async(
     request_type=bigtable_instance_admin.ListClustersRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2380,20 +2294,16 @@ async def test_list_clusters_async(
                 next_page_token="next_page_token_value",
             )
         )
-
         response = await client.list_clusters(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListClustersRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, bigtable_instance_admin.ListClustersResponse)
-
     assert response.failed_locations == ["failed_locations_value"]
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -2404,18 +2314,18 @@ async def test_list_clusters_async_from_dict():
 
 def test_list_clusters_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.ListClustersRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_clusters), "__call__") as call:
         call.return_value = bigtable_instance_admin.ListClustersResponse()
-
         client.list_clusters(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2431,12 +2341,13 @@ def test_list_clusters_field_headers():
 @pytest.mark.asyncio
 async def test_list_clusters_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.ListClustersRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2444,7 +2355,6 @@ async def test_list_clusters_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_instance_admin.ListClustersResponse()
         )
-
         await client.list_clusters(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2459,14 +2369,13 @@ async def test_list_clusters_field_headers_async():
 
 def test_list_clusters_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_clusters), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = bigtable_instance_admin.ListClustersResponse()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_clusters(parent="parent_value",)
@@ -2475,13 +2384,12 @@ def test_list_clusters_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 def test_list_clusters_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2495,7 +2403,7 @@ def test_list_clusters_flattened_error():
 @pytest.mark.asyncio
 async def test_list_clusters_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2514,14 +2422,13 @@ async def test_list_clusters_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 @pytest.mark.asyncio
 async def test_list_clusters_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2534,7 +2441,7 @@ async def test_list_clusters_flattened_error_async():
 
 def test_update_cluster(transport: str = "grpc", request_type=instance.Cluster):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2545,13 +2452,11 @@ def test_update_cluster(transport: str = "grpc", request_type=instance.Cluster):
     with mock.patch.object(type(client.transport.update_cluster), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.update_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == instance.Cluster()
 
     # Establish that the response is the type that we expect.
@@ -2566,7 +2471,7 @@ def test_update_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2574,7 +2479,6 @@ def test_update_cluster_empty_call():
         client.update_cluster()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == instance.Cluster()
 
 
@@ -2583,7 +2487,7 @@ async def test_update_cluster_async(
     transport: str = "grpc_asyncio", request_type=instance.Cluster
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2596,13 +2500,11 @@ async def test_update_cluster_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.update_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == instance.Cluster()
 
     # Establish that the response is the type that we expect.
@@ -2616,18 +2518,18 @@ async def test_update_cluster_async_from_dict():
 
 def test_update_cluster_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = instance.Cluster()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_cluster), "__call__") as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.update_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2643,12 +2545,13 @@ def test_update_cluster_field_headers():
 @pytest.mark.asyncio
 async def test_update_cluster_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = instance.Cluster()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2656,7 +2559,6 @@ async def test_update_cluster_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.update_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2673,7 +2575,7 @@ def test_delete_cluster(
     transport: str = "grpc", request_type=bigtable_instance_admin.DeleteClusterRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2684,13 +2586,11 @@ def test_delete_cluster(
     with mock.patch.object(type(client.transport.delete_cluster), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         response = client.delete_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteClusterRequest()
 
     # Establish that the response is the type that we expect.
@@ -2705,7 +2605,7 @@ def test_delete_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2713,7 +2613,6 @@ def test_delete_cluster_empty_call():
         client.delete_cluster()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteClusterRequest()
 
 
@@ -2723,7 +2622,7 @@ async def test_delete_cluster_async(
     request_type=bigtable_instance_admin.DeleteClusterRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2734,13 +2633,11 @@ async def test_delete_cluster_async(
     with mock.patch.object(type(client.transport.delete_cluster), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         response = await client.delete_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteClusterRequest()
 
     # Establish that the response is the type that we expect.
@@ -2754,18 +2651,18 @@ async def test_delete_cluster_async_from_dict():
 
 def test_delete_cluster_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.DeleteClusterRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_cluster), "__call__") as call:
         call.return_value = None
-
         client.delete_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2781,18 +2678,18 @@ def test_delete_cluster_field_headers():
 @pytest.mark.asyncio
 async def test_delete_cluster_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.DeleteClusterRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_cluster), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         await client.delete_cluster(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2807,14 +2704,13 @@ async def test_delete_cluster_field_headers_async():
 
 def test_delete_cluster_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_cluster), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.delete_cluster(name="name_value",)
@@ -2823,13 +2719,12 @@ def test_delete_cluster_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_delete_cluster_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2843,7 +2738,7 @@ def test_delete_cluster_flattened_error():
 @pytest.mark.asyncio
 async def test_delete_cluster_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2860,14 +2755,13 @@ async def test_delete_cluster_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_delete_cluster_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2883,7 +2777,7 @@ def test_create_app_profile(
     request_type=bigtable_instance_admin.CreateAppProfileRequest,
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2901,23 +2795,17 @@ def test_create_app_profile(
             description="description_value",
             multi_cluster_routing_use_any=None,
         )
-
         response = client.create_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateAppProfileRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, instance.AppProfile)
-
     assert response.name == "name_value"
-
     assert response.etag == "etag_value"
-
     assert response.description == "description_value"
 
 
@@ -2929,7 +2817,7 @@ def test_create_app_profile_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2939,7 +2827,6 @@ def test_create_app_profile_empty_call():
         client.create_app_profile()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateAppProfileRequest()
 
 
@@ -2949,7 +2836,7 @@ async def test_create_app_profile_async(
     request_type=bigtable_instance_admin.CreateAppProfileRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2966,22 +2853,17 @@ async def test_create_app_profile_async(
                 name="name_value", etag="etag_value", description="description_value",
             )
         )
-
         response = await client.create_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.CreateAppProfileRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, instance.AppProfile)
-
     assert response.name == "name_value"
-
     assert response.etag == "etag_value"
-
     assert response.description == "description_value"
 
 
@@ -2992,12 +2874,13 @@ async def test_create_app_profile_async_from_dict():
 
 def test_create_app_profile_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.CreateAppProfileRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3005,7 +2888,6 @@ def test_create_app_profile_field_headers():
         type(client.transport.create_app_profile), "__call__"
     ) as call:
         call.return_value = instance.AppProfile()
-
         client.create_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3021,12 +2903,13 @@ def test_create_app_profile_field_headers():
 @pytest.mark.asyncio
 async def test_create_app_profile_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.CreateAppProfileRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3034,7 +2917,6 @@ async def test_create_app_profile_field_headers_async():
         type(client.transport.create_app_profile), "__call__"
     ) as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(instance.AppProfile())
-
         await client.create_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3049,7 +2931,7 @@ async def test_create_app_profile_field_headers_async():
 
 def test_create_app_profile_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3058,7 +2940,6 @@ def test_create_app_profile_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = instance.AppProfile()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.create_app_profile(
@@ -3071,17 +2952,14 @@ def test_create_app_profile_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].app_profile_id == "app_profile_id_value"
-
         assert args[0].app_profile == instance.AppProfile(name="name_value")
 
 
 def test_create_app_profile_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3098,7 +2976,7 @@ def test_create_app_profile_flattened_error():
 @pytest.mark.asyncio
 async def test_create_app_profile_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3121,18 +2999,15 @@ async def test_create_app_profile_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].app_profile_id == "app_profile_id_value"
-
         assert args[0].app_profile == instance.AppProfile(name="name_value")
 
 
 @pytest.mark.asyncio
 async def test_create_app_profile_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3150,7 +3025,7 @@ def test_get_app_profile(
     transport: str = "grpc", request_type=bigtable_instance_admin.GetAppProfileRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3166,23 +3041,17 @@ def test_get_app_profile(
             description="description_value",
             multi_cluster_routing_use_any=None,
         )
-
         response = client.get_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetAppProfileRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, instance.AppProfile)
-
     assert response.name == "name_value"
-
     assert response.etag == "etag_value"
-
     assert response.description == "description_value"
 
 
@@ -3194,7 +3063,7 @@ def test_get_app_profile_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3202,7 +3071,6 @@ def test_get_app_profile_empty_call():
         client.get_app_profile()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetAppProfileRequest()
 
 
@@ -3212,7 +3080,7 @@ async def test_get_app_profile_async(
     request_type=bigtable_instance_admin.GetAppProfileRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3227,22 +3095,17 @@ async def test_get_app_profile_async(
                 name="name_value", etag="etag_value", description="description_value",
             )
         )
-
         response = await client.get_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.GetAppProfileRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, instance.AppProfile)
-
     assert response.name == "name_value"
-
     assert response.etag == "etag_value"
-
     assert response.description == "description_value"
 
 
@@ -3253,18 +3116,18 @@ async def test_get_app_profile_async_from_dict():
 
 def test_get_app_profile_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.GetAppProfileRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_app_profile), "__call__") as call:
         call.return_value = instance.AppProfile()
-
         client.get_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3280,18 +3143,18 @@ def test_get_app_profile_field_headers():
 @pytest.mark.asyncio
 async def test_get_app_profile_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.GetAppProfileRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_app_profile), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(instance.AppProfile())
-
         await client.get_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3306,14 +3169,13 @@ async def test_get_app_profile_field_headers_async():
 
 def test_get_app_profile_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_app_profile), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = instance.AppProfile()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_app_profile(name="name_value",)
@@ -3322,13 +3184,12 @@ def test_get_app_profile_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_get_app_profile_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3342,7 +3203,7 @@ def test_get_app_profile_flattened_error():
 @pytest.mark.asyncio
 async def test_get_app_profile_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3359,14 +3220,13 @@ async def test_get_app_profile_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_get_app_profile_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3381,7 +3241,7 @@ def test_list_app_profiles(
     transport: str = "grpc", request_type=bigtable_instance_admin.ListAppProfilesRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3397,21 +3257,16 @@ def test_list_app_profiles(
             next_page_token="next_page_token_value",
             failed_locations=["failed_locations_value"],
         )
-
         response = client.list_app_profiles(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListAppProfilesRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, pagers.ListAppProfilesPager)
-
     assert response.next_page_token == "next_page_token_value"
-
     assert response.failed_locations == ["failed_locations_value"]
 
 
@@ -3423,7 +3278,7 @@ def test_list_app_profiles_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3433,7 +3288,6 @@ def test_list_app_profiles_empty_call():
         client.list_app_profiles()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListAppProfilesRequest()
 
 
@@ -3443,7 +3297,7 @@ async def test_list_app_profiles_async(
     request_type=bigtable_instance_admin.ListAppProfilesRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3461,20 +3315,16 @@ async def test_list_app_profiles_async(
                 failed_locations=["failed_locations_value"],
             )
         )
-
         response = await client.list_app_profiles(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.ListAppProfilesRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListAppProfilesAsyncPager)
-
     assert response.next_page_token == "next_page_token_value"
-
     assert response.failed_locations == ["failed_locations_value"]
 
 
@@ -3485,12 +3335,13 @@ async def test_list_app_profiles_async_from_dict():
 
 def test_list_app_profiles_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.ListAppProfilesRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3498,7 +3349,6 @@ def test_list_app_profiles_field_headers():
         type(client.transport.list_app_profiles), "__call__"
     ) as call:
         call.return_value = bigtable_instance_admin.ListAppProfilesResponse()
-
         client.list_app_profiles(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3514,12 +3364,13 @@ def test_list_app_profiles_field_headers():
 @pytest.mark.asyncio
 async def test_list_app_profiles_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.ListAppProfilesRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3529,7 +3380,6 @@ async def test_list_app_profiles_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_instance_admin.ListAppProfilesResponse()
         )
-
         await client.list_app_profiles(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3544,7 +3394,7 @@ async def test_list_app_profiles_field_headers_async():
 
 def test_list_app_profiles_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3553,7 +3403,6 @@ def test_list_app_profiles_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = bigtable_instance_admin.ListAppProfilesResponse()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_app_profiles(parent="parent_value",)
@@ -3562,13 +3411,12 @@ def test_list_app_profiles_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 def test_list_app_profiles_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3582,7 +3430,7 @@ def test_list_app_profiles_flattened_error():
 @pytest.mark.asyncio
 async def test_list_app_profiles_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3603,14 +3451,13 @@ async def test_list_app_profiles_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 @pytest.mark.asyncio
 async def test_list_app_profiles_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3622,7 +3469,9 @@ async def test_list_app_profiles_flattened_error_async():
 
 
 def test_list_app_profiles_pager():
-    client = BigtableInstanceAdminClient(credentials=credentials.AnonymousCredentials,)
+    client = BigtableInstanceAdminClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3664,7 +3513,9 @@ def test_list_app_profiles_pager():
 
 
 def test_list_app_profiles_pages():
-    client = BigtableInstanceAdminClient(credentials=credentials.AnonymousCredentials,)
+    client = BigtableInstanceAdminClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3699,7 +3550,7 @@ def test_list_app_profiles_pages():
 @pytest.mark.asyncio
 async def test_list_app_profiles_async_pager():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials,
+        credentials=ga_credentials.AnonymousCredentials,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3742,7 +3593,7 @@ async def test_list_app_profiles_async_pager():
 @pytest.mark.asyncio
 async def test_list_app_profiles_async_pages():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials,
+        credentials=ga_credentials.AnonymousCredentials,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3784,7 +3635,7 @@ def test_update_app_profile(
     request_type=bigtable_instance_admin.UpdateAppProfileRequest,
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3797,13 +3648,11 @@ def test_update_app_profile(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.update_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.UpdateAppProfileRequest()
 
     # Establish that the response is the type that we expect.
@@ -3818,7 +3667,7 @@ def test_update_app_profile_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3828,7 +3677,6 @@ def test_update_app_profile_empty_call():
         client.update_app_profile()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.UpdateAppProfileRequest()
 
 
@@ -3838,7 +3686,7 @@ async def test_update_app_profile_async(
     request_type=bigtable_instance_admin.UpdateAppProfileRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3853,13 +3701,11 @@ async def test_update_app_profile_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.update_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.UpdateAppProfileRequest()
 
     # Establish that the response is the type that we expect.
@@ -3873,12 +3719,13 @@ async def test_update_app_profile_async_from_dict():
 
 def test_update_app_profile_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.UpdateAppProfileRequest()
+
     request.app_profile.name = "app_profile.name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3886,7 +3733,6 @@ def test_update_app_profile_field_headers():
         type(client.transport.update_app_profile), "__call__"
     ) as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.update_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3904,12 +3750,13 @@ def test_update_app_profile_field_headers():
 @pytest.mark.asyncio
 async def test_update_app_profile_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.UpdateAppProfileRequest()
+
     request.app_profile.name = "app_profile.name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3919,7 +3766,6 @@ async def test_update_app_profile_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.update_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3936,7 +3782,7 @@ async def test_update_app_profile_field_headers_async():
 
 def test_update_app_profile_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3945,27 +3791,24 @@ def test_update_app_profile_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.update_app_profile(
             app_profile=instance.AppProfile(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].app_profile == instance.AppProfile(name="name_value")
-
-        assert args[0].update_mask == field_mask.FieldMask(paths=["paths_value"])
+        assert args[0].update_mask == field_mask_pb2.FieldMask(paths=["paths_value"])
 
 
 def test_update_app_profile_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3974,14 +3817,14 @@ def test_update_app_profile_flattened_error():
         client.update_app_profile(
             bigtable_instance_admin.UpdateAppProfileRequest(),
             app_profile=instance.AppProfile(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
 
 @pytest.mark.asyncio
 async def test_update_app_profile_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3998,23 +3841,21 @@ async def test_update_app_profile_flattened_async():
         # using the keyword arguments to the method.
         response = await client.update_app_profile(
             app_profile=instance.AppProfile(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].app_profile == instance.AppProfile(name="name_value")
-
-        assert args[0].update_mask == field_mask.FieldMask(paths=["paths_value"])
+        assert args[0].update_mask == field_mask_pb2.FieldMask(paths=["paths_value"])
 
 
 @pytest.mark.asyncio
 async def test_update_app_profile_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -4023,7 +3864,7 @@ async def test_update_app_profile_flattened_error_async():
         await client.update_app_profile(
             bigtable_instance_admin.UpdateAppProfileRequest(),
             app_profile=instance.AppProfile(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
 
@@ -4032,7 +3873,7 @@ def test_delete_app_profile(
     request_type=bigtable_instance_admin.DeleteAppProfileRequest,
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4045,13 +3886,11 @@ def test_delete_app_profile(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         response = client.delete_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteAppProfileRequest()
 
     # Establish that the response is the type that we expect.
@@ -4066,7 +3905,7 @@ def test_delete_app_profile_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4076,7 +3915,6 @@ def test_delete_app_profile_empty_call():
         client.delete_app_profile()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteAppProfileRequest()
 
 
@@ -4086,7 +3924,7 @@ async def test_delete_app_profile_async(
     request_type=bigtable_instance_admin.DeleteAppProfileRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4099,13 +3937,11 @@ async def test_delete_app_profile_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         response = await client.delete_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_instance_admin.DeleteAppProfileRequest()
 
     # Establish that the response is the type that we expect.
@@ -4119,12 +3955,13 @@ async def test_delete_app_profile_async_from_dict():
 
 def test_delete_app_profile_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.DeleteAppProfileRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4132,7 +3969,6 @@ def test_delete_app_profile_field_headers():
         type(client.transport.delete_app_profile), "__call__"
     ) as call:
         call.return_value = None
-
         client.delete_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4148,12 +3984,13 @@ def test_delete_app_profile_field_headers():
 @pytest.mark.asyncio
 async def test_delete_app_profile_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_instance_admin.DeleteAppProfileRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4161,7 +3998,6 @@ async def test_delete_app_profile_field_headers_async():
         type(client.transport.delete_app_profile), "__call__"
     ) as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         await client.delete_app_profile(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4176,7 +4012,7 @@ async def test_delete_app_profile_field_headers_async():
 
 def test_delete_app_profile_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4185,7 +4021,6 @@ def test_delete_app_profile_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.delete_app_profile(name="name_value",)
@@ -4194,13 +4029,12 @@ def test_delete_app_profile_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_delete_app_profile_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -4214,7 +4048,7 @@ def test_delete_app_profile_flattened_error():
 @pytest.mark.asyncio
 async def test_delete_app_profile_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4233,14 +4067,13 @@ async def test_delete_app_profile_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_delete_app_profile_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -4252,10 +4085,10 @@ async def test_delete_app_profile_flattened_error_async():
 
 
 def test_get_iam_policy(
-    transport: str = "grpc", request_type=iam_policy.GetIamPolicyRequest
+    transport: str = "grpc", request_type=iam_policy_pb2.GetIamPolicyRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4265,22 +4098,17 @@ def test_get_iam_policy(
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy(version=774, etag=b"etag_blob",)
-
+        call.return_value = policy_pb2.Policy(version=774, etag=b"etag_blob",)
         response = client.get_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.GetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.GetIamPolicyRequest()
 
     # Establish that the response is the type that we expect.
-
-    assert isinstance(response, policy.Policy)
-
+    assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
-
     assert response.etag == b"etag_blob"
 
 
@@ -4292,7 +4120,7 @@ def test_get_iam_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4300,16 +4128,15 @@ def test_get_iam_policy_empty_call():
         client.get_iam_policy()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.GetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.GetIamPolicyRequest()
 
 
 @pytest.mark.asyncio
 async def test_get_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy.GetIamPolicyRequest
+    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.GetIamPolicyRequest
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4320,22 +4147,18 @@ async def test_get_iam_policy_async(
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            policy.Policy(version=774, etag=b"etag_blob",)
+            policy_pb2.Policy(version=774, etag=b"etag_blob",)
         )
-
         response = await client.get_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.GetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.GetIamPolicyRequest()
 
     # Establish that the response is the type that we expect.
-    assert isinstance(response, policy.Policy)
-
+    assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
-
     assert response.etag == b"etag_blob"
 
 
@@ -4346,18 +4169,18 @@ async def test_get_iam_policy_async_from_dict():
 
 def test_get_iam_policy_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.GetIamPolicyRequest()
+    request = iam_policy_pb2.GetIamPolicyRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         client.get_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4373,18 +4196,18 @@ def test_get_iam_policy_field_headers():
 @pytest.mark.asyncio
 async def test_get_iam_policy_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.GetIamPolicyRequest()
+    request = iam_policy_pb2.GetIamPolicyRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
-
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy_pb2.Policy())
         await client.get_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4399,17 +4222,16 @@ async def test_get_iam_policy_field_headers_async():
 
 def test_get_iam_policy_from_dict_foreign():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         response = client.get_iam_policy(
             request={
                 "resource": "resource_value",
-                "options": options.GetPolicyOptions(requested_policy_version=2598),
+                "options": options_pb2.GetPolicyOptions(requested_policy_version=2598),
             }
         )
         call.assert_called()
@@ -4417,14 +4239,13 @@ def test_get_iam_policy_from_dict_foreign():
 
 def test_get_iam_policy_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_iam_policy(resource="resource_value",)
@@ -4433,35 +4254,34 @@ def test_get_iam_policy_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
 
 
 def test_get_iam_policy_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_iam_policy(
-            iam_policy.GetIamPolicyRequest(), resource="resource_value",
+            iam_policy_pb2.GetIamPolicyRequest(), resource="resource_value",
         )
 
 
 @pytest.mark.asyncio
 async def test_get_iam_policy_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
+        call.return_value = policy_pb2.Policy()
 
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy_pb2.Policy())
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.get_iam_policy(resource="resource_value",)
@@ -4470,29 +4290,28 @@ async def test_get_iam_policy_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
 
 
 @pytest.mark.asyncio
 async def test_get_iam_policy_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_iam_policy(
-            iam_policy.GetIamPolicyRequest(), resource="resource_value",
+            iam_policy_pb2.GetIamPolicyRequest(), resource="resource_value",
         )
 
 
 def test_set_iam_policy(
-    transport: str = "grpc", request_type=iam_policy.SetIamPolicyRequest
+    transport: str = "grpc", request_type=iam_policy_pb2.SetIamPolicyRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4502,22 +4321,17 @@ def test_set_iam_policy(
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy(version=774, etag=b"etag_blob",)
-
+        call.return_value = policy_pb2.Policy(version=774, etag=b"etag_blob",)
         response = client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.SetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.SetIamPolicyRequest()
 
     # Establish that the response is the type that we expect.
-
-    assert isinstance(response, policy.Policy)
-
+    assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
-
     assert response.etag == b"etag_blob"
 
 
@@ -4529,7 +4343,7 @@ def test_set_iam_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4537,16 +4351,15 @@ def test_set_iam_policy_empty_call():
         client.set_iam_policy()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.SetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.SetIamPolicyRequest()
 
 
 @pytest.mark.asyncio
 async def test_set_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy.SetIamPolicyRequest
+    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.SetIamPolicyRequest
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4557,22 +4370,18 @@ async def test_set_iam_policy_async(
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            policy.Policy(version=774, etag=b"etag_blob",)
+            policy_pb2.Policy(version=774, etag=b"etag_blob",)
         )
-
         response = await client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.SetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.SetIamPolicyRequest()
 
     # Establish that the response is the type that we expect.
-    assert isinstance(response, policy.Policy)
-
+    assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
-
     assert response.etag == b"etag_blob"
 
 
@@ -4583,18 +4392,18 @@ async def test_set_iam_policy_async_from_dict():
 
 def test_set_iam_policy_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.SetIamPolicyRequest()
+    request = iam_policy_pb2.SetIamPolicyRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4610,18 +4419,18 @@ def test_set_iam_policy_field_headers():
 @pytest.mark.asyncio
 async def test_set_iam_policy_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.SetIamPolicyRequest()
+    request = iam_policy_pb2.SetIamPolicyRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
-
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy_pb2.Policy())
         await client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4636,17 +4445,16 @@ async def test_set_iam_policy_field_headers_async():
 
 def test_set_iam_policy_from_dict_foreign():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         response = client.set_iam_policy(
             request={
                 "resource": "resource_value",
-                "policy": policy.Policy(version=774),
+                "policy": policy_pb2.Policy(version=774),
             }
         )
         call.assert_called()
@@ -4654,14 +4462,13 @@ def test_set_iam_policy_from_dict_foreign():
 
 def test_set_iam_policy_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.set_iam_policy(resource="resource_value",)
@@ -4670,35 +4477,34 @@ def test_set_iam_policy_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
 
 
 def test_set_iam_policy_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.set_iam_policy(
-            iam_policy.SetIamPolicyRequest(), resource="resource_value",
+            iam_policy_pb2.SetIamPolicyRequest(), resource="resource_value",
         )
 
 
 @pytest.mark.asyncio
 async def test_set_iam_policy_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
+        call.return_value = policy_pb2.Policy()
 
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy_pb2.Policy())
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.set_iam_policy(resource="resource_value",)
@@ -4707,29 +4513,28 @@ async def test_set_iam_policy_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
 
 
 @pytest.mark.asyncio
 async def test_set_iam_policy_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         await client.set_iam_policy(
-            iam_policy.SetIamPolicyRequest(), resource="resource_value",
+            iam_policy_pb2.SetIamPolicyRequest(), resource="resource_value",
         )
 
 
 def test_test_iam_permissions(
-    transport: str = "grpc", request_type=iam_policy.TestIamPermissionsRequest
+    transport: str = "grpc", request_type=iam_policy_pb2.TestIamPermissionsRequest
 ):
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4741,22 +4546,18 @@ def test_test_iam_permissions(
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = iam_policy.TestIamPermissionsResponse(
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse(
             permissions=["permissions_value"],
         )
-
         response = client.test_iam_permissions(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.TestIamPermissionsRequest()
+        assert args[0] == iam_policy_pb2.TestIamPermissionsRequest()
 
     # Establish that the response is the type that we expect.
-
-    assert isinstance(response, iam_policy.TestIamPermissionsResponse)
-
+    assert isinstance(response, iam_policy_pb2.TestIamPermissionsResponse)
     assert response.permissions == ["permissions_value"]
 
 
@@ -4768,7 +4569,7 @@ def test_test_iam_permissions_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4778,16 +4579,16 @@ def test_test_iam_permissions_empty_call():
         client.test_iam_permissions()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.TestIamPermissionsRequest()
+        assert args[0] == iam_policy_pb2.TestIamPermissionsRequest()
 
 
 @pytest.mark.asyncio
 async def test_test_iam_permissions_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy.TestIamPermissionsRequest
+    transport: str = "grpc_asyncio",
+    request_type=iam_policy_pb2.TestIamPermissionsRequest,
 ):
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4800,20 +4601,19 @@ async def test_test_iam_permissions_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            iam_policy.TestIamPermissionsResponse(permissions=["permissions_value"],)
+            iam_policy_pb2.TestIamPermissionsResponse(
+                permissions=["permissions_value"],
+            )
         )
-
         response = await client.test_iam_permissions(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.TestIamPermissionsRequest()
+        assert args[0] == iam_policy_pb2.TestIamPermissionsRequest()
 
     # Establish that the response is the type that we expect.
-    assert isinstance(response, iam_policy.TestIamPermissionsResponse)
-
+    assert isinstance(response, iam_policy_pb2.TestIamPermissionsResponse)
     assert response.permissions == ["permissions_value"]
 
 
@@ -4824,20 +4624,20 @@ async def test_test_iam_permissions_async_from_dict():
 
 def test_test_iam_permissions_field_headers():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.TestIamPermissionsRequest()
+    request = iam_policy_pb2.TestIamPermissionsRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
-        call.return_value = iam_policy.TestIamPermissionsResponse()
-
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse()
         client.test_iam_permissions(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4853,12 +4653,13 @@ def test_test_iam_permissions_field_headers():
 @pytest.mark.asyncio
 async def test_test_iam_permissions_field_headers_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.TestIamPermissionsRequest()
+    request = iam_policy_pb2.TestIamPermissionsRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4866,9 +4667,8 @@ async def test_test_iam_permissions_field_headers_async():
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            iam_policy.TestIamPermissionsResponse()
+            iam_policy_pb2.TestIamPermissionsResponse()
         )
-
         await client.test_iam_permissions(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4883,15 +4683,14 @@ async def test_test_iam_permissions_field_headers_async():
 
 def test_test_iam_permissions_from_dict_foreign():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = iam_policy.TestIamPermissionsResponse()
-
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse()
         response = client.test_iam_permissions(
             request={
                 "resource": "resource_value",
@@ -4903,7 +4702,7 @@ def test_test_iam_permissions_from_dict_foreign():
 
 def test_test_iam_permissions_flattened():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4911,8 +4710,7 @@ def test_test_iam_permissions_flattened():
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = iam_policy.TestIamPermissionsResponse()
-
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.test_iam_permissions(
@@ -4923,22 +4721,20 @@ def test_test_iam_permissions_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
-
         assert args[0].permissions == ["permissions_value"]
 
 
 def test_test_iam_permissions_flattened_error():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.test_iam_permissions(
-            iam_policy.TestIamPermissionsRequest(),
+            iam_policy_pb2.TestIamPermissionsRequest(),
             resource="resource_value",
             permissions=["permissions_value"],
         )
@@ -4947,7 +4743,7 @@ def test_test_iam_permissions_flattened_error():
 @pytest.mark.asyncio
 async def test_test_iam_permissions_flattened_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4955,10 +4751,10 @@ async def test_test_iam_permissions_flattened_async():
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = iam_policy.TestIamPermissionsResponse()
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse()
 
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            iam_policy.TestIamPermissionsResponse()
+            iam_policy_pb2.TestIamPermissionsResponse()
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
@@ -4970,23 +4766,21 @@ async def test_test_iam_permissions_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
-
         assert args[0].permissions == ["permissions_value"]
 
 
 @pytest.mark.asyncio
 async def test_test_iam_permissions_flattened_error_async():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         await client.test_iam_permissions(
-            iam_policy.TestIamPermissionsRequest(),
+            iam_policy_pb2.TestIamPermissionsRequest(),
             resource="resource_value",
             permissions=["permissions_value"],
         )
@@ -4995,16 +4789,16 @@ async def test_test_iam_permissions_flattened_error_async():
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
     transport = transports.BigtableInstanceAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     with pytest.raises(ValueError):
         client = BigtableInstanceAdminClient(
-            credentials=credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
     transport = transports.BigtableInstanceAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     with pytest.raises(ValueError):
         client = BigtableInstanceAdminClient(
@@ -5014,7 +4808,7 @@ def test_credentials_transport_error():
 
     # It is an error to provide scopes and a transport instance.
     transport = transports.BigtableInstanceAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     with pytest.raises(ValueError):
         client = BigtableInstanceAdminClient(
@@ -5025,7 +4819,7 @@ def test_credentials_transport_error():
 def test_transport_instance():
     # A client may be instantiated with a custom transport instance.
     transport = transports.BigtableInstanceAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     client = BigtableInstanceAdminClient(transport=transport)
     assert client.transport is transport
@@ -5034,13 +4828,13 @@ def test_transport_instance():
 def test_transport_get_channel():
     # A client may be instantiated with a custom transport instance.
     transport = transports.BigtableInstanceAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     channel = transport.grpc_channel
     assert channel
 
     transport = transports.BigtableInstanceAdminGrpcAsyncIOTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     channel = transport.grpc_channel
     assert channel
@@ -5055,8 +4849,8 @@ def test_transport_get_channel():
 )
 def test_transport_adc(transport_class):
     # Test default credentials are used if not provided.
-    with mock.patch.object(auth, "default") as adc:
-        adc.return_value = (credentials.AnonymousCredentials(), None)
+    with mock.patch.object(google.auth, "default") as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport_class()
         adc.assert_called_once()
 
@@ -5064,16 +4858,16 @@ def test_transport_adc(transport_class):
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     assert isinstance(client.transport, transports.BigtableInstanceAdminGrpcTransport,)
 
 
 def test_bigtable_instance_admin_base_transport_error():
     # Passing both a credentials object and credentials_file should raise an error
-    with pytest.raises(exceptions.DuplicateCredentialArgs):
+    with pytest.raises(core_exceptions.DuplicateCredentialArgs):
         transport = transports.BigtableInstanceAdminTransport(
-            credentials=credentials.AnonymousCredentials(),
+            credentials=ga_credentials.AnonymousCredentials(),
             credentials_file="credentials.json",
         )
 
@@ -5085,7 +4879,7 @@ def test_bigtable_instance_admin_base_transport():
     ) as Transport:
         Transport.return_value = None
         transport = transports.BigtableInstanceAdminTransport(
-            credentials=credentials.AnonymousCredentials(),
+            credentials=ga_credentials.AnonymousCredentials(),
         )
 
     # Every method on the transport should just blindly
@@ -5121,15 +4915,45 @@ def test_bigtable_instance_admin_base_transport():
         transport.operations_client
 
 
+@requires_google_auth_gte_1_25_0
 def test_bigtable_instance_admin_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(
-        auth, "load_credentials_from_file"
+        google.auth, "load_credentials_from_file", autospec=True
     ) as load_creds, mock.patch(
         "google.cloud.bigtable_admin_v2.services.bigtable_instance_admin.transports.BigtableInstanceAdminTransport._prep_wrapped_messages"
     ) as Transport:
         Transport.return_value = None
-        load_creds.return_value = (credentials.AnonymousCredentials(), None)
+        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport = transports.BigtableInstanceAdminTransport(
+            credentials_file="credentials.json", quota_project_id="octopus",
+        )
+        load_creds.assert_called_once_with(
+            "credentials.json",
+            scopes=None,
+            default_scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/bigtable.admin.instance",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            quota_project_id="octopus",
+        )
+
+
+@requires_google_auth_lt_1_25_0
+def test_bigtable_instance_admin_base_transport_with_credentials_file_old_google_auth():
+    # Instantiate the base transport with a credentials file
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch(
+        "google.cloud.bigtable_admin_v2.services.bigtable_instance_admin.transports.BigtableInstanceAdminTransport._prep_wrapped_messages"
+    ) as Transport:
+        Transport.return_value = None
+        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.BigtableInstanceAdminTransport(
             credentials_file="credentials.json", quota_project_id="octopus",
         )
@@ -5150,19 +4974,41 @@ def test_bigtable_instance_admin_base_transport_with_credentials_file():
 
 def test_bigtable_instance_admin_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
-    with mock.patch.object(auth, "default") as adc, mock.patch(
+    with mock.patch.object(google.auth, "default", autospec=True) as adc, mock.patch(
         "google.cloud.bigtable_admin_v2.services.bigtable_instance_admin.transports.BigtableInstanceAdminTransport._prep_wrapped_messages"
     ) as Transport:
         Transport.return_value = None
-        adc.return_value = (credentials.AnonymousCredentials(), None)
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.BigtableInstanceAdminTransport()
         adc.assert_called_once()
 
 
+@requires_google_auth_gte_1_25_0
 def test_bigtable_instance_admin_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(auth, "default") as adc:
-        adc.return_value = (credentials.AnonymousCredentials(), None)
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        BigtableInstanceAdminClient()
+        adc.assert_called_once_with(
+            scopes=None,
+            default_scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/bigtable.admin.instance",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            quota_project_id=None,
+        )
+
+
+@requires_google_auth_lt_1_25_0
+def test_bigtable_instance_admin_auth_adc_old_google_auth():
+    # If no credentials are provided, we should use ADC credentials.
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
         BigtableInstanceAdminClient()
         adc.assert_called_once_with(
             scopes=(
@@ -5178,16 +5024,23 @@ def test_bigtable_instance_admin_auth_adc():
         )
 
 
-def test_bigtable_instance_admin_transport_auth_adc():
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.BigtableInstanceAdminGrpcTransport,
+        transports.BigtableInstanceAdminGrpcAsyncIOTransport,
+    ],
+)
+@requires_google_auth_gte_1_25_0
+def test_bigtable_instance_admin_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
-    with mock.patch.object(auth, "default") as adc:
-        adc.return_value = (credentials.AnonymousCredentials(), None)
-        transports.BigtableInstanceAdminGrpcTransport(
-            host="squid.clam.whelk", quota_project_id="octopus"
-        )
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
         adc.assert_called_once_with(
-            scopes=(
+            scopes=["1", "2"],
+            default_scopes=(
                 "https://www.googleapis.com/auth/bigtable.admin",
                 "https://www.googleapis.com/auth/bigtable.admin.cluster",
                 "https://www.googleapis.com/auth/bigtable.admin.instance",
@@ -5207,10 +5060,165 @@ def test_bigtable_instance_admin_transport_auth_adc():
         transports.BigtableInstanceAdminGrpcAsyncIOTransport,
     ],
 )
+@requires_google_auth_lt_1_25_0
+def test_bigtable_instance_admin_transport_auth_adc_old_google_auth(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus")
+        adc.assert_called_once_with(
+            scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/bigtable.admin.instance",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            quota_project_id="octopus",
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.BigtableInstanceAdminGrpcTransport, grpc_helpers),
+        (transports.BigtableInstanceAdminGrpcAsyncIOTransport, grpc_helpers_async),
+    ],
+)
+@requires_api_core_gte_1_26_0
+def test_bigtable_instance_admin_transport_create_channel(
+    transport_class, grpc_helpers
+):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+
+        create_channel.assert_called_with(
+            "bigtableadmin.googleapis.com:443",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            default_scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/bigtable.admin.instance",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            scopes=["1", "2"],
+            default_host="bigtableadmin.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.BigtableInstanceAdminGrpcTransport, grpc_helpers),
+        (transports.BigtableInstanceAdminGrpcAsyncIOTransport, grpc_helpers_async),
+    ],
+)
+@requires_api_core_lt_1_26_0
+def test_bigtable_instance_admin_transport_create_channel_old_api_core(
+    transport_class, grpc_helpers
+):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+        transport_class(quota_project_id="octopus")
+
+        create_channel.assert_called_with(
+            "bigtableadmin.googleapis.com:443",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/bigtable.admin.instance",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.cluster",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.BigtableInstanceAdminGrpcTransport, grpc_helpers),
+        (transports.BigtableInstanceAdminGrpcAsyncIOTransport, grpc_helpers_async),
+    ],
+)
+@requires_api_core_lt_1_26_0
+def test_bigtable_instance_admin_transport_create_channel_user_scopes(
+    transport_class, grpc_helpers
+):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+
+        create_channel.assert_called_with(
+            "bigtableadmin.googleapis.com:443",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            scopes=["1", "2"],
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.BigtableInstanceAdminGrpcTransport,
+        transports.BigtableInstanceAdminGrpcAsyncIOTransport,
+    ],
+)
 def test_bigtable_instance_admin_grpc_transport_client_cert_source_for_mtls(
     transport_class,
 ):
-    cred = credentials.AnonymousCredentials()
+    cred = ga_credentials.AnonymousCredentials()
 
     # Check ssl_channel_credentials is used if provided.
     with mock.patch.object(transport_class, "create_channel") as mock_create_channel:
@@ -5257,7 +5265,7 @@ def test_bigtable_instance_admin_grpc_transport_client_cert_source_for_mtls(
 
 def test_bigtable_instance_admin_host_no_port():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="bigtableadmin.googleapis.com"
         ),
@@ -5267,7 +5275,7 @@ def test_bigtable_instance_admin_host_no_port():
 
 def test_bigtable_instance_admin_host_with_port():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="bigtableadmin.googleapis.com:8000"
         ),
@@ -5323,9 +5331,9 @@ def test_bigtable_instance_admin_transport_channel_mtls_with_client_cert_source(
             mock_grpc_channel = mock.Mock()
             grpc_create_channel.return_value = mock_grpc_channel
 
-            cred = credentials.AnonymousCredentials()
+            cred = ga_credentials.AnonymousCredentials()
             with pytest.warns(DeprecationWarning):
-                with mock.patch.object(auth, "default") as adc:
+                with mock.patch.object(google.auth, "default") as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
                         host="squid.clam.whelk",
@@ -5417,7 +5425,7 @@ def test_bigtable_instance_admin_transport_channel_mtls_with_adc(transport_class
 
 def test_bigtable_instance_admin_grpc_lro_client():
     client = BigtableInstanceAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
     transport = client.transport
 
@@ -5430,7 +5438,7 @@ def test_bigtable_instance_admin_grpc_lro_client():
 
 def test_bigtable_instance_admin_grpc_lro_async_client():
     client = BigtableInstanceAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
     )
     transport = client.transport
 
@@ -5445,7 +5453,6 @@ def test_app_profile_path():
     project = "squid"
     instance = "clam"
     app_profile = "whelk"
-
     expected = "projects/{project}/instances/{instance}/appProfiles/{app_profile}".format(
         project=project, instance=instance, app_profile=app_profile,
     )
@@ -5472,7 +5479,6 @@ def test_cluster_path():
     project = "cuttlefish"
     instance = "mussel"
     cluster = "winkle"
-
     expected = "projects/{project}/instances/{instance}/clusters/{cluster}".format(
         project=project, instance=instance, cluster=cluster,
     )
@@ -5498,7 +5504,6 @@ def test_crypto_key_path():
     location = "clam"
     key_ring = "whelk"
     crypto_key = "octopus"
-
     expected = "projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}".format(
         project=project, location=location, key_ring=key_ring, crypto_key=crypto_key,
     )
@@ -5525,7 +5530,6 @@ def test_parse_crypto_key_path():
 def test_instance_path():
     project = "winkle"
     instance = "nautilus"
-
     expected = "projects/{project}/instances/{instance}".format(
         project=project, instance=instance,
     )
@@ -5547,7 +5551,6 @@ def test_parse_instance_path():
 
 def test_common_billing_account_path():
     billing_account = "squid"
-
     expected = "billingAccounts/{billing_account}".format(
         billing_account=billing_account,
     )
@@ -5568,7 +5571,6 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "whelk"
-
     expected = "folders/{folder}".format(folder=folder,)
     actual = BigtableInstanceAdminClient.common_folder_path(folder)
     assert expected == actual
@@ -5587,7 +5589,6 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "oyster"
-
     expected = "organizations/{organization}".format(organization=organization,)
     actual = BigtableInstanceAdminClient.common_organization_path(organization)
     assert expected == actual
@@ -5606,7 +5607,6 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "cuttlefish"
-
     expected = "projects/{project}".format(project=project,)
     actual = BigtableInstanceAdminClient.common_project_path(project)
     assert expected == actual
@@ -5626,7 +5626,6 @@ def test_parse_common_project_path():
 def test_common_location_path():
     project = "winkle"
     location = "nautilus"
-
     expected = "projects/{project}/locations/{location}".format(
         project=project, location=location,
     )
@@ -5653,7 +5652,7 @@ def test_client_withDEFAULT_CLIENT_INFO():
         transports.BigtableInstanceAdminTransport, "_prep_wrapped_messages"
     ) as prep:
         client = BigtableInstanceAdminClient(
-            credentials=credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -5662,6 +5661,6 @@ def test_client_withDEFAULT_CLIENT_INFO():
     ) as prep:
         transport_class = BigtableInstanceAdminClient.get_transport_class()
         transport = transport_class(
-            credentials=credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
         )
         prep.assert_called_once_with(client_info)

--- a/tests/unit/gapic/bigtable_admin_v2/test_bigtable_table_admin.py
+++ b/tests/unit/gapic/bigtable_admin_v2/test_bigtable_table_admin.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import os
 import mock
+import packaging.version
 
 import grpc
 from grpc.experimental import aio
@@ -24,16 +23,16 @@ import math
 import pytest
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 
-from google import auth
+
 from google.api_core import client_options
-from google.api_core import exceptions
+from google.api_core import exceptions as core_exceptions
 from google.api_core import future
 from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
-from google.auth import credentials
+from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.bigtable_admin_v2.services.bigtable_table_admin import (
     BigtableTableAdminAsyncClient,
@@ -43,20 +42,50 @@ from google.cloud.bigtable_admin_v2.services.bigtable_table_admin import (
 )
 from google.cloud.bigtable_admin_v2.services.bigtable_table_admin import pagers
 from google.cloud.bigtable_admin_v2.services.bigtable_table_admin import transports
+from google.cloud.bigtable_admin_v2.services.bigtable_table_admin.transports.base import (
+    _API_CORE_VERSION,
+)
+from google.cloud.bigtable_admin_v2.services.bigtable_table_admin.transports.base import (
+    _GOOGLE_AUTH_VERSION,
+)
 from google.cloud.bigtable_admin_v2.types import bigtable_table_admin
 from google.cloud.bigtable_admin_v2.types import table
 from google.cloud.bigtable_admin_v2.types import table as gba_table
-from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
-from google.iam.v1 import options_pb2 as options  # type: ignore
-from google.iam.v1 import policy_pb2 as policy  # type: ignore
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import options_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
 from google.longrunning import operations_pb2
 from google.oauth2 import service_account
-from google.protobuf import any_pb2 as gp_any  # type: ignore
-from google.protobuf import duration_pb2 as duration  # type: ignore
-from google.protobuf import field_mask_pb2 as field_mask  # type: ignore
-from google.protobuf import timestamp_pb2 as timestamp  # type: ignore
-from google.rpc import status_pb2 as status  # type: ignore
-from google.type import expr_pb2 as expr  # type: ignore
+from google.protobuf import any_pb2  # type: ignore
+from google.protobuf import duration_pb2  # type: ignore
+from google.protobuf import field_mask_pb2  # type: ignore
+from google.protobuf import timestamp_pb2  # type: ignore
+from google.rpc import status_pb2  # type: ignore
+from google.type import expr_pb2  # type: ignore
+import google.auth
+
+
+# TODO(busunkim): Once google-api-core >= 1.26.0 is required:
+# - Delete all the api-core and auth "less than" test cases
+# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
+requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
+    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
+    reason="This test requires google-auth < 1.25.0",
+)
+requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
+    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
+    reason="This test requires google-auth >= 1.25.0",
+)
+
+requires_api_core_lt_1_26_0 = pytest.mark.skipif(
+    packaging.version.parse(_API_CORE_VERSION) >= packaging.version.parse("1.26.0"),
+    reason="This test requires google-api-core < 1.26.0",
+)
+
+requires_api_core_gte_1_26_0 = pytest.mark.skipif(
+    packaging.version.parse(_API_CORE_VERSION) < packaging.version.parse("1.26.0"),
+    reason="This test requires google-api-core >= 1.26.0",
+)
 
 
 def client_cert_source_callback():
@@ -108,7 +137,7 @@ def test__get_default_mtls_endpoint():
     "client_class", [BigtableTableAdminClient, BigtableTableAdminAsyncClient,]
 )
 def test_bigtable_table_admin_client_from_service_account_info(client_class):
-    creds = credentials.AnonymousCredentials()
+    creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_info"
     ) as factory:
@@ -125,7 +154,7 @@ def test_bigtable_table_admin_client_from_service_account_info(client_class):
     "client_class", [BigtableTableAdminClient, BigtableTableAdminAsyncClient,]
 )
 def test_bigtable_table_admin_client_from_service_account_file(client_class):
-    creds = credentials.AnonymousCredentials()
+    creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(
         service_account.Credentials, "from_service_account_file"
     ) as factory:
@@ -178,7 +207,7 @@ def test_bigtable_table_admin_client_client_options(
 ):
     # Check that if channel is provided we won't create a new one.
     with mock.patch.object(BigtableTableAdminClient, "get_transport_class") as gtc:
-        transport = transport_class(credentials=credentials.AnonymousCredentials())
+        transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
         client = client_class(transport=transport)
         gtc.assert_not_called()
 
@@ -476,7 +505,7 @@ def test_create_table(
     transport: str = "grpc", request_type=bigtable_table_admin.CreateTableRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -489,21 +518,16 @@ def test_create_table(
         call.return_value = gba_table.Table(
             name="name_value", granularity=gba_table.Table.TimestampGranularity.MILLIS,
         )
-
         response = client.create_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateTableRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, gba_table.Table)
-
     assert response.name == "name_value"
-
     assert response.granularity == gba_table.Table.TimestampGranularity.MILLIS
 
 
@@ -515,7 +539,7 @@ def test_create_table_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -523,7 +547,6 @@ def test_create_table_empty_call():
         client.create_table()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateTableRequest()
 
 
@@ -533,7 +556,7 @@ async def test_create_table_async(
     request_type=bigtable_table_admin.CreateTableRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -549,20 +572,16 @@ async def test_create_table_async(
                 granularity=gba_table.Table.TimestampGranularity.MILLIS,
             )
         )
-
         response = await client.create_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateTableRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, gba_table.Table)
-
     assert response.name == "name_value"
-
     assert response.granularity == gba_table.Table.TimestampGranularity.MILLIS
 
 
@@ -572,17 +591,19 @@ async def test_create_table_async_from_dict():
 
 
 def test_create_table_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.CreateTableRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_table), "__call__") as call:
         call.return_value = gba_table.Table()
-
         client.create_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -598,18 +619,18 @@ def test_create_table_field_headers():
 @pytest.mark.asyncio
 async def test_create_table_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.CreateTableRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_table), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(gba_table.Table())
-
         await client.create_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -623,13 +644,14 @@ async def test_create_table_field_headers_async():
 
 
 def test_create_table_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_table), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = gba_table.Table()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.create_table(
@@ -642,16 +664,15 @@ def test_create_table_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].table_id == "table_id_value"
-
         assert args[0].table == gba_table.Table(name="name_value")
 
 
 def test_create_table_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -667,7 +688,7 @@ def test_create_table_flattened_error():
 @pytest.mark.asyncio
 async def test_create_table_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -688,18 +709,15 @@ async def test_create_table_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].table_id == "table_id_value"
-
         assert args[0].table == gba_table.Table(name="name_value")
 
 
 @pytest.mark.asyncio
 async def test_create_table_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -718,7 +736,7 @@ def test_create_table_from_snapshot(
     request_type=bigtable_table_admin.CreateTableFromSnapshotRequest,
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -731,13 +749,11 @@ def test_create_table_from_snapshot(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.create_table_from_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateTableFromSnapshotRequest()
 
     # Establish that the response is the type that we expect.
@@ -752,7 +768,7 @@ def test_create_table_from_snapshot_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -762,7 +778,6 @@ def test_create_table_from_snapshot_empty_call():
         client.create_table_from_snapshot()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateTableFromSnapshotRequest()
 
 
@@ -772,7 +787,7 @@ async def test_create_table_from_snapshot_async(
     request_type=bigtable_table_admin.CreateTableFromSnapshotRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -787,13 +802,11 @@ async def test_create_table_from_snapshot_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.create_table_from_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateTableFromSnapshotRequest()
 
     # Establish that the response is the type that we expect.
@@ -806,11 +819,14 @@ async def test_create_table_from_snapshot_async_from_dict():
 
 
 def test_create_table_from_snapshot_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.CreateTableFromSnapshotRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -818,7 +834,6 @@ def test_create_table_from_snapshot_field_headers():
         type(client.transport.create_table_from_snapshot), "__call__"
     ) as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.create_table_from_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -834,12 +849,13 @@ def test_create_table_from_snapshot_field_headers():
 @pytest.mark.asyncio
 async def test_create_table_from_snapshot_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.CreateTableFromSnapshotRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -849,7 +865,6 @@ async def test_create_table_from_snapshot_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.create_table_from_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -863,7 +878,9 @@ async def test_create_table_from_snapshot_field_headers_async():
 
 
 def test_create_table_from_snapshot_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -871,7 +888,6 @@ def test_create_table_from_snapshot_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.create_table_from_snapshot(
@@ -884,16 +900,15 @@ def test_create_table_from_snapshot_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].table_id == "table_id_value"
-
         assert args[0].source_snapshot == "source_snapshot_value"
 
 
 def test_create_table_from_snapshot_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -909,7 +924,7 @@ def test_create_table_from_snapshot_flattened_error():
 @pytest.mark.asyncio
 async def test_create_table_from_snapshot_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -934,18 +949,15 @@ async def test_create_table_from_snapshot_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].table_id == "table_id_value"
-
         assert args[0].source_snapshot == "source_snapshot_value"
 
 
 @pytest.mark.asyncio
 async def test_create_table_from_snapshot_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -963,7 +975,7 @@ def test_list_tables(
     transport: str = "grpc", request_type=bigtable_table_admin.ListTablesRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -976,19 +988,15 @@ def test_list_tables(
         call.return_value = bigtable_table_admin.ListTablesResponse(
             next_page_token="next_page_token_value",
         )
-
         response = client.list_tables(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListTablesRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, pagers.ListTablesPager)
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -1000,7 +1008,7 @@ def test_list_tables_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1008,7 +1016,6 @@ def test_list_tables_empty_call():
         client.list_tables()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListTablesRequest()
 
 
@@ -1017,7 +1024,7 @@ async def test_list_tables_async(
     transport: str = "grpc_asyncio", request_type=bigtable_table_admin.ListTablesRequest
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1032,18 +1039,15 @@ async def test_list_tables_async(
                 next_page_token="next_page_token_value",
             )
         )
-
         response = await client.list_tables(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListTablesRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListTablesAsyncPager)
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -1053,17 +1057,19 @@ async def test_list_tables_async_from_dict():
 
 
 def test_list_tables_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.ListTablesRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_tables), "__call__") as call:
         call.return_value = bigtable_table_admin.ListTablesResponse()
-
         client.list_tables(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1079,12 +1085,13 @@ def test_list_tables_field_headers():
 @pytest.mark.asyncio
 async def test_list_tables_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.ListTablesRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1092,7 +1099,6 @@ async def test_list_tables_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_table_admin.ListTablesResponse()
         )
-
         await client.list_tables(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1106,13 +1112,14 @@ async def test_list_tables_field_headers_async():
 
 
 def test_list_tables_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_tables), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = bigtable_table_admin.ListTablesResponse()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_tables(parent="parent_value",)
@@ -1121,12 +1128,13 @@ def test_list_tables_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 def test_list_tables_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1139,7 +1147,7 @@ def test_list_tables_flattened_error():
 @pytest.mark.asyncio
 async def test_list_tables_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1158,14 +1166,13 @@ async def test_list_tables_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 @pytest.mark.asyncio
 async def test_list_tables_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1177,7 +1184,7 @@ async def test_list_tables_flattened_error_async():
 
 
 def test_list_tables_pager():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials,)
+    client = BigtableTableAdminClient(credentials=ga_credentials.AnonymousCredentials,)
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_tables), "__call__") as call:
@@ -1211,7 +1218,7 @@ def test_list_tables_pager():
 
 
 def test_list_tables_pages():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials,)
+    client = BigtableTableAdminClient(credentials=ga_credentials.AnonymousCredentials,)
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_tables), "__call__") as call:
@@ -1238,7 +1245,7 @@ def test_list_tables_pages():
 @pytest.mark.asyncio
 async def test_list_tables_async_pager():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials,
+        credentials=ga_credentials.AnonymousCredentials,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1273,7 +1280,7 @@ async def test_list_tables_async_pager():
 @pytest.mark.asyncio
 async def test_list_tables_async_pages():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials,
+        credentials=ga_credentials.AnonymousCredentials,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1306,7 +1313,7 @@ def test_get_table(
     transport: str = "grpc", request_type=bigtable_table_admin.GetTableRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1319,21 +1326,16 @@ def test_get_table(
         call.return_value = table.Table(
             name="name_value", granularity=table.Table.TimestampGranularity.MILLIS,
         )
-
         response = client.get_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetTableRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, table.Table)
-
     assert response.name == "name_value"
-
     assert response.granularity == table.Table.TimestampGranularity.MILLIS
 
 
@@ -1345,7 +1347,7 @@ def test_get_table_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1353,7 +1355,6 @@ def test_get_table_empty_call():
         client.get_table()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetTableRequest()
 
 
@@ -1362,7 +1363,7 @@ async def test_get_table_async(
     transport: str = "grpc_asyncio", request_type=bigtable_table_admin.GetTableRequest
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1377,20 +1378,16 @@ async def test_get_table_async(
                 name="name_value", granularity=table.Table.TimestampGranularity.MILLIS,
             )
         )
-
         response = await client.get_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetTableRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, table.Table)
-
     assert response.name == "name_value"
-
     assert response.granularity == table.Table.TimestampGranularity.MILLIS
 
 
@@ -1400,17 +1397,19 @@ async def test_get_table_async_from_dict():
 
 
 def test_get_table_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.GetTableRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_table), "__call__") as call:
         call.return_value = table.Table()
-
         client.get_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1426,18 +1425,18 @@ def test_get_table_field_headers():
 @pytest.mark.asyncio
 async def test_get_table_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.GetTableRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_table), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(table.Table())
-
         await client.get_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1451,13 +1450,14 @@ async def test_get_table_field_headers_async():
 
 
 def test_get_table_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_table), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = table.Table()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_table(name="name_value",)
@@ -1466,12 +1466,13 @@ def test_get_table_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_get_table_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1484,7 +1485,7 @@ def test_get_table_flattened_error():
 @pytest.mark.asyncio
 async def test_get_table_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1501,14 +1502,13 @@ async def test_get_table_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_get_table_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1523,7 +1523,7 @@ def test_delete_table(
     transport: str = "grpc", request_type=bigtable_table_admin.DeleteTableRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1534,13 +1534,11 @@ def test_delete_table(
     with mock.patch.object(type(client.transport.delete_table), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         response = client.delete_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteTableRequest()
 
     # Establish that the response is the type that we expect.
@@ -1555,7 +1553,7 @@ def test_delete_table_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1563,7 +1561,6 @@ def test_delete_table_empty_call():
         client.delete_table()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteTableRequest()
 
 
@@ -1573,7 +1570,7 @@ async def test_delete_table_async(
     request_type=bigtable_table_admin.DeleteTableRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1584,13 +1581,11 @@ async def test_delete_table_async(
     with mock.patch.object(type(client.transport.delete_table), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         response = await client.delete_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteTableRequest()
 
     # Establish that the response is the type that we expect.
@@ -1603,17 +1598,19 @@ async def test_delete_table_async_from_dict():
 
 
 def test_delete_table_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.DeleteTableRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_table), "__call__") as call:
         call.return_value = None
-
         client.delete_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1629,18 +1626,18 @@ def test_delete_table_field_headers():
 @pytest.mark.asyncio
 async def test_delete_table_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.DeleteTableRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_table), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         await client.delete_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1654,13 +1651,14 @@ async def test_delete_table_field_headers_async():
 
 
 def test_delete_table_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_table), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.delete_table(name="name_value",)
@@ -1669,12 +1667,13 @@ def test_delete_table_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_delete_table_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1687,7 +1686,7 @@ def test_delete_table_flattened_error():
 @pytest.mark.asyncio
 async def test_delete_table_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1704,14 +1703,13 @@ async def test_delete_table_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_delete_table_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1727,7 +1725,7 @@ def test_modify_column_families(
     request_type=bigtable_table_admin.ModifyColumnFamiliesRequest,
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1742,21 +1740,16 @@ def test_modify_column_families(
         call.return_value = table.Table(
             name="name_value", granularity=table.Table.TimestampGranularity.MILLIS,
         )
-
         response = client.modify_column_families(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ModifyColumnFamiliesRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, table.Table)
-
     assert response.name == "name_value"
-
     assert response.granularity == table.Table.TimestampGranularity.MILLIS
 
 
@@ -1768,7 +1761,7 @@ def test_modify_column_families_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1778,7 +1771,6 @@ def test_modify_column_families_empty_call():
         client.modify_column_families()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ModifyColumnFamiliesRequest()
 
 
@@ -1788,7 +1780,7 @@ async def test_modify_column_families_async(
     request_type=bigtable_table_admin.ModifyColumnFamiliesRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1805,20 +1797,16 @@ async def test_modify_column_families_async(
                 name="name_value", granularity=table.Table.TimestampGranularity.MILLIS,
             )
         )
-
         response = await client.modify_column_families(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ModifyColumnFamiliesRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, table.Table)
-
     assert response.name == "name_value"
-
     assert response.granularity == table.Table.TimestampGranularity.MILLIS
 
 
@@ -1828,11 +1816,14 @@ async def test_modify_column_families_async_from_dict():
 
 
 def test_modify_column_families_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.ModifyColumnFamiliesRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1840,7 +1831,6 @@ def test_modify_column_families_field_headers():
         type(client.transport.modify_column_families), "__call__"
     ) as call:
         call.return_value = table.Table()
-
         client.modify_column_families(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1856,12 +1846,13 @@ def test_modify_column_families_field_headers():
 @pytest.mark.asyncio
 async def test_modify_column_families_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.ModifyColumnFamiliesRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1869,7 +1860,6 @@ async def test_modify_column_families_field_headers_async():
         type(client.transport.modify_column_families), "__call__"
     ) as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(table.Table())
-
         await client.modify_column_families(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -1883,7 +1873,9 @@ async def test_modify_column_families_field_headers_async():
 
 
 def test_modify_column_families_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1891,7 +1883,6 @@ def test_modify_column_families_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = table.Table()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.modify_column_families(
@@ -1907,16 +1898,16 @@ def test_modify_column_families_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
-
         assert args[0].modifications == [
             bigtable_table_admin.ModifyColumnFamiliesRequest.Modification(id="id_value")
         ]
 
 
 def test_modify_column_families_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1935,7 +1926,7 @@ def test_modify_column_families_flattened_error():
 @pytest.mark.asyncio
 async def test_modify_column_families_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1961,9 +1952,7 @@ async def test_modify_column_families_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
-
         assert args[0].modifications == [
             bigtable_table_admin.ModifyColumnFamiliesRequest.Modification(id="id_value")
         ]
@@ -1972,7 +1961,7 @@ async def test_modify_column_families_flattened_async():
 @pytest.mark.asyncio
 async def test_modify_column_families_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -1993,7 +1982,7 @@ def test_drop_row_range(
     transport: str = "grpc", request_type=bigtable_table_admin.DropRowRangeRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2004,13 +1993,11 @@ def test_drop_row_range(
     with mock.patch.object(type(client.transport.drop_row_range), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         response = client.drop_row_range(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DropRowRangeRequest()
 
     # Establish that the response is the type that we expect.
@@ -2025,7 +2012,7 @@ def test_drop_row_range_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2033,7 +2020,6 @@ def test_drop_row_range_empty_call():
         client.drop_row_range()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DropRowRangeRequest()
 
 
@@ -2043,7 +2029,7 @@ async def test_drop_row_range_async(
     request_type=bigtable_table_admin.DropRowRangeRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2054,13 +2040,11 @@ async def test_drop_row_range_async(
     with mock.patch.object(type(client.transport.drop_row_range), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         response = await client.drop_row_range(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DropRowRangeRequest()
 
     # Establish that the response is the type that we expect.
@@ -2073,17 +2057,19 @@ async def test_drop_row_range_async_from_dict():
 
 
 def test_drop_row_range_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.DropRowRangeRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.drop_row_range), "__call__") as call:
         call.return_value = None
-
         client.drop_row_range(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2099,18 +2085,18 @@ def test_drop_row_range_field_headers():
 @pytest.mark.asyncio
 async def test_drop_row_range_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.DropRowRangeRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.drop_row_range), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         await client.drop_row_range(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2128,7 +2114,7 @@ def test_generate_consistency_token(
     request_type=bigtable_table_admin.GenerateConsistencyTokenRequest,
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2143,19 +2129,15 @@ def test_generate_consistency_token(
         call.return_value = bigtable_table_admin.GenerateConsistencyTokenResponse(
             consistency_token="consistency_token_value",
         )
-
         response = client.generate_consistency_token(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GenerateConsistencyTokenRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, bigtable_table_admin.GenerateConsistencyTokenResponse)
-
     assert response.consistency_token == "consistency_token_value"
 
 
@@ -2167,7 +2149,7 @@ def test_generate_consistency_token_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2177,7 +2159,6 @@ def test_generate_consistency_token_empty_call():
         client.generate_consistency_token()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GenerateConsistencyTokenRequest()
 
 
@@ -2187,7 +2168,7 @@ async def test_generate_consistency_token_async(
     request_type=bigtable_table_admin.GenerateConsistencyTokenRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2204,18 +2185,15 @@ async def test_generate_consistency_token_async(
                 consistency_token="consistency_token_value",
             )
         )
-
         response = await client.generate_consistency_token(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GenerateConsistencyTokenRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, bigtable_table_admin.GenerateConsistencyTokenResponse)
-
     assert response.consistency_token == "consistency_token_value"
 
 
@@ -2225,11 +2203,14 @@ async def test_generate_consistency_token_async_from_dict():
 
 
 def test_generate_consistency_token_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.GenerateConsistencyTokenRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2237,7 +2218,6 @@ def test_generate_consistency_token_field_headers():
         type(client.transport.generate_consistency_token), "__call__"
     ) as call:
         call.return_value = bigtable_table_admin.GenerateConsistencyTokenResponse()
-
         client.generate_consistency_token(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2253,12 +2233,13 @@ def test_generate_consistency_token_field_headers():
 @pytest.mark.asyncio
 async def test_generate_consistency_token_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.GenerateConsistencyTokenRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2268,7 +2249,6 @@ async def test_generate_consistency_token_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_table_admin.GenerateConsistencyTokenResponse()
         )
-
         await client.generate_consistency_token(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2282,7 +2262,9 @@ async def test_generate_consistency_token_field_headers_async():
 
 
 def test_generate_consistency_token_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2290,7 +2272,6 @@ def test_generate_consistency_token_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = bigtable_table_admin.GenerateConsistencyTokenResponse()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.generate_consistency_token(name="name_value",)
@@ -2299,12 +2280,13 @@ def test_generate_consistency_token_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_generate_consistency_token_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -2317,7 +2299,7 @@ def test_generate_consistency_token_flattened_error():
 @pytest.mark.asyncio
 async def test_generate_consistency_token_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2338,14 +2320,13 @@ async def test_generate_consistency_token_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_generate_consistency_token_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2360,7 +2341,7 @@ def test_check_consistency(
     transport: str = "grpc", request_type=bigtable_table_admin.CheckConsistencyRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2375,19 +2356,15 @@ def test_check_consistency(
         call.return_value = bigtable_table_admin.CheckConsistencyResponse(
             consistent=True,
         )
-
         response = client.check_consistency(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CheckConsistencyRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, bigtable_table_admin.CheckConsistencyResponse)
-
     assert response.consistent is True
 
 
@@ -2399,7 +2376,7 @@ def test_check_consistency_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2409,7 +2386,6 @@ def test_check_consistency_empty_call():
         client.check_consistency()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CheckConsistencyRequest()
 
 
@@ -2419,7 +2395,7 @@ async def test_check_consistency_async(
     request_type=bigtable_table_admin.CheckConsistencyRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2434,18 +2410,15 @@ async def test_check_consistency_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_table_admin.CheckConsistencyResponse(consistent=True,)
         )
-
         response = await client.check_consistency(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CheckConsistencyRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, bigtable_table_admin.CheckConsistencyResponse)
-
     assert response.consistent is True
 
 
@@ -2455,11 +2428,14 @@ async def test_check_consistency_async_from_dict():
 
 
 def test_check_consistency_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.CheckConsistencyRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2467,7 +2443,6 @@ def test_check_consistency_field_headers():
         type(client.transport.check_consistency), "__call__"
     ) as call:
         call.return_value = bigtable_table_admin.CheckConsistencyResponse()
-
         client.check_consistency(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2483,12 +2458,13 @@ def test_check_consistency_field_headers():
 @pytest.mark.asyncio
 async def test_check_consistency_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.CheckConsistencyRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2498,7 +2474,6 @@ async def test_check_consistency_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_table_admin.CheckConsistencyResponse()
         )
-
         await client.check_consistency(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2512,7 +2487,9 @@ async def test_check_consistency_field_headers_async():
 
 
 def test_check_consistency_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2520,7 +2497,6 @@ def test_check_consistency_flattened():
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = bigtable_table_admin.CheckConsistencyResponse()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.check_consistency(
@@ -2531,14 +2507,14 @@ def test_check_consistency_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
-
         assert args[0].consistency_token == "consistency_token_value"
 
 
 def test_check_consistency_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -2553,7 +2529,7 @@ def test_check_consistency_flattened_error():
 @pytest.mark.asyncio
 async def test_check_consistency_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2576,16 +2552,14 @@ async def test_check_consistency_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
-
         assert args[0].consistency_token == "consistency_token_value"
 
 
 @pytest.mark.asyncio
 async def test_check_consistency_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2602,7 +2576,7 @@ def test_snapshot_table(
     transport: str = "grpc", request_type=bigtable_table_admin.SnapshotTableRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2613,13 +2587,11 @@ def test_snapshot_table(
     with mock.patch.object(type(client.transport.snapshot_table), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.snapshot_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.SnapshotTableRequest()
 
     # Establish that the response is the type that we expect.
@@ -2634,7 +2606,7 @@ def test_snapshot_table_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2642,7 +2614,6 @@ def test_snapshot_table_empty_call():
         client.snapshot_table()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.SnapshotTableRequest()
 
 
@@ -2652,7 +2623,7 @@ async def test_snapshot_table_async(
     request_type=bigtable_table_admin.SnapshotTableRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2665,13 +2636,11 @@ async def test_snapshot_table_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.snapshot_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.SnapshotTableRequest()
 
     # Establish that the response is the type that we expect.
@@ -2684,17 +2653,19 @@ async def test_snapshot_table_async_from_dict():
 
 
 def test_snapshot_table_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.SnapshotTableRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.snapshot_table), "__call__") as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.snapshot_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2710,12 +2681,13 @@ def test_snapshot_table_field_headers():
 @pytest.mark.asyncio
 async def test_snapshot_table_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.SnapshotTableRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2723,7 +2695,6 @@ async def test_snapshot_table_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.snapshot_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2737,13 +2708,14 @@ async def test_snapshot_table_field_headers_async():
 
 
 def test_snapshot_table_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.snapshot_table), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.snapshot_table(
@@ -2757,18 +2729,16 @@ def test_snapshot_table_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
-
         assert args[0].cluster == "cluster_value"
-
         assert args[0].snapshot_id == "snapshot_id_value"
-
         assert args[0].description == "description_value"
 
 
 def test_snapshot_table_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -2785,7 +2755,7 @@ def test_snapshot_table_flattened_error():
 @pytest.mark.asyncio
 async def test_snapshot_table_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2809,20 +2779,16 @@ async def test_snapshot_table_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
-
         assert args[0].cluster == "cluster_value"
-
         assert args[0].snapshot_id == "snapshot_id_value"
-
         assert args[0].description == "description_value"
 
 
 @pytest.mark.asyncio
 async def test_snapshot_table_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -2841,7 +2807,7 @@ def test_get_snapshot(
     transport: str = "grpc", request_type=bigtable_table_admin.GetSnapshotRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2857,25 +2823,18 @@ def test_get_snapshot(
             state=table.Snapshot.State.READY,
             description="description_value",
         )
-
         response = client.get_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetSnapshotRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, table.Snapshot)
-
     assert response.name == "name_value"
-
     assert response.data_size_bytes == 1594
-
     assert response.state == table.Snapshot.State.READY
-
     assert response.description == "description_value"
 
 
@@ -2887,7 +2846,7 @@ def test_get_snapshot_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2895,7 +2854,6 @@ def test_get_snapshot_empty_call():
         client.get_snapshot()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetSnapshotRequest()
 
 
@@ -2905,7 +2863,7 @@ async def test_get_snapshot_async(
     request_type=bigtable_table_admin.GetSnapshotRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2923,24 +2881,18 @@ async def test_get_snapshot_async(
                 description="description_value",
             )
         )
-
         response = await client.get_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetSnapshotRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, table.Snapshot)
-
     assert response.name == "name_value"
-
     assert response.data_size_bytes == 1594
-
     assert response.state == table.Snapshot.State.READY
-
     assert response.description == "description_value"
 
 
@@ -2950,17 +2902,19 @@ async def test_get_snapshot_async_from_dict():
 
 
 def test_get_snapshot_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.GetSnapshotRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_snapshot), "__call__") as call:
         call.return_value = table.Snapshot()
-
         client.get_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -2976,18 +2930,18 @@ def test_get_snapshot_field_headers():
 @pytest.mark.asyncio
 async def test_get_snapshot_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.GetSnapshotRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_snapshot), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(table.Snapshot())
-
         await client.get_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3001,13 +2955,14 @@ async def test_get_snapshot_field_headers_async():
 
 
 def test_get_snapshot_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_snapshot), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = table.Snapshot()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_snapshot(name="name_value",)
@@ -3016,12 +2971,13 @@ def test_get_snapshot_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_get_snapshot_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -3034,7 +2990,7 @@ def test_get_snapshot_flattened_error():
 @pytest.mark.asyncio
 async def test_get_snapshot_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3051,14 +3007,13 @@ async def test_get_snapshot_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_get_snapshot_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3073,7 +3028,7 @@ def test_list_snapshots(
     transport: str = "grpc", request_type=bigtable_table_admin.ListSnapshotsRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3086,19 +3041,15 @@ def test_list_snapshots(
         call.return_value = bigtable_table_admin.ListSnapshotsResponse(
             next_page_token="next_page_token_value",
         )
-
         response = client.list_snapshots(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListSnapshotsRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, pagers.ListSnapshotsPager)
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -3110,7 +3061,7 @@ def test_list_snapshots_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3118,7 +3069,6 @@ def test_list_snapshots_empty_call():
         client.list_snapshots()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListSnapshotsRequest()
 
 
@@ -3128,7 +3078,7 @@ async def test_list_snapshots_async(
     request_type=bigtable_table_admin.ListSnapshotsRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3143,18 +3093,15 @@ async def test_list_snapshots_async(
                 next_page_token="next_page_token_value",
             )
         )
-
         response = await client.list_snapshots(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListSnapshotsRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListSnapshotsAsyncPager)
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -3164,17 +3111,19 @@ async def test_list_snapshots_async_from_dict():
 
 
 def test_list_snapshots_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.ListSnapshotsRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_snapshots), "__call__") as call:
         call.return_value = bigtable_table_admin.ListSnapshotsResponse()
-
         client.list_snapshots(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3190,12 +3139,13 @@ def test_list_snapshots_field_headers():
 @pytest.mark.asyncio
 async def test_list_snapshots_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.ListSnapshotsRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3203,7 +3153,6 @@ async def test_list_snapshots_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_table_admin.ListSnapshotsResponse()
         )
-
         await client.list_snapshots(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3217,13 +3166,14 @@ async def test_list_snapshots_field_headers_async():
 
 
 def test_list_snapshots_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_snapshots), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = bigtable_table_admin.ListSnapshotsResponse()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_snapshots(parent="parent_value",)
@@ -3232,12 +3182,13 @@ def test_list_snapshots_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 def test_list_snapshots_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -3250,7 +3201,7 @@ def test_list_snapshots_flattened_error():
 @pytest.mark.asyncio
 async def test_list_snapshots_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3269,14 +3220,13 @@ async def test_list_snapshots_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 @pytest.mark.asyncio
 async def test_list_snapshots_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3288,7 +3238,7 @@ async def test_list_snapshots_flattened_error_async():
 
 
 def test_list_snapshots_pager():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials,)
+    client = BigtableTableAdminClient(credentials=ga_credentials.AnonymousCredentials,)
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_snapshots), "__call__") as call:
@@ -3324,7 +3274,7 @@ def test_list_snapshots_pager():
 
 
 def test_list_snapshots_pages():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials,)
+    client = BigtableTableAdminClient(credentials=ga_credentials.AnonymousCredentials,)
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_snapshots), "__call__") as call:
@@ -3353,7 +3303,7 @@ def test_list_snapshots_pages():
 @pytest.mark.asyncio
 async def test_list_snapshots_async_pager():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials,
+        credentials=ga_credentials.AnonymousCredentials,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3390,7 +3340,7 @@ async def test_list_snapshots_async_pager():
 @pytest.mark.asyncio
 async def test_list_snapshots_async_pages():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials,
+        credentials=ga_credentials.AnonymousCredentials,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3425,7 +3375,7 @@ def test_delete_snapshot(
     transport: str = "grpc", request_type=bigtable_table_admin.DeleteSnapshotRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3436,13 +3386,11 @@ def test_delete_snapshot(
     with mock.patch.object(type(client.transport.delete_snapshot), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         response = client.delete_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteSnapshotRequest()
 
     # Establish that the response is the type that we expect.
@@ -3457,7 +3405,7 @@ def test_delete_snapshot_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3465,7 +3413,6 @@ def test_delete_snapshot_empty_call():
         client.delete_snapshot()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteSnapshotRequest()
 
 
@@ -3475,7 +3422,7 @@ async def test_delete_snapshot_async(
     request_type=bigtable_table_admin.DeleteSnapshotRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3486,13 +3433,11 @@ async def test_delete_snapshot_async(
     with mock.patch.object(type(client.transport.delete_snapshot), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         response = await client.delete_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteSnapshotRequest()
 
     # Establish that the response is the type that we expect.
@@ -3505,17 +3450,19 @@ async def test_delete_snapshot_async_from_dict():
 
 
 def test_delete_snapshot_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.DeleteSnapshotRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_snapshot), "__call__") as call:
         call.return_value = None
-
         client.delete_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3531,18 +3478,18 @@ def test_delete_snapshot_field_headers():
 @pytest.mark.asyncio
 async def test_delete_snapshot_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.DeleteSnapshotRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_snapshot), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         await client.delete_snapshot(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3556,13 +3503,14 @@ async def test_delete_snapshot_field_headers_async():
 
 
 def test_delete_snapshot_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_snapshot), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.delete_snapshot(name="name_value",)
@@ -3571,12 +3519,13 @@ def test_delete_snapshot_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_delete_snapshot_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -3589,7 +3538,7 @@ def test_delete_snapshot_flattened_error():
 @pytest.mark.asyncio
 async def test_delete_snapshot_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3606,14 +3555,13 @@ async def test_delete_snapshot_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_delete_snapshot_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3628,7 +3576,7 @@ def test_create_backup(
     transport: str = "grpc", request_type=bigtable_table_admin.CreateBackupRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3639,13 +3587,11 @@ def test_create_backup(
     with mock.patch.object(type(client.transport.create_backup), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.create_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateBackupRequest()
 
     # Establish that the response is the type that we expect.
@@ -3660,7 +3606,7 @@ def test_create_backup_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3668,7 +3614,6 @@ def test_create_backup_empty_call():
         client.create_backup()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateBackupRequest()
 
 
@@ -3678,7 +3623,7 @@ async def test_create_backup_async(
     request_type=bigtable_table_admin.CreateBackupRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3691,13 +3636,11 @@ async def test_create_backup_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.create_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.CreateBackupRequest()
 
     # Establish that the response is the type that we expect.
@@ -3710,17 +3653,19 @@ async def test_create_backup_async_from_dict():
 
 
 def test_create_backup_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.CreateBackupRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_backup), "__call__") as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.create_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3736,12 +3681,13 @@ def test_create_backup_field_headers():
 @pytest.mark.asyncio
 async def test_create_backup_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.CreateBackupRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3749,7 +3695,6 @@ async def test_create_backup_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.create_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3763,13 +3708,14 @@ async def test_create_backup_field_headers_async():
 
 
 def test_create_backup_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_backup), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.create_backup(
@@ -3782,16 +3728,15 @@ def test_create_backup_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].backup_id == "backup_id_value"
-
         assert args[0].backup == table.Backup(name="name_value")
 
 
 def test_create_backup_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -3807,7 +3752,7 @@ def test_create_backup_flattened_error():
 @pytest.mark.asyncio
 async def test_create_backup_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3830,18 +3775,15 @@ async def test_create_backup_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
-
         assert args[0].backup_id == "backup_id_value"
-
         assert args[0].backup == table.Backup(name="name_value")
 
 
 @pytest.mark.asyncio
 async def test_create_backup_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -3859,7 +3801,7 @@ def test_get_backup(
     transport: str = "grpc", request_type=bigtable_table_admin.GetBackupRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3875,25 +3817,18 @@ def test_get_backup(
             size_bytes=1089,
             state=table.Backup.State.CREATING,
         )
-
         response = client.get_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetBackupRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, table.Backup)
-
     assert response.name == "name_value"
-
     assert response.source_table == "source_table_value"
-
     assert response.size_bytes == 1089
-
     assert response.state == table.Backup.State.CREATING
 
 
@@ -3905,7 +3840,7 @@ def test_get_backup_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3913,7 +3848,6 @@ def test_get_backup_empty_call():
         client.get_backup()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetBackupRequest()
 
 
@@ -3922,7 +3856,7 @@ async def test_get_backup_async(
     transport: str = "grpc_asyncio", request_type=bigtable_table_admin.GetBackupRequest
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3940,24 +3874,18 @@ async def test_get_backup_async(
                 state=table.Backup.State.CREATING,
             )
         )
-
         response = await client.get_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.GetBackupRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, table.Backup)
-
     assert response.name == "name_value"
-
     assert response.source_table == "source_table_value"
-
     assert response.size_bytes == 1089
-
     assert response.state == table.Backup.State.CREATING
 
 
@@ -3967,17 +3895,19 @@ async def test_get_backup_async_from_dict():
 
 
 def test_get_backup_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.GetBackupRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_backup), "__call__") as call:
         call.return_value = table.Backup()
-
         client.get_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -3993,18 +3923,18 @@ def test_get_backup_field_headers():
 @pytest.mark.asyncio
 async def test_get_backup_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.GetBackupRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_backup), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(table.Backup())
-
         await client.get_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4018,13 +3948,14 @@ async def test_get_backup_field_headers_async():
 
 
 def test_get_backup_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_backup), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = table.Backup()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_backup(name="name_value",)
@@ -4033,12 +3964,13 @@ def test_get_backup_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_get_backup_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -4051,7 +3983,7 @@ def test_get_backup_flattened_error():
 @pytest.mark.asyncio
 async def test_get_backup_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4068,14 +4000,13 @@ async def test_get_backup_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_get_backup_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -4090,7 +4021,7 @@ def test_update_backup(
     transport: str = "grpc", request_type=bigtable_table_admin.UpdateBackupRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4106,25 +4037,18 @@ def test_update_backup(
             size_bytes=1089,
             state=table.Backup.State.CREATING,
         )
-
         response = client.update_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.UpdateBackupRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, table.Backup)
-
     assert response.name == "name_value"
-
     assert response.source_table == "source_table_value"
-
     assert response.size_bytes == 1089
-
     assert response.state == table.Backup.State.CREATING
 
 
@@ -4136,7 +4060,7 @@ def test_update_backup_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4144,7 +4068,6 @@ def test_update_backup_empty_call():
         client.update_backup()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.UpdateBackupRequest()
 
 
@@ -4154,7 +4077,7 @@ async def test_update_backup_async(
     request_type=bigtable_table_admin.UpdateBackupRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4172,24 +4095,18 @@ async def test_update_backup_async(
                 state=table.Backup.State.CREATING,
             )
         )
-
         response = await client.update_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.UpdateBackupRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, table.Backup)
-
     assert response.name == "name_value"
-
     assert response.source_table == "source_table_value"
-
     assert response.size_bytes == 1089
-
     assert response.state == table.Backup.State.CREATING
 
 
@@ -4199,17 +4116,19 @@ async def test_update_backup_async_from_dict():
 
 
 def test_update_backup_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.UpdateBackupRequest()
+
     request.backup.name = "backup.name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_backup), "__call__") as call:
         call.return_value = table.Backup()
-
         client.update_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4225,18 +4144,18 @@ def test_update_backup_field_headers():
 @pytest.mark.asyncio
 async def test_update_backup_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.UpdateBackupRequest()
+
     request.backup.name = "backup.name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_backup), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(table.Backup())
-
         await client.update_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4250,32 +4169,33 @@ async def test_update_backup_field_headers_async():
 
 
 def test_update_backup_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_backup), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = table.Backup()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.update_backup(
             backup=table.Backup(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].backup == table.Backup(name="name_value")
-
-        assert args[0].update_mask == field_mask.FieldMask(paths=["paths_value"])
+        assert args[0].update_mask == field_mask_pb2.FieldMask(paths=["paths_value"])
 
 
 def test_update_backup_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -4283,14 +4203,14 @@ def test_update_backup_flattened_error():
         client.update_backup(
             bigtable_table_admin.UpdateBackupRequest(),
             backup=table.Backup(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
 
 @pytest.mark.asyncio
 async def test_update_backup_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4303,23 +4223,21 @@ async def test_update_backup_flattened_async():
         # using the keyword arguments to the method.
         response = await client.update_backup(
             backup=table.Backup(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].backup == table.Backup(name="name_value")
-
-        assert args[0].update_mask == field_mask.FieldMask(paths=["paths_value"])
+        assert args[0].update_mask == field_mask_pb2.FieldMask(paths=["paths_value"])
 
 
 @pytest.mark.asyncio
 async def test_update_backup_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -4328,7 +4246,7 @@ async def test_update_backup_flattened_error_async():
         await client.update_backup(
             bigtable_table_admin.UpdateBackupRequest(),
             backup=table.Backup(name="name_value"),
-            update_mask=field_mask.FieldMask(paths=["paths_value"]),
+            update_mask=field_mask_pb2.FieldMask(paths=["paths_value"]),
         )
 
 
@@ -4336,7 +4254,7 @@ def test_delete_backup(
     transport: str = "grpc", request_type=bigtable_table_admin.DeleteBackupRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4347,13 +4265,11 @@ def test_delete_backup(
     with mock.patch.object(type(client.transport.delete_backup), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         response = client.delete_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteBackupRequest()
 
     # Establish that the response is the type that we expect.
@@ -4368,7 +4284,7 @@ def test_delete_backup_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4376,7 +4292,6 @@ def test_delete_backup_empty_call():
         client.delete_backup()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteBackupRequest()
 
 
@@ -4386,7 +4301,7 @@ async def test_delete_backup_async(
     request_type=bigtable_table_admin.DeleteBackupRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4397,13 +4312,11 @@ async def test_delete_backup_async(
     with mock.patch.object(type(client.transport.delete_backup), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         response = await client.delete_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.DeleteBackupRequest()
 
     # Establish that the response is the type that we expect.
@@ -4416,17 +4329,19 @@ async def test_delete_backup_async_from_dict():
 
 
 def test_delete_backup_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.DeleteBackupRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_backup), "__call__") as call:
         call.return_value = None
-
         client.delete_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4442,18 +4357,18 @@ def test_delete_backup_field_headers():
 @pytest.mark.asyncio
 async def test_delete_backup_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.DeleteBackupRequest()
+
     request.name = "name/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_backup), "__call__") as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-
         await client.delete_backup(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4467,13 +4382,14 @@ async def test_delete_backup_field_headers_async():
 
 
 def test_delete_backup_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_backup), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = None
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.delete_backup(name="name_value",)
@@ -4482,12 +4398,13 @@ def test_delete_backup_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 def test_delete_backup_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -4500,7 +4417,7 @@ def test_delete_backup_flattened_error():
 @pytest.mark.asyncio
 async def test_delete_backup_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4517,14 +4434,13 @@ async def test_delete_backup_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].name == "name_value"
 
 
 @pytest.mark.asyncio
 async def test_delete_backup_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -4539,7 +4455,7 @@ def test_list_backups(
     transport: str = "grpc", request_type=bigtable_table_admin.ListBackupsRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4552,19 +4468,15 @@ def test_list_backups(
         call.return_value = bigtable_table_admin.ListBackupsResponse(
             next_page_token="next_page_token_value",
         )
-
         response = client.list_backups(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListBackupsRequest()
 
     # Establish that the response is the type that we expect.
-
     assert isinstance(response, pagers.ListBackupsPager)
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -4576,7 +4488,7 @@ def test_list_backups_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4584,7 +4496,6 @@ def test_list_backups_empty_call():
         client.list_backups()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListBackupsRequest()
 
 
@@ -4594,7 +4505,7 @@ async def test_list_backups_async(
     request_type=bigtable_table_admin.ListBackupsRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4609,18 +4520,15 @@ async def test_list_backups_async(
                 next_page_token="next_page_token_value",
             )
         )
-
         response = await client.list_backups(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.ListBackupsRequest()
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListBackupsAsyncPager)
-
     assert response.next_page_token == "next_page_token_value"
 
 
@@ -4630,17 +4538,19 @@ async def test_list_backups_async_from_dict():
 
 
 def test_list_backups_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.ListBackupsRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_backups), "__call__") as call:
         call.return_value = bigtable_table_admin.ListBackupsResponse()
-
         client.list_backups(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4656,12 +4566,13 @@ def test_list_backups_field_headers():
 @pytest.mark.asyncio
 async def test_list_backups_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.ListBackupsRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4669,7 +4580,6 @@ async def test_list_backups_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             bigtable_table_admin.ListBackupsResponse()
         )
-
         await client.list_backups(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4683,13 +4593,14 @@ async def test_list_backups_field_headers_async():
 
 
 def test_list_backups_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_backups), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = bigtable_table_admin.ListBackupsResponse()
-
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_backups(parent="parent_value",)
@@ -4698,12 +4609,13 @@ def test_list_backups_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 def test_list_backups_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -4716,7 +4628,7 @@ def test_list_backups_flattened_error():
 @pytest.mark.asyncio
 async def test_list_backups_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4735,14 +4647,13 @@ async def test_list_backups_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].parent == "parent_value"
 
 
 @pytest.mark.asyncio
 async def test_list_backups_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
@@ -4754,7 +4665,7 @@ async def test_list_backups_flattened_error_async():
 
 
 def test_list_backups_pager():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials,)
+    client = BigtableTableAdminClient(credentials=ga_credentials.AnonymousCredentials,)
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_backups), "__call__") as call:
@@ -4790,7 +4701,7 @@ def test_list_backups_pager():
 
 
 def test_list_backups_pages():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials,)
+    client = BigtableTableAdminClient(credentials=ga_credentials.AnonymousCredentials,)
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_backups), "__call__") as call:
@@ -4819,7 +4730,7 @@ def test_list_backups_pages():
 @pytest.mark.asyncio
 async def test_list_backups_async_pager():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials,
+        credentials=ga_credentials.AnonymousCredentials,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4856,7 +4767,7 @@ async def test_list_backups_async_pager():
 @pytest.mark.asyncio
 async def test_list_backups_async_pages():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials,
+        credentials=ga_credentials.AnonymousCredentials,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4891,7 +4802,7 @@ def test_restore_table(
     transport: str = "grpc", request_type=bigtable_table_admin.RestoreTableRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4902,13 +4813,11 @@ def test_restore_table(
     with mock.patch.object(type(client.transport.restore_table), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = operations_pb2.Operation(name="operations/spam")
-
         response = client.restore_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.RestoreTableRequest()
 
     # Establish that the response is the type that we expect.
@@ -4923,7 +4832,7 @@ def test_restore_table_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -4931,7 +4840,6 @@ def test_restore_table_empty_call():
         client.restore_table()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.RestoreTableRequest()
 
 
@@ -4941,7 +4849,7 @@ async def test_restore_table_async(
     request_type=bigtable_table_admin.RestoreTableRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4954,13 +4862,11 @@ async def test_restore_table_async(
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/spam")
         )
-
         response = await client.restore_table(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0] == bigtable_table_admin.RestoreTableRequest()
 
     # Establish that the response is the type that we expect.
@@ -4973,17 +4879,19 @@ async def test_restore_table_async_from_dict():
 
 
 def test_restore_table_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.RestoreTableRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.restore_table), "__call__") as call:
         call.return_value = operations_pb2.Operation(name="operations/op")
-
         client.restore_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -4999,12 +4907,13 @@ def test_restore_table_field_headers():
 @pytest.mark.asyncio
 async def test_restore_table_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
     request = bigtable_table_admin.RestoreTableRequest()
+
     request.parent = "parent/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -5012,7 +4921,6 @@ async def test_restore_table_field_headers_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name="operations/op")
         )
-
         await client.restore_table(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -5026,10 +4934,10 @@ async def test_restore_table_field_headers_async():
 
 
 def test_get_iam_policy(
-    transport: str = "grpc", request_type=iam_policy.GetIamPolicyRequest
+    transport: str = "grpc", request_type=iam_policy_pb2.GetIamPolicyRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -5039,22 +4947,17 @@ def test_get_iam_policy(
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy(version=774, etag=b"etag_blob",)
-
+        call.return_value = policy_pb2.Policy(version=774, etag=b"etag_blob",)
         response = client.get_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.GetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.GetIamPolicyRequest()
 
     # Establish that the response is the type that we expect.
-
-    assert isinstance(response, policy.Policy)
-
+    assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
-
     assert response.etag == b"etag_blob"
 
 
@@ -5066,7 +4969,7 @@ def test_get_iam_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -5074,16 +4977,15 @@ def test_get_iam_policy_empty_call():
         client.get_iam_policy()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.GetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.GetIamPolicyRequest()
 
 
 @pytest.mark.asyncio
 async def test_get_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy.GetIamPolicyRequest
+    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.GetIamPolicyRequest
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -5094,22 +4996,18 @@ async def test_get_iam_policy_async(
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            policy.Policy(version=774, etag=b"etag_blob",)
+            policy_pb2.Policy(version=774, etag=b"etag_blob",)
         )
-
         response = await client.get_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.GetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.GetIamPolicyRequest()
 
     # Establish that the response is the type that we expect.
-    assert isinstance(response, policy.Policy)
-
+    assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
-
     assert response.etag == b"etag_blob"
 
 
@@ -5119,17 +5017,19 @@ async def test_get_iam_policy_async_from_dict():
 
 
 def test_get_iam_policy_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.GetIamPolicyRequest()
+    request = iam_policy_pb2.GetIamPolicyRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         client.get_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -5145,18 +5045,18 @@ def test_get_iam_policy_field_headers():
 @pytest.mark.asyncio
 async def test_get_iam_policy_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.GetIamPolicyRequest()
+    request = iam_policy_pb2.GetIamPolicyRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
-
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy_pb2.Policy())
         await client.get_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -5170,29 +5070,31 @@ async def test_get_iam_policy_field_headers_async():
 
 
 def test_get_iam_policy_from_dict_foreign():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         response = client.get_iam_policy(
             request={
                 "resource": "resource_value",
-                "options": options.GetPolicyOptions(requested_policy_version=2598),
+                "options": options_pb2.GetPolicyOptions(requested_policy_version=2598),
             }
         )
         call.assert_called()
 
 
 def test_get_iam_policy_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_iam_policy(resource="resource_value",)
@@ -5201,33 +5103,34 @@ def test_get_iam_policy_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
 
 
 def test_get_iam_policy_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_iam_policy(
-            iam_policy.GetIamPolicyRequest(), resource="resource_value",
+            iam_policy_pb2.GetIamPolicyRequest(), resource="resource_value",
         )
 
 
 @pytest.mark.asyncio
 async def test_get_iam_policy_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
+        call.return_value = policy_pb2.Policy()
 
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy_pb2.Policy())
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.get_iam_policy(resource="resource_value",)
@@ -5236,29 +5139,28 @@ async def test_get_iam_policy_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
 
 
 @pytest.mark.asyncio
 async def test_get_iam_policy_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_iam_policy(
-            iam_policy.GetIamPolicyRequest(), resource="resource_value",
+            iam_policy_pb2.GetIamPolicyRequest(), resource="resource_value",
         )
 
 
 def test_set_iam_policy(
-    transport: str = "grpc", request_type=iam_policy.SetIamPolicyRequest
+    transport: str = "grpc", request_type=iam_policy_pb2.SetIamPolicyRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -5268,22 +5170,17 @@ def test_set_iam_policy(
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy(version=774, etag=b"etag_blob",)
-
+        call.return_value = policy_pb2.Policy(version=774, etag=b"etag_blob",)
         response = client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.SetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.SetIamPolicyRequest()
 
     # Establish that the response is the type that we expect.
-
-    assert isinstance(response, policy.Policy)
-
+    assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
-
     assert response.etag == b"etag_blob"
 
 
@@ -5295,7 +5192,7 @@ def test_set_iam_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -5303,16 +5200,15 @@ def test_set_iam_policy_empty_call():
         client.set_iam_policy()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.SetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.SetIamPolicyRequest()
 
 
 @pytest.mark.asyncio
 async def test_set_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy.SetIamPolicyRequest
+    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.SetIamPolicyRequest
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -5323,22 +5219,18 @@ async def test_set_iam_policy_async(
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            policy.Policy(version=774, etag=b"etag_blob",)
+            policy_pb2.Policy(version=774, etag=b"etag_blob",)
         )
-
         response = await client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.SetIamPolicyRequest()
+        assert args[0] == iam_policy_pb2.SetIamPolicyRequest()
 
     # Establish that the response is the type that we expect.
-    assert isinstance(response, policy.Policy)
-
+    assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
-
     assert response.etag == b"etag_blob"
 
 
@@ -5348,17 +5240,19 @@ async def test_set_iam_policy_async_from_dict():
 
 
 def test_set_iam_policy_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.SetIamPolicyRequest()
+    request = iam_policy_pb2.SetIamPolicyRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -5374,18 +5268,18 @@ def test_set_iam_policy_field_headers():
 @pytest.mark.asyncio
 async def test_set_iam_policy_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.SetIamPolicyRequest()
+    request = iam_policy_pb2.SetIamPolicyRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
-
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy_pb2.Policy())
         await client.set_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -5399,29 +5293,31 @@ async def test_set_iam_policy_field_headers_async():
 
 
 def test_set_iam_policy_from_dict_foreign():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         response = client.set_iam_policy(
             request={
                 "resource": "resource_value",
-                "policy": policy.Policy(version=774),
+                "policy": policy_pb2.Policy(version=774),
             }
         )
         call.assert_called()
 
 
 def test_set_iam_policy_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
-
+        call.return_value = policy_pb2.Policy()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.set_iam_policy(resource="resource_value",)
@@ -5430,33 +5326,34 @@ def test_set_iam_policy_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
 
 
 def test_set_iam_policy_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.set_iam_policy(
-            iam_policy.SetIamPolicyRequest(), resource="resource_value",
+            iam_policy_pb2.SetIamPolicyRequest(), resource="resource_value",
         )
 
 
 @pytest.mark.asyncio
 async def test_set_iam_policy_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
-        call.return_value = policy.Policy()
+        call.return_value = policy_pb2.Policy()
 
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy_pb2.Policy())
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.set_iam_policy(resource="resource_value",)
@@ -5465,29 +5362,28 @@ async def test_set_iam_policy_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
 
 
 @pytest.mark.asyncio
 async def test_set_iam_policy_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         await client.set_iam_policy(
-            iam_policy.SetIamPolicyRequest(), resource="resource_value",
+            iam_policy_pb2.SetIamPolicyRequest(), resource="resource_value",
         )
 
 
 def test_test_iam_permissions(
-    transport: str = "grpc", request_type=iam_policy.TestIamPermissionsRequest
+    transport: str = "grpc", request_type=iam_policy_pb2.TestIamPermissionsRequest
 ):
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -5499,22 +5395,18 @@ def test_test_iam_permissions(
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = iam_policy.TestIamPermissionsResponse(
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse(
             permissions=["permissions_value"],
         )
-
         response = client.test_iam_permissions(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.TestIamPermissionsRequest()
+        assert args[0] == iam_policy_pb2.TestIamPermissionsRequest()
 
     # Establish that the response is the type that we expect.
-
-    assert isinstance(response, iam_policy.TestIamPermissionsResponse)
-
+    assert isinstance(response, iam_policy_pb2.TestIamPermissionsResponse)
     assert response.permissions == ["permissions_value"]
 
 
@@ -5526,7 +5418,7 @@ def test_test_iam_permissions_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -5536,16 +5428,16 @@ def test_test_iam_permissions_empty_call():
         client.test_iam_permissions()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.TestIamPermissionsRequest()
+        assert args[0] == iam_policy_pb2.TestIamPermissionsRequest()
 
 
 @pytest.mark.asyncio
 async def test_test_iam_permissions_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy.TestIamPermissionsRequest
+    transport: str = "grpc_asyncio",
+    request_type=iam_policy_pb2.TestIamPermissionsRequest,
 ):
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -5558,20 +5450,19 @@ async def test_test_iam_permissions_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            iam_policy.TestIamPermissionsResponse(permissions=["permissions_value"],)
+            iam_policy_pb2.TestIamPermissionsResponse(
+                permissions=["permissions_value"],
+            )
         )
-
         response = await client.test_iam_permissions(request)
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
-        assert args[0] == iam_policy.TestIamPermissionsRequest()
+        assert args[0] == iam_policy_pb2.TestIamPermissionsRequest()
 
     # Establish that the response is the type that we expect.
-    assert isinstance(response, iam_policy.TestIamPermissionsResponse)
-
+    assert isinstance(response, iam_policy_pb2.TestIamPermissionsResponse)
     assert response.permissions == ["permissions_value"]
 
 
@@ -5581,19 +5472,21 @@ async def test_test_iam_permissions_async_from_dict():
 
 
 def test_test_iam_permissions_field_headers():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.TestIamPermissionsRequest()
+    request = iam_policy_pb2.TestIamPermissionsRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
-        call.return_value = iam_policy.TestIamPermissionsResponse()
-
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse()
         client.test_iam_permissions(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -5609,12 +5502,13 @@ def test_test_iam_permissions_field_headers():
 @pytest.mark.asyncio
 async def test_test_iam_permissions_field_headers_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
-    request = iam_policy.TestIamPermissionsRequest()
+    request = iam_policy_pb2.TestIamPermissionsRequest()
+
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -5622,9 +5516,8 @@ async def test_test_iam_permissions_field_headers_async():
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            iam_policy.TestIamPermissionsResponse()
+            iam_policy_pb2.TestIamPermissionsResponse()
         )
-
         await client.test_iam_permissions(request)
 
         # Establish that the underlying gRPC stub method was called.
@@ -5638,14 +5531,15 @@ async def test_test_iam_permissions_field_headers_async():
 
 
 def test_test_iam_permissions_from_dict_foreign():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = iam_policy.TestIamPermissionsResponse()
-
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse()
         response = client.test_iam_permissions(
             request={
                 "resource": "resource_value",
@@ -5656,15 +5550,16 @@ def test_test_iam_permissions_from_dict_foreign():
 
 
 def test_test_iam_permissions_flattened():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = iam_policy.TestIamPermissionsResponse()
-
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.test_iam_permissions(
@@ -5675,20 +5570,20 @@ def test_test_iam_permissions_flattened():
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
-
         assert args[0].permissions == ["permissions_value"]
 
 
 def test_test_iam_permissions_flattened_error():
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.test_iam_permissions(
-            iam_policy.TestIamPermissionsRequest(),
+            iam_policy_pb2.TestIamPermissionsRequest(),
             resource="resource_value",
             permissions=["permissions_value"],
         )
@@ -5697,7 +5592,7 @@ def test_test_iam_permissions_flattened_error():
 @pytest.mark.asyncio
 async def test_test_iam_permissions_flattened_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -5705,10 +5600,10 @@ async def test_test_iam_permissions_flattened_async():
         type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = iam_policy.TestIamPermissionsResponse()
+        call.return_value = iam_policy_pb2.TestIamPermissionsResponse()
 
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            iam_policy.TestIamPermissionsResponse()
+            iam_policy_pb2.TestIamPermissionsResponse()
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
@@ -5720,23 +5615,21 @@ async def test_test_iam_permissions_flattened_async():
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-
         assert args[0].resource == "resource_value"
-
         assert args[0].permissions == ["permissions_value"]
 
 
 @pytest.mark.asyncio
 async def test_test_iam_permissions_flattened_error_async():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         await client.test_iam_permissions(
-            iam_policy.TestIamPermissionsRequest(),
+            iam_policy_pb2.TestIamPermissionsRequest(),
             resource="resource_value",
             permissions=["permissions_value"],
         )
@@ -5745,16 +5638,16 @@ async def test_test_iam_permissions_flattened_error_async():
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
     transport = transports.BigtableTableAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     with pytest.raises(ValueError):
         client = BigtableTableAdminClient(
-            credentials=credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
     transport = transports.BigtableTableAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     with pytest.raises(ValueError):
         client = BigtableTableAdminClient(
@@ -5764,7 +5657,7 @@ def test_credentials_transport_error():
 
     # It is an error to provide scopes and a transport instance.
     transport = transports.BigtableTableAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     with pytest.raises(ValueError):
         client = BigtableTableAdminClient(
@@ -5775,7 +5668,7 @@ def test_credentials_transport_error():
 def test_transport_instance():
     # A client may be instantiated with a custom transport instance.
     transport = transports.BigtableTableAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     client = BigtableTableAdminClient(transport=transport)
     assert client.transport is transport
@@ -5784,13 +5677,13 @@ def test_transport_instance():
 def test_transport_get_channel():
     # A client may be instantiated with a custom transport instance.
     transport = transports.BigtableTableAdminGrpcTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     channel = transport.grpc_channel
     assert channel
 
     transport = transports.BigtableTableAdminGrpcAsyncIOTransport(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
     )
     channel = transport.grpc_channel
     assert channel
@@ -5805,23 +5698,25 @@ def test_transport_get_channel():
 )
 def test_transport_adc(transport_class):
     # Test default credentials are used if not provided.
-    with mock.patch.object(auth, "default") as adc:
-        adc.return_value = (credentials.AnonymousCredentials(), None)
+    with mock.patch.object(google.auth, "default") as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport_class()
         adc.assert_called_once()
 
 
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
-    client = BigtableTableAdminClient(credentials=credentials.AnonymousCredentials(),)
+    client = BigtableTableAdminClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
     assert isinstance(client.transport, transports.BigtableTableAdminGrpcTransport,)
 
 
 def test_bigtable_table_admin_base_transport_error():
     # Passing both a credentials object and credentials_file should raise an error
-    with pytest.raises(exceptions.DuplicateCredentialArgs):
+    with pytest.raises(core_exceptions.DuplicateCredentialArgs):
         transport = transports.BigtableTableAdminTransport(
-            credentials=credentials.AnonymousCredentials(),
+            credentials=ga_credentials.AnonymousCredentials(),
             credentials_file="credentials.json",
         )
 
@@ -5833,7 +5728,7 @@ def test_bigtable_table_admin_base_transport():
     ) as Transport:
         Transport.return_value = None
         transport = transports.BigtableTableAdminTransport(
-            credentials=credentials.AnonymousCredentials(),
+            credentials=ga_credentials.AnonymousCredentials(),
         )
 
     # Every method on the transport should just blindly
@@ -5872,15 +5767,44 @@ def test_bigtable_table_admin_base_transport():
         transport.operations_client
 
 
+@requires_google_auth_gte_1_25_0
 def test_bigtable_table_admin_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(
-        auth, "load_credentials_from_file"
+        google.auth, "load_credentials_from_file", autospec=True
     ) as load_creds, mock.patch(
         "google.cloud.bigtable_admin_v2.services.bigtable_table_admin.transports.BigtableTableAdminTransport._prep_wrapped_messages"
     ) as Transport:
         Transport.return_value = None
-        load_creds.return_value = (credentials.AnonymousCredentials(), None)
+        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport = transports.BigtableTableAdminTransport(
+            credentials_file="credentials.json", quota_project_id="octopus",
+        )
+        load_creds.assert_called_once_with(
+            "credentials.json",
+            scopes=None,
+            default_scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            quota_project_id="octopus",
+        )
+
+
+@requires_google_auth_lt_1_25_0
+def test_bigtable_table_admin_base_transport_with_credentials_file_old_google_auth():
+    # Instantiate the base transport with a credentials file
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch(
+        "google.cloud.bigtable_admin_v2.services.bigtable_table_admin.transports.BigtableTableAdminTransport._prep_wrapped_messages"
+    ) as Transport:
+        Transport.return_value = None
+        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.BigtableTableAdminTransport(
             credentials_file="credentials.json", quota_project_id="octopus",
         )
@@ -5900,19 +5824,40 @@ def test_bigtable_table_admin_base_transport_with_credentials_file():
 
 def test_bigtable_table_admin_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
-    with mock.patch.object(auth, "default") as adc, mock.patch(
+    with mock.patch.object(google.auth, "default", autospec=True) as adc, mock.patch(
         "google.cloud.bigtable_admin_v2.services.bigtable_table_admin.transports.BigtableTableAdminTransport._prep_wrapped_messages"
     ) as Transport:
         Transport.return_value = None
-        adc.return_value = (credentials.AnonymousCredentials(), None)
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.BigtableTableAdminTransport()
         adc.assert_called_once()
 
 
+@requires_google_auth_gte_1_25_0
 def test_bigtable_table_admin_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(auth, "default") as adc:
-        adc.return_value = (credentials.AnonymousCredentials(), None)
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        BigtableTableAdminClient()
+        adc.assert_called_once_with(
+            scopes=None,
+            default_scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            quota_project_id=None,
+        )
+
+
+@requires_google_auth_lt_1_25_0
+def test_bigtable_table_admin_auth_adc_old_google_auth():
+    # If no credentials are provided, we should use ADC credentials.
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
         BigtableTableAdminClient()
         adc.assert_called_once_with(
             scopes=(
@@ -5927,16 +5872,23 @@ def test_bigtable_table_admin_auth_adc():
         )
 
 
-def test_bigtable_table_admin_transport_auth_adc():
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.BigtableTableAdminGrpcTransport,
+        transports.BigtableTableAdminGrpcAsyncIOTransport,
+    ],
+)
+@requires_google_auth_gte_1_25_0
+def test_bigtable_table_admin_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
-    with mock.patch.object(auth, "default") as adc:
-        adc.return_value = (credentials.AnonymousCredentials(), None)
-        transports.BigtableTableAdminGrpcTransport(
-            host="squid.clam.whelk", quota_project_id="octopus"
-        )
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
         adc.assert_called_once_with(
-            scopes=(
+            scopes=["1", "2"],
+            default_scopes=(
                 "https://www.googleapis.com/auth/bigtable.admin",
                 "https://www.googleapis.com/auth/bigtable.admin.table",
                 "https://www.googleapis.com/auth/cloud-bigtable.admin",
@@ -5955,10 +5907,160 @@ def test_bigtable_table_admin_transport_auth_adc():
         transports.BigtableTableAdminGrpcAsyncIOTransport,
     ],
 )
+@requires_google_auth_lt_1_25_0
+def test_bigtable_table_admin_transport_auth_adc_old_google_auth(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus")
+        adc.assert_called_once_with(
+            scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            quota_project_id="octopus",
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.BigtableTableAdminGrpcTransport, grpc_helpers),
+        (transports.BigtableTableAdminGrpcAsyncIOTransport, grpc_helpers_async),
+    ],
+)
+@requires_api_core_gte_1_26_0
+def test_bigtable_table_admin_transport_create_channel(transport_class, grpc_helpers):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+
+        create_channel.assert_called_with(
+            "bigtableadmin.googleapis.com:443",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            default_scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            scopes=["1", "2"],
+            default_host="bigtableadmin.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.BigtableTableAdminGrpcTransport, grpc_helpers),
+        (transports.BigtableTableAdminGrpcAsyncIOTransport, grpc_helpers_async),
+    ],
+)
+@requires_api_core_lt_1_26_0
+def test_bigtable_table_admin_transport_create_channel_old_api_core(
+    transport_class, grpc_helpers
+):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+        transport_class(quota_project_id="octopus")
+
+        create_channel.assert_called_with(
+            "bigtableadmin.googleapis.com:443",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            scopes=(
+                "https://www.googleapis.com/auth/bigtable.admin",
+                "https://www.googleapis.com/auth/bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin",
+                "https://www.googleapis.com/auth/cloud-bigtable.admin.table",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+            ),
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.BigtableTableAdminGrpcTransport, grpc_helpers),
+        (transports.BigtableTableAdminGrpcAsyncIOTransport, grpc_helpers_async),
+    ],
+)
+@requires_api_core_lt_1_26_0
+def test_bigtable_table_admin_transport_create_channel_user_scopes(
+    transport_class, grpc_helpers
+):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+
+        create_channel.assert_called_with(
+            "bigtableadmin.googleapis.com:443",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            scopes=["1", "2"],
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.BigtableTableAdminGrpcTransport,
+        transports.BigtableTableAdminGrpcAsyncIOTransport,
+    ],
+)
 def test_bigtable_table_admin_grpc_transport_client_cert_source_for_mtls(
     transport_class,
 ):
-    cred = credentials.AnonymousCredentials()
+    cred = ga_credentials.AnonymousCredentials()
 
     # Check ssl_channel_credentials is used if provided.
     with mock.patch.object(transport_class, "create_channel") as mock_create_channel:
@@ -6004,7 +6106,7 @@ def test_bigtable_table_admin_grpc_transport_client_cert_source_for_mtls(
 
 def test_bigtable_table_admin_host_no_port():
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="bigtableadmin.googleapis.com"
         ),
@@ -6014,7 +6116,7 @@ def test_bigtable_table_admin_host_no_port():
 
 def test_bigtable_table_admin_host_with_port():
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(),
+        credentials=ga_credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(
             api_endpoint="bigtableadmin.googleapis.com:8000"
         ),
@@ -6070,9 +6172,9 @@ def test_bigtable_table_admin_transport_channel_mtls_with_client_cert_source(
             mock_grpc_channel = mock.Mock()
             grpc_create_channel.return_value = mock_grpc_channel
 
-            cred = credentials.AnonymousCredentials()
+            cred = ga_credentials.AnonymousCredentials()
             with pytest.warns(DeprecationWarning):
-                with mock.patch.object(auth, "default") as adc:
+                with mock.patch.object(google.auth, "default") as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
                         host="squid.clam.whelk",
@@ -6162,7 +6264,7 @@ def test_bigtable_table_admin_transport_channel_mtls_with_adc(transport_class):
 
 def test_bigtable_table_admin_grpc_lro_client():
     client = BigtableTableAdminClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
     )
     transport = client.transport
 
@@ -6175,7 +6277,7 @@ def test_bigtable_table_admin_grpc_lro_client():
 
 def test_bigtable_table_admin_grpc_lro_async_client():
     client = BigtableTableAdminAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
     )
     transport = client.transport
 
@@ -6191,7 +6293,6 @@ def test_backup_path():
     instance = "clam"
     cluster = "whelk"
     backup = "octopus"
-
     expected = "projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}".format(
         project=project, instance=instance, cluster=cluster, backup=backup,
     )
@@ -6217,7 +6318,6 @@ def test_cluster_path():
     project = "winkle"
     instance = "nautilus"
     cluster = "scallop"
-
     expected = "projects/{project}/instances/{instance}/clusters/{cluster}".format(
         project=project, instance=instance, cluster=cluster,
     )
@@ -6244,7 +6344,6 @@ def test_crypto_key_version_path():
     key_ring = "oyster"
     crypto_key = "nudibranch"
     crypto_key_version = "cuttlefish"
-
     expected = "projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}/cryptoKeyVersions/{crypto_key_version}".format(
         project=project,
         location=location,
@@ -6276,7 +6375,6 @@ def test_parse_crypto_key_version_path():
 def test_instance_path():
     project = "squid"
     instance = "clam"
-
     expected = "projects/{project}/instances/{instance}".format(
         project=project, instance=instance,
     )
@@ -6301,7 +6399,6 @@ def test_snapshot_path():
     instance = "nudibranch"
     cluster = "cuttlefish"
     snapshot = "mussel"
-
     expected = "projects/{project}/instances/{instance}/clusters/{cluster}/snapshots/{snapshot}".format(
         project=project, instance=instance, cluster=cluster, snapshot=snapshot,
     )
@@ -6329,7 +6426,6 @@ def test_table_path():
     project = "squid"
     instance = "clam"
     table = "whelk"
-
     expected = "projects/{project}/instances/{instance}/tables/{table}".format(
         project=project, instance=instance, table=table,
     )
@@ -6352,7 +6448,6 @@ def test_parse_table_path():
 
 def test_common_billing_account_path():
     billing_account = "cuttlefish"
-
     expected = "billingAccounts/{billing_account}".format(
         billing_account=billing_account,
     )
@@ -6373,7 +6468,6 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "winkle"
-
     expected = "folders/{folder}".format(folder=folder,)
     actual = BigtableTableAdminClient.common_folder_path(folder)
     assert expected == actual
@@ -6392,7 +6486,6 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "scallop"
-
     expected = "organizations/{organization}".format(organization=organization,)
     actual = BigtableTableAdminClient.common_organization_path(organization)
     assert expected == actual
@@ -6411,7 +6504,6 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "squid"
-
     expected = "projects/{project}".format(project=project,)
     actual = BigtableTableAdminClient.common_project_path(project)
     assert expected == actual
@@ -6431,7 +6523,6 @@ def test_parse_common_project_path():
 def test_common_location_path():
     project = "whelk"
     location = "octopus"
-
     expected = "projects/{project}/locations/{location}".format(
         project=project, location=location,
     )
@@ -6458,7 +6549,7 @@ def test_client_withDEFAULT_CLIENT_INFO():
         transports.BigtableTableAdminTransport, "_prep_wrapped_messages"
     ) as prep:
         client = BigtableTableAdminClient(
-            credentials=credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -6467,6 +6558,6 @@ def test_client_withDEFAULT_CLIENT_INFO():
     ) as prep:
         transport_class = BigtableTableAdminClient.get_transport_class()
         transport = transport_class(
-            credentials=credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
         )
         prep.assert_called_once_with(client_info)


### PR DESCRIPTION
`owlbot.py` was not configured correctly in #313 as a result, changes were not pull in from googleapis-gen. This PR includes the following fixes/features:

chore: upgrade gapic-generator-python to 0.46.3
fix: add async client to %name_%version/init.py
chore: add autogenerated snippets
chore: remove auth, policy, and options from the reserved names list
feat: support self-signed JWT flow for service accounts
chore: enable GAPIC metadata generation
chore: sort subpackages in %namespace/%name/init.py
