### PR TITLE
tests: split systest into a seperate Kokoro build

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -29,6 +29,7 @@ branchProtectionRules:
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
     - 'Kokoro'
+    - 'Kokoro system-3.8'
     - 'cla/google'
 # List of explicit permissions to add (additive only)
 permissionRules:

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -1,1 +1,7 @@
 # Format: //devtools/kokoro/config/proto/build.proto
+
+# Disable system tests.
+env_vars: {
+    key: "RUN_SYSTEM_TESTS"
+    value: "false"
+}

--- a/.kokoro/presubmit/system-3.8.cfg
+++ b/.kokoro/presubmit/system-3.8.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "system-3.8"
+}

--- a/owlbot.py
+++ b/owlbot.py
@@ -85,6 +85,7 @@ s.remove_staging_dirs()
 # ----------------------------------------------------------------------------
 templated_files = common.py_library(
     samples=True,  # set to True only if there are samples
+    split_system_tests=True,
     microgenerator=True,
     cov_level=100,
 )


### PR DESCRIPTION
Closes #388.

This PR will need to have the corresponding changes made to Kokoro configuration in `google3`.