### PR TITLE
docs: Update the docstring for ExactValueFilter

### DIFF
--- a/google/cloud/bigtable/row_filters.py
+++ b/google/cloud/bigtable/row_filters.py
@@ -460,13 +460,18 @@ class ValueRegexFilter(_RegexFilter):
 
 
 class ExactValueFilter(ValueRegexFilter):
-    """Row filter for an exact value.
+    """Row filter for an exact integer value.
 
 
     :type value: bytes or str or int
     :param value:
         a literal string encodable as ASCII, or the
         equivalent bytes, or an integer (which will be packed into 8-bytes).
+
+    When passing non-integer ``value``, it must be valid RE2 patterns. See Google's
+    `RE2 reference`_ for the accepted syntax.
+
+    .. _RE2 reference: https://github.com/google/re2/wiki/Syntax
     """
 
     def __init__(self, value):


### PR DESCRIPTION
It derives from ValueRegexFilter, so it still expects a regular expression.

The name itself was a misnomer, it was mostly to handle int values rather than exact values.

For filtering on matching str/byte values, we can use the ValueRangeFilter.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-python#15327 🦕
