### PR TITLE
feat: read rows query model class

### DIFF
--- a/google/cloud/bigtable/__init__.py
+++ b/google/cloud/bigtable/__init__.py
@@ -22,6 +22,7 @@ from google.cloud.bigtable.client import BigtableDataClient
 from google.cloud.bigtable.client import Table
 
 from google.cloud.bigtable.read_rows_query import ReadRowsQuery
+from google.cloud.bigtable.read_rows_query import RowRange
 from google.cloud.bigtable.row_response import RowResponse
 from google.cloud.bigtable.row_response import CellResponse
 
@@ -43,6 +44,7 @@ __all__ = (
     "Table",
     "RowKeySamples",
     "ReadRowsQuery",
+    "RowRange",
     "MutationsBatcher",
     "Mutation",
     "BulkMutationsEntry",

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -196,10 +196,7 @@ class ReadRowsQuery:
               Can be a RowRange object or a dict representation in
               RowRange proto format
         """
-        if not (
-            isinstance(row_range, dict)
-            or isinstance(row_range, RowRange)
-        ):
+        if not (isinstance(row_range, dict) or isinstance(row_range, RowRange)):
             raise ValueError("row_range must be a RowRange or dict")
         self.row_ranges.append(row_range)
 

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -70,6 +70,17 @@ class RowRange:
             else None
         )
 
+    def _to_dict(self) -> dict[str, bytes]:
+        """Converts this object to a dictionary"""
+        output = {}
+        if self.start is not None:
+            key = "start_key_closed" if self.start.is_inclusive else "start_key_open"
+            output[key] = self.start.key
+        if self.end is not None:
+            key = "end_key_closed" if self.end.is_inclusive else "end_key_open"
+            output[key] = self.end.key
+        return output
+
 class ReadRowsQuery:
     """
     Class to encapsulate details of a read row request
@@ -77,7 +88,7 @@ class ReadRowsQuery:
 
     def __init__(
         self,
-        row_key: list[str | bytes] | str | bytes | None = None,
+        row_keys: list[str | bytes] | str | bytes | None = None,
         row_ranges: list[RowRange] | RowRange | None = None,
         limit: int | None = None,
         row_filter: RowFilter | dict[str, Any] | None = None,
@@ -197,21 +208,12 @@ class ReadRowsQuery:
         """
         raise NotImplementedError
 
-    def to_dict(self) -> dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         """
         Convert this query into a dictionary that can be used to construct a
         ReadRowsRequest protobuf
         """
-        ranges = []
-        for start, end in self.row_ranges:
-            new_range = {}
-            if start is not None:
-                key = "start_key_closed" if start.is_inclusive else "start_key_open"
-                new_range[key] = start.key
-            if end is not None:
-                key = "end_key_closed" if end.is_inclusive else "end_key_open"
-                new_range[key] = end.key
-            ranges.append(new_range)
+        ranges = [r._to_dict() for r in self.row_ranges]
         row_keys = list(self.row_keys)
         row_keys.sort()
         row_set = {"row_keys": row_keys, "row_ranges": ranges}

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -115,6 +115,10 @@ class ReadRowsQuery:
         self.filter: RowFilter | dict[str, Any] = row_filter
 
     @property
+    def limit(self) -> int | None:
+        return self._limit
+
+    @property.setter
     def limit(self, new_limit: int | None):
         """
         Set the maximum number of rows to return by this query.
@@ -133,6 +137,10 @@ class ReadRowsQuery:
         self._limit = new_limit
 
     @property
+    def filter(self) -> RowFilter | dict[str, Any]:
+        return self._filter
+
+    @property.setter
     def filter(
         self, row_filter: RowFilter | dict[str, Any] | None
     ):

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -25,8 +25,10 @@ if TYPE_CHECKING:
 @dataclass
 class _RangePoint:
     """Model class for a point in a row range"""
+
     key: row_key
     is_inclusive: bool
+
 
 @dataclass
 class RowRange:
@@ -65,9 +67,7 @@ class RowRange:
             else None
         )
         self.end = (
-            _RangePoint(end_key, end_is_inclusive)
-            if end_key is not None
-            else None
+            _RangePoint(end_key, end_is_inclusive) if end_key is not None else None
         )
 
     def _to_dict(self) -> dict[str, bytes]:
@@ -80,6 +80,7 @@ class RowRange:
             key = "end_key_closed" if self.end.is_inclusive else "end_key_open"
             output[key] = self.end.key
         return output
+
 
 class ReadRowsQuery:
     """
@@ -117,7 +118,7 @@ class ReadRowsQuery:
             for k in row_keys:
                 self.add_key(k)
         self.limit: int | None = limit
-        self.filter: RowFilter | dict[str, Any] = row_filter
+        self.filter: RowFilter | dict[str, Any] | None = row_filter
 
     @property
     def limit(self) -> int | None:
@@ -142,13 +143,11 @@ class ReadRowsQuery:
         self._limit = new_limit
 
     @property
-    def filter(self) -> RowFilter | dict[str, Any]:
+    def filter(self) -> RowFilter | dict[str, Any] | None:
         return self._filter
 
     @filter.setter
-    def filter(
-        self, row_filter: RowFilter | dict[str, Any] | None
-    ):
+    def filter(self, row_filter: RowFilter | dict[str, Any] | None):
         """
         Set a RowFilter to apply to this query
 
@@ -200,7 +199,6 @@ class ReadRowsQuery:
         if not (
             isinstance(row_range, dict)
             or isinstance(row_range, RowRange)
-            or row_range is None
         ):
             raise ValueError("row_range must be a RowRange or dict")
         self.row_ranges.append(row_range)

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -13,11 +13,20 @@
 # limitations under the License.
 #
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+from .row_response import row_key
+from dataclasses import dataclass
+from google.cloud.bigtable.row_filters import RowFilter
 
 if TYPE_CHECKING:
-    from google.cloud.bigtable.row_filters import RowFilter
     from google.cloud.bigtable import RowKeySamples
+
+
+@dataclass
+class _RangePoint:
+    # model class for a point in a row range
+    key: row_key
+    is_inclusive: bool
 
 
 class ReadRowsQuery:
@@ -26,23 +35,140 @@ class ReadRowsQuery:
     """
 
     def __init__(
-        self, row_keys: list[str | bytes] | str | bytes | None = None, limit=None
+        self,
+        row_keys: list[str | bytes] | str | bytes | None = None,
+        limit: int | None = None,
+        row_filter: RowFilter | dict[str, Any] | None = None,
     ):
-        pass
+        """
+        Create a new ReadRowsQuery
 
-    def set_limit(self, limit: int) -> ReadRowsQuery:
-        raise NotImplementedError
+        Args:
+          - row_keys: a list of row keys to include in the query
+          - limit: the maximum number of rows to return. None or 0 means no limit
+                default: None (no limit)
+          - row_filter: a RowFilter to apply to the query
+        """
+        self.row_keys: set[bytes] = set()
+        self.row_ranges: list[tuple[_RangePoint | None, _RangePoint | None]] = []
+        if row_keys:
+            self.add_rows(row_keys)
+        self.limit: int | None = limit
+        self.filter: RowFilter | dict[str, Any] = row_filter
 
-    def set_filter(self, filter: "RowFilter") -> ReadRowsQuery:
-        raise NotImplementedError
+    def set_limit(self, new_limit: int | None):
+        """
+        Set the maximum number of rows to return by this query.
 
-    def add_rows(self, row_id_list: list[str]) -> ReadRowsQuery:
-        raise NotImplementedError
+        None or 0 means no limit
+
+        Args:
+          - new_limit: the new limit to apply to this query
+        Returns:
+          - a reference to this query for chaining
+        Raises:
+          - ValueError if new_limit is < 0
+        """
+        if new_limit is not None and new_limit < 0:
+            raise ValueError("limit must be >= 0")
+        self._limit = new_limit
+        return self
+
+    def set_filter(
+        self, row_filter: RowFilter | dict[str, Any] | None
+    ) -> ReadRowsQuery:
+        """
+        Set a RowFilter to apply to this query
+
+        Args:
+          - row_filter: a RowFilter to apply to this query
+              Can be a RowFilter object or a dict representation
+        Returns:
+          - a reference to this query for chaining
+        """
+        if not (
+            isinstance(row_filter, dict)
+            or isinstance(row_filter, RowFilter)
+            or row_filter is None
+        ):
+            raise ValueError(
+                "row_filter must be a RowFilter or corresponding dict representation"
+            )
+        self._filter = row_filter
+        return self
+
+    def add_rows(self, row_keys: list[str | bytes] | str | bytes) -> ReadRowsQuery:
+        """
+        Add a list of row keys to this query
+
+        Args:
+          - row_keys: a list of row keys to add to this query
+        Returns:
+          - a reference to this query for chaining
+        Raises:
+          - ValueError if an input is not a string or bytes
+        """
+        if not isinstance(row_keys, list):
+            row_keys = [row_keys]
+        update_set = set()
+        for k in row_keys:
+            if isinstance(k, str):
+                k = k.encode()
+            elif not isinstance(k, bytes):
+                raise ValueError("row_keys must be strings or bytes")
+            update_set.add(k)
+        self.row_keys.update(update_set)
+        return self
 
     def add_range(
-        self, start_key: str | bytes | None = None, end_key: str | bytes | None = None
+        self,
+        start_key: str | bytes | None = None,
+        end_key: str | bytes | None = None,
+        start_is_inclusive: bool | None = None,
+        end_is_inclusive: bool | None = None,
     ) -> ReadRowsQuery:
-        raise NotImplementedError
+        """
+        Add a range of row keys to this query.
+
+        Args:
+          - start_key: the start of the range
+              if None, start_key is interpreted as the empty string, inclusive
+          - end_key: the end of the range
+              if None, end_key is interpreted as the infinite row key, exclusive
+          - start_is_inclusive: if True, the start key is included in the range
+              defaults to True if None. Must not be included if start_key is None
+          - end_is_inclusive: if True, the end key is included in the range
+              defaults to False if None. Must not be included if end_key is None
+        """
+        # check for invalid combinations of arguments
+        if start_is_inclusive is None:
+            start_is_inclusive = True
+        elif start_key is None:
+            raise ValueError(
+                "start_is_inclusive must not be included if start_key is None"
+            )
+        if end_is_inclusive is None:
+            end_is_inclusive = False
+        elif end_key is None:
+            raise ValueError("end_is_inclusive must not be included if end_key is None")
+        # ensure that start_key and end_key are bytes
+        if isinstance(start_key, str):
+            start_key = start_key.encode()
+        elif start_key is not None and not isinstance(start_key, bytes):
+            raise ValueError("start_key must be a string or bytes")
+        if isinstance(end_key, str):
+            end_key = end_key.encode()
+        elif end_key is not None and not isinstance(end_key, bytes):
+            raise ValueError("end_key must be a string or bytes")
+
+        start_pt = (
+            _RangePoint(start_key, start_is_inclusive)
+            if start_key is not None
+            else None
+        )
+        end_pt = _RangePoint(end_key, end_is_inclusive) if end_key is not None else None
+        self.row_ranges.append((start_pt, end_pt))
+        return self
 
     def shard(self, shard_keys: "RowKeySamples" | None = None) -> list[ReadRowsQuery]:
         """
@@ -54,3 +180,63 @@ class ReadRowsQuery:
               query (if possible)
         """
         raise NotImplementedError
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert this query into a dictionary that can be used to construct a
+        ReadRowsRequest protobuf
+        """
+        ranges = []
+        for start, end in self.row_ranges:
+            new_range = {}
+            if start is not None:
+                key = "start_key_closed" if start.is_inclusive else "start_key_open"
+                new_range[key] = start.key
+            if end is not None:
+                key = "end_key_closed" if end.is_inclusive else "end_key_open"
+                new_range[key] = end.key
+            ranges.append(new_range)
+        row_keys = list(self.row_keys)
+        row_keys.sort()
+        row_set = {"row_keys": row_keys, "row_ranges": ranges}
+        final_dict: dict[str, Any] = {
+            "rows": row_set,
+        }
+        dict_filter = (
+            self.filter.to_dict() if isinstance(self.filter, RowFilter) else self.filter
+        )
+        if dict_filter:
+            final_dict["filter"] = dict_filter
+        if self.limit is not None:
+            final_dict["rows_limit"] = self.limit
+        return final_dict
+
+    # Support limit and filter as properties
+
+    @property
+    def limit(self) -> int | None:
+        """
+        Getter implementation for limit property
+        """
+        return self._limit
+
+    @limit.setter
+    def limit(self, new_limit: int | None):
+        """
+        Setter implementation for limit property
+        """
+        self.set_limit(new_limit)
+
+    @property
+    def filter(self):
+        """
+        Getter implemntation for filter property
+        """
+        return self._filter
+
+    @filter.setter
+    def filter(self, row_filter: RowFilter | dict[str, Any] | None):
+        """
+        Setter implementation for filter property
+        """
+        self.set_filter(row_filter)

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -192,6 +192,12 @@ class ReadRowsQuery:
               Can be a RowRange object or a dict representation in
               RowRange proto format
         """
+        if not (
+            isinstance(row_range, dict)
+            or isinstance(row_range, RowRange)
+            or row_range is None
+        ):
+            raise ValueError("row_range must be a RowRange or dict")
         self.row_ranges.append(row_range)
 
     def shard(self, shard_keys: "RowKeySamples" | None = None) -> list[ReadRowsQuery]:

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -29,12 +29,13 @@ class _RangePoint:
     is_inclusive: bool
 
 @dataclass
-class RowRange
+class RowRange:
     start: _RangePoint | None
     end: _RangePoint | None
 
-    def __init__(self,
-        start_key: str | bytes | None = None, 
+    def __init__(
+        self,
+        start_key: str | bytes | None = None,
         end_key: str | bytes | None = None,
         start_is_inclusive: bool | None = None,
         end_is_inclusive: bool | None = None,
@@ -102,7 +103,8 @@ class ReadRowsQuery:
         self.limit: int | None = limit
         self.filter: RowFilter | dict[str, Any] = row_filter
 
-    def set_limit(self, new_limit: int | None):
+    @property
+    def limit(self, new_limit: int | None):
         """
         Set the maximum number of rows to return by this query.
 
@@ -118,11 +120,11 @@ class ReadRowsQuery:
         if new_limit is not None and new_limit < 0:
             raise ValueError("limit must be >= 0")
         self._limit = new_limit
-        return self
 
-    def set_filter(
+    @property
+    def filter(
         self, row_filter: RowFilter | dict[str, Any] | None
-    ) -> ReadRowsQuery:
+    ):
         """
         Set a RowFilter to apply to this query
 
@@ -139,9 +141,8 @@ class ReadRowsQuery:
         ):
             raise ValueError("row_filter must be a RowFilter or dict")
         self._filter = row_filter
-        return self
 
-    def add_key(self, row_key: str | bytes) -> ReadRowsQuery:
+    def add_key(self, row_key: str | bytes):
         """
         Add a row key to this query
 
@@ -159,7 +160,6 @@ class ReadRowsQuery:
         elif not isinstance(row_key, bytes):
             raise ValueError("row_key must be string or bytes")
         self.row_keys.add(row_key)
-        return self
 
     def add_range(
         self,
@@ -167,7 +167,7 @@ class ReadRowsQuery:
         end_key: str | bytes | None = None,
         start_is_inclusive: bool | None = None,
         end_is_inclusive: bool | None = None,
-    ) -> ReadRowsQuery:
+    ):
         """
         Add a range of row keys to this query.
 
@@ -185,7 +185,6 @@ class ReadRowsQuery:
             start_key, end_key, start_is_inclusive, end_is_inclusive
         )
         self.row_ranges.append(new_range)
-        return self
 
     def shard(self, shard_keys: "RowKeySamples" | None = None) -> list[ReadRowsQuery]:
         """
