### PR TITLE
fix: make sure that the proper exception type is bubbled up for ReadRows

### DIFF
--- a/google/cloud/bigtable/row_data.py
+++ b/google/cloud/bigtable/row_data.py
@@ -330,8 +330,6 @@ class InvalidChunk(RuntimeError):
 
 
 def _retry_read_rows_exception(exc):
-    if isinstance(exc, grpc.RpcError):
-        exc = exceptions.from_grpc_error(exc)
     return isinstance(exc, (exceptions.ServiceUnavailable, exceptions.DeadlineExceeded))
 
 
@@ -467,7 +465,10 @@ class PartialRowsData(object):
 
     def _read_next(self):
         """Helper for :meth:`__iter__`."""
-        return six.next(self.response_iterator)
+        try:
+            return six.next(self.response_iterator)
+        except grpc.RpcError as grpc_error:
+            raise exceptions.from_grpc_error(grpc_error)
 
     def _read_next_response(self):
         """Helper for :meth:`__iter__`."""

--- a/tests/unit/test_row_data.py
+++ b/tests/unit/test_row_data.py
@@ -336,20 +336,6 @@ class Test_retry_read_rows_exception(unittest.TestCase):
         exception = self._make_grpc_call_error(wrapped)
         self.assertFalse(self._call_fut(exception))
 
-    def test_w_service_unavailable_wrapped_in_grpc(self):
-        from google.api_core.exceptions import ServiceUnavailable
-
-        wrapped = ServiceUnavailable("testing")
-        exception = self._make_grpc_call_error(wrapped)
-        self.assertTrue(self._call_fut(exception))
-
-    def test_w_deadline_exceeded_wrapped_in_grpc(self):
-        from google.api_core.exceptions import DeadlineExceeded
-
-        wrapped = DeadlineExceeded("testing")
-        exception = self._make_grpc_call_error(wrapped)
-        self.assertTrue(self._call_fut(exception))
-
 
 class TestPartialRowsData(unittest.TestCase):
     ROW_KEY = b"row-key"


### PR DESCRIPTION
ReadRows (in client 1.x) bypasses gapic layer and use the raw grpc stubs. Which means that the errors are not being wrapped. Previously the this conversion would be handled in the Retry predicate, however this creates usability issues for end users that are trying to change the exceptions they want to retry on. This PR moves the wrapping a bit lower

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
