### PR TITLE
fix: workaround to use default deadlines

### DIFF
--- a/google/cloud/bigtable/client.py
+++ b/google/cloud/bigtable/client.py
@@ -78,7 +78,7 @@ _GRPC_CHANNEL_OPTIONS = (
 
 def _create_gapic_client(client_class, client_options=None, transport=None):
     def inner(self):
-        klass =  client_class(
+        klass = client_class(
             credentials=None,
             client_info=self._client_info,
             client_options=client_options,
@@ -99,8 +99,12 @@ def _create_gapic_client(client_class, client_options=None, transport=None):
             if name.startswith("__"):
                 continue
 
-            if m.__kwdefaults__ is not None and 'timeout' in m.__kwdefaults__ and m.__kwdefaults__['timeout'] is None:
-                m.__kwdefaults__['timeout'] = METHOD_DEFAULT
+            if (
+                m.__kwdefaults__ is not None
+                and "timeout" in m.__kwdefaults__
+                and m.__kwdefaults__["timeout"] is None
+            ):
+                m.__kwdefaults__["timeout"] = METHOD_DEFAULT
 
         return klass
 


### PR DESCRIPTION
This is a workaround for https://github.com/googleapis/gapic-generator-python/issues/1477.

The underlying gapic client in the python-bigtable has a bug that prevents it from using the default client deadlines configured in base.py. The root cause is that the gapic micro generator sets the default deadline = None in rpc method signatures. This signals to the underlying infrastructure to strip away any default deadlines.

This PR monkeypatches the method signatures to use default deadlines by default by passing in the default sentinel value 
