### PR TITLE
test(samples): add backoff to cluster creation sample

### DIFF
--- a/samples/instanceadmin/requirements.txt
+++ b/samples/instanceadmin/requirements.txt
@@ -1,1 +1,2 @@
 google-cloud-bigtable==2.0.0
+backoff==1.11.0

--- a/samples/instanceadmin/test_instanceadmin.py
+++ b/samples/instanceadmin/test_instanceadmin.py
@@ -17,9 +17,11 @@ import random
 import time
 import warnings
 
-from google.cloud import bigtable
-
+import backoff
 import pytest
+
+from google.api_core import exceptions
+from google.cloud import bigtable
 
 import instanceadmin
 
@@ -128,7 +130,10 @@ def test_add_and_delete_cluster(capsys, dispose_of):
     capsys.readouterr()  # throw away output
 
     # Add a cluster to that instance
-    instanceadmin.add_cluster(PROJECT, INSTANCE, CLUSTER2)
+    # Avoid failing for "instance is currently being changed" by
+    # applying an exponential backoff
+    w_backoff = backoff.on_exception(backoff.expo, exceptions.ServiceUnavailable)
+    w_backoff(instanceadmin.add_cluster)(PROJECT, INSTANCE, CLUSTER2)
     out = capsys.readouterr().out
     assert f"Adding cluster to instance {INSTANCE}" in out
     assert "Listing clusters..." in out

--- a/samples/instanceadmin/test_instanceadmin.py
+++ b/samples/instanceadmin/test_instanceadmin.py
@@ -18,10 +18,9 @@ import time
 import warnings
 
 import backoff
-import pytest
-
 from google.api_core import exceptions
 from google.cloud import bigtable
+import pytest
 
 import instanceadmin
 


### PR DESCRIPTION
Closes #353.

@kolea2 Note that this PR injects "repeatability" noise into the sample, which may be undesirable from the perspective of documentation.