### PR TITLE
tests: revert testing against prerelease deps on Python 3.9

### DIFF
--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,2 +1,0 @@
-# Allow prerelease requirements
---pre


### PR DESCRIPTION
Reverts googleapis/python-bigtable#402

Consensus from today's meeting is that testing prereleases of third-party dependencies needs to happen outside the normal `presubmit` path.