### PR TITLE
fix: use public 'table_admin_client' property in backups methods

### DIFF
--- a/google/cloud/bigtable/backup.py
+++ b/google/cloud/bigtable/backup.py
@@ -330,7 +330,7 @@ class Backup(object):
             expire_time=_datetime_to_pb_timestamp(self.expire_time),
         )
 
-        api = self._instance._client._table_admin_client
+        api = self._instance._client.table_admin_client
         return api.create_backup(
             request={
                 "parent": self.parent,
@@ -351,7 +351,7 @@ class Backup(object):
                 due to a retryable error and retry attempts failed.
         :raises ValueError: If the parameters are invalid.
         """
-        api = self._instance._client._table_admin_client
+        api = self._instance._client.table_admin_client
         try:
             return api.get_backup(request={"name": self.name})
         except NotFound:
@@ -385,13 +385,13 @@ class Backup(object):
             name=self.name, expire_time=_datetime_to_pb_timestamp(new_expire_time),
         )
         update_mask = field_mask_pb2.FieldMask(paths=["expire_time"])
-        api = self._instance._client._table_admin_client
+        api = self._instance._client.table_admin_client
         api.update_backup(request={"backup": backup_update, "update_mask": update_mask})
         self._expire_time = new_expire_time
 
     def delete(self):
         """Delete this Backup."""
-        self._instance._client._table_admin_client.delete_backup(
+        self._instance._client.table_admin_client.delete_backup(
             request={"name": self.name}
         )
 
@@ -423,7 +423,7 @@ class Backup(object):
                  due to a retryable error and retry attempts failed.
         :raises: ValueError: If the parameters are invalid.
         """
-        api = self._instance._client._table_admin_client
+        api = self._instance._client.table_admin_client
         if instance_id:
             parent = BigtableTableAdminClient.instance_path(
                 project=self._instance._client.project, instance=instance_id,

--- a/tests/system.py
+++ b/tests/system.py
@@ -1080,6 +1080,9 @@ class TestTableAdminAPI(unittest.TestCase):
             expire_time=datetime.datetime.utcfromtimestamp(expire),
         )
 
+        # Reinitialize the admin client. This is to test `_table_admin_client` returns a client object (and not NoneType)
+        temp_backup._instance._client = Client(admin=True)
+
         # Sanity check for `Backup.exists()` method
         self.assertFalse(temp_backup.exists())
 

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -494,7 +494,7 @@ class TestBackup(unittest.TestCase):
         from google.api_core.exceptions import Unknown
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.get_backup.side_effect = Unknown("testing")
 
         instance = _Instance(self.INSTANCE_NAME, client=client)
@@ -510,7 +510,7 @@ class TestBackup(unittest.TestCase):
         from google.api_core.exceptions import NotFound
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.get_backup.side_effect = NotFound("testing")
 
         instance = _Instance(self.INSTANCE_NAME, client=client)
@@ -537,7 +537,7 @@ class TestBackup(unittest.TestCase):
             size_bytes=0,
             state=state,
         )
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.get_backup.return_value = backup_pb
 
         instance = _Instance(self.INSTANCE_NAME, client=client)
@@ -562,7 +562,7 @@ class TestBackup(unittest.TestCase):
             size_bytes=0,
             state=state,
         )
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.get_backup.return_value = backup_pb
 
         instance = _Instance(self.INSTANCE_NAME, client=client)
@@ -581,7 +581,7 @@ class TestBackup(unittest.TestCase):
 
         client = _Client()
         backup_pb = table.Backup(name=self.BACKUP_NAME)
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.get_backup.return_value = backup_pb
 
         instance = _Instance(self.INSTANCE_NAME, client=client)

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -332,7 +332,7 @@ class TestBackup(unittest.TestCase):
         from google.cloud.bigtable_admin_v2.types import table
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.create_backup.side_effect = Unknown("testing")
 
         timestamp = self._make_timestamp()
@@ -365,7 +365,7 @@ class TestBackup(unittest.TestCase):
         from google.cloud.exceptions import Conflict
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.create_backup.side_effect = Conflict("testing")
 
         timestamp = self._make_timestamp()
@@ -398,7 +398,7 @@ class TestBackup(unittest.TestCase):
         from google.cloud.exceptions import NotFound
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.create_backup.side_effect = NotFound("testing")
 
         timestamp = self._make_timestamp()
@@ -595,7 +595,7 @@ class TestBackup(unittest.TestCase):
         from google.api_core.exceptions import Unknown
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.delete_backup.side_effect = Unknown("testing")
         instance = _Instance(self.INSTANCE_NAME, client=client)
         backup = self._make_one(self.BACKUP_ID, instance, cluster_id=self.CLUSTER_ID)
@@ -609,7 +609,7 @@ class TestBackup(unittest.TestCase):
         from google.api_core.exceptions import NotFound
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.delete_backup.side_effect = NotFound("testing")
         instance = _Instance(self.INSTANCE_NAME, client=client)
         backup = self._make_one(self.BACKUP_ID, instance, cluster_id=self.CLUSTER_ID)
@@ -623,7 +623,7 @@ class TestBackup(unittest.TestCase):
         from google.protobuf.empty_pb2 import Empty
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.delete_backup.return_value = Empty()
         instance = _Instance(self.INSTANCE_NAME, client=client)
         backup = self._make_one(self.BACKUP_ID, instance, cluster_id=self.CLUSTER_ID)
@@ -639,7 +639,7 @@ class TestBackup(unittest.TestCase):
         from google.protobuf import field_mask_pb2
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.update_backup.side_effect = Unknown("testing")
         instance = _Instance(self.INSTANCE_NAME, client=client)
         backup = self._make_one(self.BACKUP_ID, instance, cluster_id=self.CLUSTER_ID)
@@ -663,7 +663,7 @@ class TestBackup(unittest.TestCase):
         from google.protobuf import field_mask_pb2
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.update_backup.side_effect = NotFound("testing")
         instance = _Instance(self.INSTANCE_NAME, client=client)
         backup = self._make_one(self.BACKUP_ID, instance, cluster_id=self.CLUSTER_ID)
@@ -686,7 +686,7 @@ class TestBackup(unittest.TestCase):
         from google.protobuf import field_mask_pb2
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.update_backup.return_type = table.Backup(name=self.BACKUP_NAME)
         instance = _Instance(self.INSTANCE_NAME, client=client)
         backup = self._make_one(self.BACKUP_ID, instance, cluster_id=self.CLUSTER_ID)
@@ -707,7 +707,7 @@ class TestBackup(unittest.TestCase):
         from google.api_core.exceptions import Unknown
 
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.restore_table.side_effect = Unknown("testing")
 
         timestamp = self._make_timestamp()
@@ -732,7 +732,7 @@ class TestBackup(unittest.TestCase):
 
     def test_restore_cluster_not_set(self):
         client = _Client()
-        client._table_admin_client = self._make_table_admin_client()
+        client.table_admin_client = self._make_table_admin_client()
         backup = self._make_one(
             self.BACKUP_ID,
             _Instance(self.INSTANCE_NAME, client=client),
@@ -746,7 +746,7 @@ class TestBackup(unittest.TestCase):
     def _restore_helper(self, instance_id=None, instance_name=None):
         op_future = object()
         client = _Client()
-        api = client._table_admin_client = self._make_table_admin_client()
+        api = client.table_admin_client = self._make_table_admin_client()
         api.restore_table.return_value = op_future
 
         timestamp = self._make_timestamp()


### PR DESCRIPTION
calling `_table_admin_client` was lazily evaluated and would return a `NoneType` in cases where table operations were not already done.
