### PR TITLE
fix: first pass on making retry configuration more consistent

### DIFF
--- a/google/cloud/bigtable/row_data.py
+++ b/google/cloud/bigtable/row_data.py
@@ -345,7 +345,7 @@ DEFAULT_RETRY_READ_ROWS = retry.Retry(
     # NOTE: this is a soft read timeout: this limits for how long we are willing
     # to schedule retry attempts to read the next row. This does not set the
     # RPC timeout. Please use the separate overal_timeout parameter of read_rows
-    # to limit the attempt duration
+    # to limit the operation duration
     deadline=60.0,  # 60 seconds
 )
 """The default retry strategy to be used on retry-able errors.

--- a/google/cloud/bigtable/table.py
+++ b/google/cloud/bigtable/table.py
@@ -640,6 +640,11 @@ class Table(object):
         :param row_set: (Optional) The row set containing multiple row keys and
                         row_ranges.
 
+        :type attempt_timeout: float
+        :param attempt_timeout: (Optional) the attempt timeout to execute a
+                single RPC. If this attempt fails and there is overall_timeout
+                left, another attempt will be sent.
+
         :type overall_timeout: float
         :param overall_timeout: (Optional) the overall operation deadline to
                       to completely read the entire ReadRows stream.

--- a/google/cloud/bigtable/table.py
+++ b/google/cloud/bigtable/table.py
@@ -523,6 +523,7 @@ class Table(object):
         end_inclusive=False,
         row_set=None,
         retry=DEFAULT_RETRY_READ_ROWS,
+        attempt_timeout=None,
         overall_timeout=None,
     ):
         """Read rows from this table.
@@ -575,6 +576,12 @@ class Table(object):
             deadline, it will not limit how long a single attempt to read the
             next row will run. Prefer to use overall_timeout below.
 
+
+        :type attempt_timeout: float
+        :param attempt_timeout: (Optional) the attempt timeout to execute a
+                single RPC. If this attempt fails and there is overall_timeout
+                left, another attempt will be sent.
+
         :type overall_timeout: float
         :param overall_timeout: (Optional) the overall operation deadline to
                       to completely read the entire ReadRows stream.
@@ -598,6 +605,7 @@ class Table(object):
             data_client.transport.read_rows,
             request_pb,
             retry,
+            attempt_timeout=attempt_timeout,
             overall_timeout=overall_timeout,
         )
 

--- a/google/cloud/bigtable/table.py
+++ b/google/cloud/bigtable/table.py
@@ -481,7 +481,7 @@ class Table(object):
             for cluster_id, value_pb in table_pb.cluster_states.items()
         }
 