@@ -227,33 +226,3 @@ class ReadRowsQuery:
         if self.limit is not None:
             final_dict["rows_limit"] = self.limit
         return final_dict
-
-    # Support limit and filter as properties
-
-    @property
-    def limit(self) -> int | None:
-        """
-        Getter implementation for limit property
-        """
-        return self._limit
-
-    @limit.setter
-    def limit(self, new_limit: int | None):
-        """
-        Setter implementation for limit property
-        """
-        self.set_limit(new_limit)
-
-    @property
-    def filter(self):
-        """
-        Getter implementation for filter property
-        """
-        return self._filter
-
-    @filter.setter
-    def filter(self, row_filter: RowFilter | dict[str, Any] | None):
-        """
-        Setter implementation for filter property
-        """
-        self.set_filter(row_filter)

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -146,7 +146,7 @@ class ReadRowsQuery:
         if end_is_inclusive is None:
             end_is_inclusive = False
         elif end_key is None:
-            raise ValueError("end_is_inclusive must not be set without end_key")
+            raise ValueError("end_is_inclusive must be set with end_key")
         # ensure that start_key and end_key are bytes
         if isinstance(start_key, str):
             start_key = start_key.encode()

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -91,9 +91,7 @@ class ReadRowsQuery:
             or isinstance(row_filter, RowFilter)
             or row_filter is None
         ):
