### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigtable",
     "name_pretty": "Cloud Bigtable",
     "product_documentation": "https://cloud.google.com/bigtable",
-    "client_documentation": "https://googleapis.dev/python/bigtable/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/bigtable/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559777",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Analytics, Maps, and Gmail.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigtable.svg
    :target: https://pypi.org/project/google-cloud-bigtable/
 .. _Google Cloud Bigtable: https://cloud.google.com/bigtable
-.. _Client Library Documentation: https://googleapis.dev/python/bigtable/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigtable/latest
 .. _Product Documentation:  https://cloud.google.com/bigtable/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.