-    def read_row(self, row_key, filter_=None):
+    def read_row(self, row_key, filter_=None, overall_timeout=60):
         """Read a single row from this table.
 
         For example:
@@ -507,7 +507,9 @@ class Table(object):
         row_set = RowSet()
         row_set.add_row_key(row_key)
         result_iter = iter(
-            self.read_rows(filter_=filter_, row_set=row_set, overall_timeout=60)
+            self.read_rows(
+                filter_=filter_, row_set=row_set, overall_timeout=overall_timeout
+            )
         )
         row = next(result_iter, None)
         if next(result_iter, None) is not None:

--- a/tests/unit/test_row_data.py
+++ b/tests/unit/test_row_data.py
@@ -388,12 +388,14 @@ class TestPartialRowsData(unittest.TestCase):
         client = _Client()
         client._data_stub = mock.MagicMock()
         request = object()
-        partial_rows_data = self._make_one(client._data_stub.ReadRows, request, overall_timeout=11)
+        partial_rows_data = self._make_one(
+            client._data_stub.ReadRows, request, overall_timeout=11
+        )
         partial_rows_data.read_method.assert_called_once_with(request, timeout=mock.ANY)
 
         # the deadline being passed to the first RPC should be close to 11
         # But to avoid flakiness on slow test runners, its padded down by 3 secs
-        self.assertLess(8, partial_rows_data.read_method.call_args.kwargs['timeout'])
+        self.assertLess(8, partial_rows_data.read_method.call_args.kwargs["timeout"])
 
         self.assertIs(partial_rows_data.request, request)
         self.assertEqual(partial_rows_data.rows, {})

--- a/tests/unit/test_row_data.py
+++ b/tests/unit/test_row_data.py
@@ -384,20 +384,23 @@ class TestPartialRowsData(unittest.TestCase):
         self.assertEqual(partial_rows_data.rows, {})
         self.assertEqual(partial_rows_data.retry, DEFAULT_RETRY_READ_ROWS)
 
-    def test_constructor_with_retry(self):
-        from google.cloud.bigtable.row_data import DEFAULT_RETRY_READ_ROWS
-
+    def test_constructor_with_overall_timeout(self):
         client = _Client()
         client._data_stub = mock.MagicMock()
         request = object()
-        retry = DEFAULT_RETRY_READ_ROWS
-        partial_rows_data = self._make_one(client._data_stub.ReadRows, request, retry)
-        partial_rows_data.read_method.assert_called_once_with(
-            request, timeout=DEFAULT_RETRY_READ_ROWS.deadline + 1
-        )
+        partial_rows_data = self._make_one(client._data_stub.ReadRows, request, overall_timeout=11)
+        partial_rows_data.read_method.assert_called_once_with(request, timeout=mock.ANY)
+
+        # the deadline being passed to the first RPC should be close to 11
+        # But to avoid flakiness on slow test runners, its padded down by 3 secs
+        self.assertLess(8, partial_rows_data.read_method.call_args.kwargs['timeout'])
+
         self.assertIs(partial_rows_data.request, request)
         self.assertEqual(partial_rows_data.rows, {})
-        self.assertEqual(partial_rows_data.retry, retry)
+        # The remaining deadline should be
+        # But to avoid flakiness on slow test runners, its padded down by 3 secs
+        self.assertLess(8, partial_rows_data.remaining_overall_timeout)
+        self.assertLessEqual(partial_rows_data.remaining_overall_timeout, 11)
 
     def test___eq__(self):
         client = _Client()

--- a/tests/unit/test_row_data.py
+++ b/tests/unit/test_row_data.py
@@ -393,8 +393,9 @@ class TestPartialRowsData(unittest.TestCase):
         )
         partial_rows_data.read_method.assert_called_once_with(request, timeout=mock.ANY)
 
-        # the deadline being passed to the first RPC should be close to 11
-        # But to avoid flakiness on slow test runners, its padded down by 3 secs
+        # the deadline being passed to the first RPC should be slightly less
+        # than 11. But to avoid flakiness on slow test runners, its padded down
+        # by 3 secs
         self.assertLess(8, partial_rows_data.read_method.call_args.kwargs["timeout"])
 
         self.assertIs(partial_rows_data.request, request)

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -887,6 +887,8 @@ class TestTable(unittest.TestCase):
             side_effect=[_MockReadRowsIterator()]
         )
         list(table.read_rows(overall_timeout=10.0))
+        # The RPC timeout should be slightly less than 10.0 but to avoid test
+        # flakiness its padded by a couple of secs.
         self.assertLess(
             8.0,
             client._table_data_client.transport.read_rows.call_args.kwargs["timeout"],
@@ -914,6 +916,7 @@ class TestTable(unittest.TestCase):
             side_effect=[DelayedFailureIterator(), _MockReadRowsIterator()]
         )
         list(table.read_rows(attempt_timeout=1.0, overall_timeout=1.0))
+
         self.assertGreater(
             1.0,
             client._table_data_client.transport.read_rows.call_args.kwargs["timeout"],

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -797,7 +797,6 @@ class TestTable(unittest.TestCase):
 
     def test_read_retry_rows(self):
         from google.cloud.bigtable_v2.gapic import bigtable_client
-        from google.cloud.bigtable_admin_v2.gapic import bigtable_table_admin_client
         from google.api_core import retry
 
         data_api = bigtable_client.BigtableClient(mock.Mock())
@@ -854,7 +853,6 @@ class TestTable(unittest.TestCase):
 
     def test_read_retry_rows_timeouts(self):
         from google.cloud.bigtable_v2.gapic import bigtable_client
-        from google.api_core import retry
 
         data_api = bigtable_client.BigtableClient(mock.Mock())
         credentials = _make_credentials()


### PR DESCRIPTION
Currently ReadRows uses the Retry.deadline configuration inconsistently:
- its used as the attempt timeout for the first retry attempt
- its used as a limit for retry scheduling for reading a single row

Conceptually there are 3 timeouts that are relevant to ReadRows:
- attempt timeout: how long a single RPC is allowed to run, this should map directly to a gRPC deadline
- overall timeout: Limit how long we should wait across all of the retry attempts, possibly truncating the last attempt timeout.
- read timeout: How long we are willing to wait for the next row in a stream

Ideally Retry.deadline would represent an operation deadline (since thats the primary concern of the end user). However there is no backwards compatible way to do this. Changing the behavior would cause existing application to start enforcing a very short deadline.

This PR tries to improve the situation in a backwards compatible way:
- keep Retry.deadline as a read timeout
- introduce a new parameter for overall timeout

This results in less than ideal api, but avoids breaking existing applications.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
