### PR TITLE
chore: add py.typed file for PEP 561 compatibility

### DIFF
--- a/google/cloud/bigtable/py.typed
+++ b/google/cloud/bigtable/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561.
+# The google-cloud-bigtable package uses inline types.


### PR DESCRIPTION
fixes googleapis/google-cloud-python#15334 