### PR TITLE
fix: Prevent sending full table scan when retrying

### DIFF
--- a/google/cloud/bigtable/row_data.py
+++ b/google/cloud/bigtable/row_data.py
@@ -643,6 +643,16 @@ class _ReadRowsRequestManager(object):
         else:
             row_keys = self._filter_rows_keys()
             row_ranges = self._filter_row_ranges()
+
+            if len(row_keys) == 0 and len(row_ranges) == 0:
+                # Avoid sending empty row_keys and row_ranges
+                # if that was not the intention
+                if (
+                    len(self.message.rows.row_ranges) > 0
+                    or len(self.message.rows.row_keys) > 0
+                ):
+                    raise StopIteration
+
             resume_request.rows = data_v2_pb2.RowSet(
                 row_keys=row_keys, row_ranges=row_ranges
             )

--- a/google/cloud/bigtable/row_data.py
+++ b/google/cloud/bigtable/row_data.py
@@ -655,11 +655,7 @@ class _ReadRowsRequestManager(object):
             if len(row_keys) == 0 and len(row_ranges) == 0:
                 # Avoid sending empty row_keys and row_ranges
                 # if that was not the intention
-                if (
-                    len(self.message.rows.row_ranges) > 0
-                    or len(self.message.rows.row_keys) > 0
-                ):
-                    raise InvalidRetryRequest
+                raise InvalidRetryRequest
 
             resume_request.rows = data_v2_pb2.RowSet(
                 row_keys=row_keys, row_ranges=row_ranges

--- a/google/cloud/bigtable/row_data.py
+++ b/google/cloud/bigtable/row_data.py
@@ -321,11 +321,15 @@ class PartialRowData(object):
 
 
 class InvalidReadRowsResponse(RuntimeError):
-    """Exception raised to to invalid response data from back-end."""
+    """Exception raised to invalid response data from back-end."""
 
 
 class InvalidChunk(RuntimeError):
-    """Exception raised to to invalid chunk data from back-end."""
+    """Exception raised to invalid chunk data from back-end."""
+
+
+class InvalidRetryRequest(RuntimeError):
+    """Exception raised when retry request is invalid."""
 
 
 def _retry_read_rows_exception(exc):
@@ -486,6 +490,9 @@ class PartialRowsData(object):
                 if self.state != self.NEW_ROW:
                     raise ValueError("The row remains partial / is not committed.")
                 break
+            except InvalidRetryRequest:
+                self._cancelled = True
+                break
 
             for chunk in response.chunks:
                 if self._cancelled:
@@ -629,10 +636,11 @@ class _ReadRowsRequestManager(object):
         data_messages_v2_pb2.ReadRowsRequest.copy_from(resume_request, self.message)
 
         if self.message.rows_limit != 0:
-            # TODO: Throw an error if rows_limit - read_so_far is 0 or negative.
-            resume_request.rows_limit = max(
-                1, self.message.rows_limit - self.rows_read_so_far
-            )
+            row_limit_remaining = self.message.rows_limit - self.rows_read_so_far
+            if row_limit_remaining > 0:
+                resume_request.rows_limit = row_limit_remaining
+            else:
+                raise InvalidRetryRequest
 
         # if neither RowSet.row_keys nor RowSet.row_ranges currently exist,
         # add row_range that starts with last_scanned_key as start_key_open
@@ -651,7 +659,7 @@ class _ReadRowsRequestManager(object):
                     len(self.message.rows.row_ranges) > 0
                     or len(self.message.rows.row_keys) > 0
                 ):
-                    raise StopIteration
+                    raise InvalidRetryRequest
 
             resume_request.rows = data_v2_pb2.RowSet(
                 row_keys=row_keys, row_ranges=row_ranges

--- a/tests/unit/test_row_data.py
+++ b/tests/unit/test_row_data.py
@@ -810,6 +810,18 @@ def test_RRRM__filter_row_key():
     assert expected_row_keys == row_keys
 
 
+def test_RRRM__filter_row_key_is_empty():
+    table_name = "table_name"
+    request = _ReadRowsRequestPB(table_name=table_name)
+    request.rows.row_keys.extend([b"row_key1", b"row_key2", b"row_key3", b"row_key4"])
+
+    last_scanned_key = b"row_key4"
+    request_manager = _make_read_rows_request_manager(request, last_scanned_key, 4)
+    row_keys = request_manager._filter_rows_keys()
+
+    assert row_keys == []
+
+
 def test_RRRM__filter_row_ranges_all_ranges_added_back(rrrm_data):
     from google.cloud.bigtable_v2.types import data as data_v2_pb2
 
@@ -1083,6 +1095,27 @@ def test_RRRM_build_updated_request_row_ranges_read_raises_invalid_retry_request
     )
     with pytest.raises(InvalidRetryRequest):
         request_manager.build_updated_request()
+
+
+def test_RRRM_build_updated_request_row_ranges_valid():
+    from google.cloud.bigtable import row_set
+
+    row_range1 = row_set.RowRange(b"row_key21", b"row_key29")
+
+    request = _ReadRowsRequestPB(table_name=TABLE_NAME)
+    request.rows.row_ranges.append(row_range1.get_range_kwargs())
+
+    last_scanned_key = b"row_key21"
+    request = _ReadRowsRequestPB(
+        table_name=TABLE_NAME,
+    )
+    request.rows.row_ranges.append(row_range1.get_range_kwargs())
+
+    request_manager = _make_read_rows_request_manager(
+        request, last_scanned_key, rows_read_so_far=1
+    )
+    updated_request = request_manager.build_updated_request()
+    assert len(updated_request.rows.row_ranges) > 0
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Update the retry logic. Don't send empty row_key and empty row_ranges
if the original message didn't ask for those.

Closes internal issue 214449800

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