-            raise ValueError(
-                "row_filter must be a RowFilter or corresponding dict representation"
-            )
+            raise ValueError("row_filter must be a RowFilter or dict")
         self._filter = row_filter
         return self
 
@@ -144,13 +142,11 @@ class ReadRowsQuery:
         if start_is_inclusive is None:
             start_is_inclusive = True
         elif start_key is None:
-            raise ValueError(
-                "start_is_inclusive must not be included if start_key is None"
-            )
+            raise ValueError("start_is_inclusive must not be set without start_key")
         if end_is_inclusive is None:
             end_is_inclusive = False
         elif end_key is None:
-            raise ValueError("end_is_inclusive must not be included if end_key is None")
+            raise ValueError("end_is_inclusive must not be set without end_key")
         # ensure that start_key and end_key are bytes
         if isinstance(start_key, str):
             start_key = start_key.encode()

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -91,7 +91,7 @@ class ReadRowsQuery:
         row_keys: list[str | bytes] | str | bytes | None = None,
         row_ranges: list[RowRange] | RowRange | None = None,
         limit: int | None = None,
-        row_filter: RowFilter | dict[str, Any] | None = None,
+        row_filter: RowFilter | None = None,
     ):
         """
         Create a new ReadRowsQuery
@@ -105,10 +105,15 @@ class ReadRowsQuery:
           - row_filter: a RowFilter to apply to the query
         """
         self.row_keys: set[bytes] = set()
