### PR TITLE
doc(samples): use operation to ensure creation completed

### DIFF
--- a/samples/instanceadmin/instanceadmin.py
+++ b/samples/instanceadmin/instanceadmin.py
@@ -74,7 +74,7 @@ def run_instance_operations(project_id, instance_id, cluster_id):
         # Create instance with given options
         operation = instance.create(clusters=[cluster])
         # Ensure the operation completes.
-        operation.result(timeout=10)
+        operation.result(timeout=30)
         print("\nCreated instance: {}".format(instance_id))
     # [END bigtable_create_prod_instance]
 

--- a/samples/instanceadmin/instanceadmin.py
+++ b/samples/instanceadmin/instanceadmin.py
@@ -73,7 +73,7 @@ def run_instance_operations(project_id, instance_id, cluster_id):
         print("\nCreating an instance")
         # Create instance with given options
         operation = instance.create(clusters=[cluster])
-        # Enssure the operation completes.
+        # Ensure the operation completes.
         operation.result(timeout=10)
         print("\nCreated instance: {}".format(instance_id))
     # [END bigtable_create_prod_instance]
@@ -158,7 +158,7 @@ def add_cluster(project_id, instance_id, cluster_id):
             print("\nCluster not created, as {} already exists.".format(cluster_id))
         else:
             operation = cluster.create()
-            # Enssure the operation completes.
+            # Ensure the operation completes.
             operation.result(timeout=30)
             print("\nCluster created: {}".format(cluster_id))
         # [END bigtable_create_cluster]

--- a/samples/instanceadmin/instanceadmin.py
+++ b/samples/instanceadmin/instanceadmin.py
@@ -72,7 +72,9 @@ def run_instance_operations(project_id, instance_id, cluster_id):
     if not instance.exists():
         print("\nCreating an instance")
         # Create instance with given options
-        instance.create(clusters=[cluster])
+        operation = instance.create(clusters=[cluster])
+        # Enssure the operation completes.
+        operation.result(timeout=10)
         print("\nCreated instance: {}".format(instance_id))
     # [END bigtable_create_prod_instance]
 
@@ -155,7 +157,9 @@ def add_cluster(project_id, instance_id, cluster_id):
         if cluster.exists():
             print("\nCluster not created, as {} already exists.".format(cluster_id))
         else:
-            cluster.create()
+            operation = cluster.create()
+            # Enssure the operation completes.
+            operation.result(timeout=30)
             print("\nCluster created: {}".format(cluster_id))
         # [END bigtable_create_cluster]
 


### PR DESCRIPTION
In addition to showing the better practice (using the operation returned
from 'Instance.create' / 'Cluster.create'), this change also hardens
the sample against eventual-consistency issues.

Closes #353.