### PR TITLE
fix: Ensure message fields are copied when building retry request

### DIFF
--- a/google/cloud/bigtable/row_data.py
+++ b/google/cloud/bigtable/row_data.py
@@ -16,6 +16,7 @@
 
 
 import copy
+import proto
 
 import grpc  # type: ignore
 
@@ -626,7 +627,7 @@ class _ReadRowsRequestManager(object):
         """Updates the given message request as per last scanned key"""
 
         updated_message = data_messages_v2_pb2.ReadRowsRequest()
-        data_messages_v2_pb2.ReadRowsRequest.copy_from(updated_message, self.message)
+        proto.Message.copy_from(updated_message, self.message)
 
         if self.message.rows_limit != 0:
             updated_message.rows_limit = max(

--- a/google/cloud/bigtable/row_data.py
+++ b/google/cloud/bigtable/row_data.py
@@ -25,6 +25,7 @@ from google.cloud._helpers import _datetime_from_microseconds  # type: ignore
 from google.cloud._helpers import _to_bytes  # type: ignore
 from google.cloud.bigtable_v2.types import bigtable as data_messages_v2_pb2
 from google.cloud.bigtable_v2.types import data as data_v2_pb2
+from google.cloud.bigtable_v2.types.bigtable import ReadRowsRequest
 
 _MISSING_COLUMN_FAMILY = "Column family {} is not among the cells stored in this row."
 _MISSING_COLUMN = (
@@ -625,13 +626,8 @@ class _ReadRowsRequestManager(object):
     def build_updated_request(self):
         """Updates the given message request as per last scanned key"""
 
-        # TODO: Generalize this to ensure fields don't get rewritten when retrying the request
-
-        r_kwargs = {
-            "table_name": self.message.table_name,
-            "filter": self.message.filter,
-            "app_profile_id": self.message.app_profile_id,
-        }
+        r_kwargs = ReadRowsRequest.to_dict(self.message)
+        r_kwargs["filter"] = self.message.filter
 
         if self.message.rows_limit != 0:
             r_kwargs["rows_limit"] = max(

--- a/google/cloud/bigtable/row_data.py
+++ b/google/cloud/bigtable/row_data.py
@@ -16,7 +16,6 @@
 
 
 import copy
-import proto
 
 import grpc  # type: ignore
 
@@ -626,11 +625,12 @@ class _ReadRowsRequestManager(object):
     def build_updated_request(self):
         """Updates the given message request as per last scanned key"""
 
-        updated_message = data_messages_v2_pb2.ReadRowsRequest()
-        proto.Message.copy_from(updated_message, self.message)
+        resume_request = data_messages_v2_pb2.ReadRowsRequest()
+        data_messages_v2_pb2.ReadRowsRequest.copy_from(resume_request, self.message)
 
         if self.message.rows_limit != 0:
-            updated_message.rows_limit = max(
+            # TODO: Throw an error if rows_limit - read_so_far is 0 or negative.
+            resume_request.rows_limit = max(
                 1, self.message.rows_limit - self.rows_read_so_far
             )
 
@@ -639,14 +639,14 @@ class _ReadRowsRequestManager(object):
         # to request only rows that have not been returned yet
         if "rows" not in self.message:
             row_range = data_v2_pb2.RowRange(start_key_open=self.last_scanned_key)
-            updated_message.rows = data_v2_pb2.RowSet(row_ranges=[row_range])
+            resume_request.rows = data_v2_pb2.RowSet(row_ranges=[row_range])
         else:
             row_keys = self._filter_rows_keys()
             row_ranges = self._filter_row_ranges()
-            updated_message.rows = data_v2_pb2.RowSet(
+            resume_request.rows = data_v2_pb2.RowSet(
                 row_keys=row_keys, row_ranges=row_ranges
             )
-        return updated_message
+        return resume_request
 
     def _filter_rows_keys(self):
         """ Helper for :meth:`build_updated_request`"""

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,8 +27,8 @@ import nox
 BLACK_VERSION = "black==19.10b0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
-SYSTEM_TEST_PYTHON_VERSIONS = ["3.8"]
+DEFAULT_PYTHON_VERSION = "3.9"
+SYSTEM_TEST_PYTHON_VERSIONS = ["3.9"]
 UNIT_TEST_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,8 +27,8 @@ import nox
 BLACK_VERSION = "black==19.10b0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.9"
-SYSTEM_TEST_PYTHON_VERSIONS = ["3.9"]
+DEFAULT_PYTHON_VERSION = "3.8"
+SYSTEM_TEST_PYTHON_VERSIONS = ["3.8"]
 UNIT_TEST_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ dependencies = [
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-cloud-core >= 1.4.1, <3.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
-    "proto-plus >= 1.15.0",
+    "proto-plus >= 1.18.0",
 ]
 extras = {"libcst": "libcst >= 0.2.5"}
 

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -8,5 +8,5 @@
 google-api-core==1.31.5
 google-cloud-core==1.4.1
 grpc-google-iam-v1==0.12.3
-proto-plus==1.15.0
+proto-plus==1.18.0
 libcst==0.2.5

--- a/tests/unit/test_row_data.py
+++ b/tests/unit/test_row_data.py
@@ -928,7 +928,7 @@ def test_RRRM_build_updated_request_full_table():
     request_manager = _make_read_rows_request_manager(request, last_scanned_key, 2)
 
     result = request_manager.build_updated_request()
-    expected_result = _ReadRowsRequestPB(table_name=TABLE_NAME, filter={})
+    expected_result = _ReadRowsRequestPB(table_name=TABLE_NAME)
     row_range1 = types.RowRange(start_key_open=last_scanned_key)
     expected_result.rows.row_ranges.append(row_range1)
     assert expected_result == result
@@ -1021,7 +1021,7 @@ def test_RRRM_build_updated_request_rows_limit():
     request_manager = _make_read_rows_request_manager(request, last_scanned_key, 2)
 
     result = request_manager.build_updated_request()
-    expected_result = _ReadRowsRequestPB(table_name=TABLE_NAME, filter={}, rows_limit=8)
+    expected_result = _ReadRowsRequestPB(table_name=TABLE_NAME, rows_limit=8)
     row_range1 = types.RowRange(start_key_open=last_scanned_key)
     expected_result.rows.row_ranges.append(row_range1)
     assert expected_result == result


### PR DESCRIPTION
Use the copy_from() function when building the ReadRowsRequest arguments.

Fixes internal bug #214449800

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #214449800 🦕