-        self.row_ranges: list[RowRange] = []
-        for range in row_ranges:
-            self.row_ranges.append(range)
+        self.row_ranges: list[RowRange | dict[str, bytes]] = []
+        if row_ranges:
+            if isinstance(row_ranges, RowRange):
+                row_ranges = [row_ranges]
+            for r in row_ranges:
+                self.add_range(r)
         if row_keys:
+            if not isinstance(row_keys, list):
+                row_keys = [row_keys]
             for k in row_keys:
                 self.add_key(k)
         self.limit: int | None = limit
@@ -118,7 +123,7 @@ class ReadRowsQuery:
     def limit(self) -> int | None:
         return self._limit
 
-    @property.setter
+    @limit.setter
     def limit(self, new_limit: int | None):
         """
         Set the maximum number of rows to return by this query.
@@ -140,7 +145,7 @@ class ReadRowsQuery:
     def filter(self) -> RowFilter | dict[str, Any]:
         return self._filter
 
-    @property.setter
+    @filter.setter
     def filter(
         self, row_filter: RowFilter | dict[str, Any] | None
     ):

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class _RangePoint:
-    # model class for a point in a row range
+    """Model class for a point in a row range"""
     key: row_key
     is_inclusive: bool
 

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -142,7 +142,7 @@ class ReadRowsQuery:
         if start_is_inclusive is None:
             start_is_inclusive = True
         elif start_key is None:
-            raise ValueError("start_is_inclusive must not be set without start_key")
+            raise ValueError("start_is_inclusive must be set with start_key")
         if end_is_inclusive is None:
             end_is_inclusive = False
         elif end_key is None:

--- a/google/cloud/bigtable/row_filters.py
+++ b/google/cloud/bigtable/row_filters.py
@@ -35,6 +35,14 @@ class RowFilter(object):
         This class is a do-nothing base class for all row filters.
     """
 
+    def to_dict(self):
+        """Convert the filter to a dictionary.
+
+        :rtype: dict
+        :returns: The dictionary representation of this filter.
+        """
+        raise NotImplementedError
+
 
 class _BoolFilter(RowFilter):
     """Row filter that uses a boolean flag.

--- a/tests/unit/test_read_rows_query.py
+++ b/tests/unit/test_read_rows_query.py
@@ -1,0 +1,284 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+TEST_ROWS = [
+    "row_key_1",
+    b"row_key_2",
+]
+
+
+class TestReadRowsQuery(unittest.TestCase):
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigtable.read_rows_query import ReadRowsQuery
+
+        return ReadRowsQuery
+
+    def _make_one(self, *args, **kwargs):
+        return self._get_target_class()(*args, **kwargs)
+
+    def test_ctor_defaults(self):
+        query = self._make_one()
+        self.assertEqual(query.row_keys, set())
+        self.assertEqual(query.row_ranges, [])
+        self.assertEqual(query.filter, None)
+        self.assertEqual(query.limit, None)
+
+    def test_ctor_explicit(self):
+        from google.cloud.bigtable.row_filters import RowFilterChain
+
+        filter_ = RowFilterChain()
+        query = self._make_one(["row_key_1", "row_key_2"], limit=10, row_filter=filter_)
+        self.assertEqual(len(query.row_keys), 2)
+        self.assertIn("row_key_1".encode(), query.row_keys)
+        self.assertIn("row_key_2".encode(), query.row_keys)
+        self.assertEqual(query.row_ranges, [])
+        self.assertEqual(query.filter, filter_)
+        self.assertEqual(query.limit, 10)
+
+    def test_ctor_invalid_limit(self):
+        with self.assertRaises(ValueError):
+            self._make_one(limit=-1)
+
+    def test_set_filter(self):
+        from google.cloud.bigtable.row_filters import RowFilterChain
+
+        filter1 = RowFilterChain()
+        query = self._make_one()
+        self.assertEqual(query.filter, None)
+        result = query.set_filter(filter1)
+        self.assertEqual(query.filter, filter1)
+        self.assertEqual(result, query)
+        filter2 = RowFilterChain()
+        result = query.set_filter(filter2)
+        self.assertEqual(query.filter, filter2)
+        result = query.set_filter(None)
+        self.assertEqual(query.filter, None)
+        self.assertEqual(result, query)
+        query.filter = RowFilterChain()
+        self.assertEqual(query.filter, RowFilterChain())
+        with self.assertRaises(ValueError):
+            query.filter = 1
+
+    def test_set_filter_dict(self):
+        from google.cloud.bigtable.row_filters import RowSampleFilter
+        from google.cloud.bigtable_v2.types.bigtable import ReadRowsRequest
+
+        filter1 = RowSampleFilter(0.5)
+        filter1_dict = filter1.to_dict()
+        query = self._make_one()
+        self.assertEqual(query.filter, None)
+        result = query.set_filter(filter1_dict)
+        self.assertEqual(query.filter, filter1_dict)
+        self.assertEqual(result, query)
+        output = query.to_dict()
+        self.assertEqual(output["filter"], filter1_dict)
+        proto_output = ReadRowsRequest(**output)
+        self.assertEqual(proto_output.filter, filter1.to_pb())
+
+        query.filter = None
+        self.assertEqual(query.filter, None)
+
+    def test_set_limit(self):
+        query = self._make_one()
+        self.assertEqual(query.limit, None)
+        result = query.set_limit(10)
+        self.assertEqual(query.limit, 10)
+        self.assertEqual(result, query)
+        query.limit = 9
+        self.assertEqual(query.limit, 9)
+        result = query.set_limit(0)
+        self.assertEqual(query.limit, 0)
+        self.assertEqual(result, query)
+        with self.assertRaises(ValueError):
+            query.set_limit(-1)
+        with self.assertRaises(ValueError):
+            query.limit = -100
+
+    def test_add_rows_str(self):
+        query = self._make_one()
+        self.assertEqual(query.row_keys, set())
+        input_str = "test_row"
+        result = query.add_rows(input_str)
+        self.assertEqual(len(query.row_keys), 1)
+        self.assertIn(input_str.encode(), query.row_keys)
+        self.assertEqual(result, query)
+        input_str2 = "test_row2"
+        result = query.add_rows(input_str2)
+        self.assertEqual(len(query.row_keys), 2)
+        self.assertIn(input_str.encode(), query.row_keys)
+        self.assertIn(input_str2.encode(), query.row_keys)
+        self.assertEqual(result, query)
+
+    def test_add_rows_bytes(self):
+        query = self._make_one()
+        self.assertEqual(query.row_keys, set())
+        input_bytes = b"test_row"
+        result = query.add_rows(input_bytes)
+        self.assertEqual(len(query.row_keys), 1)
+        self.assertIn(input_bytes, query.row_keys)
+        self.assertEqual(result, query)
+        input_bytes2 = b"test_row2"
+        result = query.add_rows(input_bytes2)
+        self.assertEqual(len(query.row_keys), 2)
+        self.assertIn(input_bytes, query.row_keys)
+        self.assertIn(input_bytes2, query.row_keys)
+        self.assertEqual(result, query)
+
+    def test_add_rows_batch(self):
+        query = self._make_one()
+        self.assertEqual(query.row_keys, set())
+        input_batch = ["test_row", b"test_row2", "test_row3"]
+        result = query.add_rows(input_batch)
+        self.assertEqual(len(query.row_keys), 3)
+        self.assertIn(b"test_row", query.row_keys)
+        self.assertIn(b"test_row2", query.row_keys)
+        self.assertIn(b"test_row3", query.row_keys)
+        self.assertEqual(result, query)
+        # test adding another batch
+        query.add_rows(["test_row4", b"test_row5"])
+        self.assertEqual(len(query.row_keys), 5)
+        self.assertIn(input_batch[0].encode(), query.row_keys)
+        self.assertIn(input_batch[1], query.row_keys)
+        self.assertIn(input_batch[2].encode(), query.row_keys)
+        self.assertIn(b"test_row4", query.row_keys)
+        self.assertIn(b"test_row5", query.row_keys)
+
+    def test_add_rows_invalid(self):
+        query = self._make_one()
+        with self.assertRaises(ValueError):
+            query.add_rows(1)
+        with self.assertRaises(ValueError):
+            query.add_rows(["s", 0])
+
+    def test_duplicate_rows(self):
+        # should only hold one of each input key
+        key_1 = b"test_row"
+        key_2 = b"test_row2"
+        query = self._make_one(row_keys=[key_1, key_1, key_2])
+        self.assertEqual(len(query.row_keys), 2)
+        self.assertIn(key_1, query.row_keys)
+        self.assertIn(key_2, query.row_keys)
+        key_3 = "test_row3"
+        query.add_rows([key_3 for _ in range(10)])
+        self.assertEqual(len(query.row_keys), 3)
+
+    def test_add_range(self):
+        # test with start and end keys
+        query = self._make_one()
+        self.assertEqual(query.row_ranges, [])
+        result = query.add_range("test_row", "test_row2")
+        self.assertEqual(len(query.row_ranges), 1)
+        self.assertEqual(query.row_ranges[0][0].key, "test_row".encode())
+        self.assertEqual(query.row_ranges[0][1].key, "test_row2".encode())
+        self.assertEqual(query.row_ranges[0][0].is_inclusive, True)
+        self.assertEqual(query.row_ranges[0][1].is_inclusive, False)
+        self.assertEqual(result, query)
+        # test with start key only
+        result = query.add_range("test_row3")
+        self.assertEqual(len(query.row_ranges), 2)
+        self.assertEqual(query.row_ranges[1][0].key, "test_row3".encode())
+        self.assertEqual(query.row_ranges[1][1], None)
+        self.assertEqual(result, query)
+        # test with end key only
+        result = query.add_range(start_key=None, end_key="test_row5")
+        self.assertEqual(len(query.row_ranges), 3)
+        self.assertEqual(query.row_ranges[2][0], None)
+        self.assertEqual(query.row_ranges[2][1].key, "test_row5".encode())
+        self.assertEqual(query.row_ranges[2][1].is_inclusive, False)
+        # test with start and end keys and inclusive flags
+        result = query.add_range(b"test_row6", b"test_row7", False, True)
+        self.assertEqual(len(query.row_ranges), 4)
+        self.assertEqual(query.row_ranges[3][0].key, b"test_row6")
+        self.assertEqual(query.row_ranges[3][1].key, b"test_row7")
+        self.assertEqual(query.row_ranges[3][0].is_inclusive, False)
+        self.assertEqual(query.row_ranges[3][1].is_inclusive, True)
+        # test with nothing passed
+        result = query.add_range()
+        self.assertEqual(len(query.row_ranges), 5)
+        self.assertEqual(query.row_ranges[4][0], None)
+        self.assertEqual(query.row_ranges[4][1], None)
+        # test with inclusive flags only
+        with self.assertRaises(ValueError):
+            query.add_range(start_is_inclusive=True, end_is_inclusive=True)
+        with self.assertRaises(ValueError):
+            query.add_range(start_is_inclusive=False, end_is_inclusive=False)
+        with self.assertRaises(ValueError):
+            query.add_range(start_is_inclusive=False)
+        with self.assertRaises(ValueError):
+            query.add_range(end_is_inclusive=True)
+
+    def test_to_dict_rows_default(self):
+        # dictionary should be in rowset proto format
+        from google.cloud.bigtable_v2.types.bigtable import ReadRowsRequest
+
+        query = self._make_one()
+        output = query.to_dict()
+        self.assertTrue(isinstance(output, dict))
+        self.assertEqual(len(output.keys()), 1)
+        expected = {"rows": {"row_keys": [], "row_ranges": []}}
+        self.assertEqual(output, expected)
+
+        request_proto = ReadRowsRequest(**output)
+        self.assertEqual(request_proto.rows.row_keys, [])
+        self.assertEqual(request_proto.rows.row_ranges, [])
+        self.assertFalse(request_proto.filter)
+        self.assertEqual(request_proto.rows_limit, 0)
+
+    def test_to_dict_rows_populated(self):
+        # dictionary should be in rowset proto format
+        from google.cloud.bigtable_v2.types.bigtable import ReadRowsRequest
+        from google.cloud.bigtable.row_filters import PassAllFilter
+
+        row_filter = PassAllFilter(False)
+        query = self._make_one(limit=100, row_filter=row_filter)
+        query.add_range("test_row", "test_row2")
+        query.add_range("test_row3")
+        query.add_range(start_key=None, end_key="test_row5")
+        query.add_range(b"test_row6", b"test_row7", False, True)
+        query.add_range()
+        query.add_rows(["test_row", b"test_row2", "test_row3"])
+        query.add_rows(["test_row3", b"test_row4"])
+        output = query.to_dict()
+        self.assertTrue(isinstance(output, dict))
+        request_proto = ReadRowsRequest(**output)
+        rowset_proto = request_proto.rows
+        # check rows
+        self.assertEqual(len(rowset_proto.row_keys), 4)
+        self.assertEqual(rowset_proto.row_keys[0], b"test_row")
+        self.assertEqual(rowset_proto.row_keys[1], b"test_row2")
+        self.assertEqual(rowset_proto.row_keys[2], b"test_row3")
+        self.assertEqual(rowset_proto.row_keys[3], b"test_row4")
+        # check ranges
+        self.assertEqual(len(rowset_proto.row_ranges), 5)
+        self.assertEqual(rowset_proto.row_ranges[0].start_key_closed, b"test_row")
+        self.assertEqual(rowset_proto.row_ranges[0].end_key_open, b"test_row2")
+        self.assertEqual(rowset_proto.row_ranges[1].start_key_closed, b"test_row3")
+        self.assertEqual(rowset_proto.row_ranges[1].end_key_open, b"")
+        self.assertEqual(rowset_proto.row_ranges[2].start_key_closed, b"")
+        self.assertEqual(rowset_proto.row_ranges[2].end_key_open, b"test_row5")
+        self.assertEqual(rowset_proto.row_ranges[3].start_key_open, b"test_row6")
+        self.assertEqual(rowset_proto.row_ranges[3].end_key_closed, b"test_row7")
+        self.assertEqual(rowset_proto.row_ranges[4].start_key_closed, b"")
+        self.assertEqual(rowset_proto.row_ranges[4].end_key_open, b"")
+        # check limit
+        self.assertEqual(request_proto.rows_limit, 100)
+        # check filter
+        filter_proto = request_proto.filter
+        self.assertEqual(filter_proto, row_filter.to_pb())
+
+    def test_shard(self):
+        pass

--- a/tests/unit/test_read_rows_query.py
+++ b/tests/unit/test_read_rows_query.py
@@ -91,7 +91,7 @@ class TestReadRowsQuery(unittest.TestCase):
         output = query.to_dict()
         self.assertEqual(output["filter"], filter1_dict)
         proto_output = ReadRowsRequest(**output)
-        self.assertEqual(proto_output.filter, filter1.to_pb())
+        self.assertEqual(proto_output.filter, filter1._to_pb())
 
         query.filter = None
         self.assertEqual(query.filter, None)
@@ -308,7 +308,7 @@ class TestReadRowsQuery(unittest.TestCase):
         self.assertEqual(request_proto.rows_limit, 100)
         # check filter
         filter_proto = request_proto.filter
-        self.assertEqual(filter_proto, row_filter.to_pb())
+        self.assertEqual(filter_proto, row_filter._to_pb())
 
     def test_shard(self):
         pass

--- a/tests/unit/test_read_rows_query.py
+++ b/tests/unit/test_read_rows_query.py
@@ -224,24 +224,24 @@ class TestReadRowsQuery(unittest.TestCase):
             query.add_range(start_is_inclusive=True, end_is_inclusive=True)
         self.assertEqual(
             exc.exception.args,
-            ("start_is_inclusive must not be set without start_key",),
+            ("start_is_inclusive must be set with start_key",),
         )
         with self.assertRaises(ValueError) as exc:
             query.add_range(start_is_inclusive=False, end_is_inclusive=False)
         self.assertEqual(
             exc.exception.args,
-            ("start_is_inclusive must not be set without start_key",),
+            ("start_is_inclusive must be set with start_key",),
         )
         with self.assertRaises(ValueError) as exc:
             query.add_range(start_is_inclusive=False)
         self.assertEqual(
             exc.exception.args,
-            ("start_is_inclusive must not be set without start_key",),
+            ("start_is_inclusive must be set with start_key",),
         )
         with self.assertRaises(ValueError) as exc:
             query.add_range(end_is_inclusive=True)
         self.assertEqual(
-            exc.exception.args, ("end_is_inclusive must not be set without end_key",)
+            exc.exception.args, ("end_is_inclusive must be set with end_key",)
         )
         # test with invalid keys
         with self.assertRaises(ValueError) as exc:

--- a/tests/unit/test_read_rows_query.py
+++ b/tests/unit/test_read_rows_query.py
@@ -19,10 +19,12 @@ TEST_ROWS = [
     b"row_key_2",
 ]
 
+
 class TestRowRange(unittest.TestCase):
     @staticmethod
     def _get_target_class():
         from google.cloud.bigtable.read_rows_query import RowRange
+
         return RowRange
 
     def _make_one(self, *args, **kwargs):
@@ -108,6 +110,7 @@ class TestRowRange(unittest.TestCase):
             "end_key_closed": b"test_row2",
         }
         self.assertEqual(row_range._to_dict(), expected)
+
 
 class TestReadRowsQuery(unittest.TestCase):
     @staticmethod
@@ -235,7 +238,7 @@ class TestReadRowsQuery(unittest.TestCase):
         self.assertIn(b"test_row2", query.row_keys)
         self.assertIn(b"test_row3", query.row_keys)
         # test adding another batch
-        for k in ['test_row4', b"test_row5"]:
+        for k in ["test_row4", b"test_row5"]:
             query.add_key(k)
         self.assertEqual(len(query.row_keys), 5)
         self.assertIn(input_batch[0].encode(), query.row_keys)
@@ -268,6 +271,7 @@ class TestReadRowsQuery(unittest.TestCase):
 
     def test_add_range(self):
         from google.cloud.bigtable.read_rows_query import RowRange
+
         query = self._make_one()
         self.assertEqual(query.row_ranges, [])
         input_range = RowRange(start_key=b"test_row")


### PR DESCRIPTION
Implements the RowQuery class, used to configure read_rows calls

Implementation is generally aligned with the [Query class in the Java library](https://github.com/googleapis/java-bigtable/blob/main/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Query.java)

Implementation for sharding will come in a future PR

---

Note: This is merging into a new v3 branch, not main. I plan on making all PRs related to this rewrite to v3 and then merging v3 into main when development is complete