### PR TITLE
feat: implement row and cell model classes

### DIFF
--- a/google/cloud/bigtable/__init__.py
+++ b/google/cloud/bigtable/__init__.py
@@ -22,8 +22,8 @@ from google.cloud.bigtable.client import BigtableDataClient
 from google.cloud.bigtable.client import Table
 
 from google.cloud.bigtable.read_rows_query import ReadRowsQuery
-from google.cloud.bigtable.row_response import RowResponse
-from google.cloud.bigtable.row_response import CellResponse
+from google.cloud.bigtable.row import Row
+from google.cloud.bigtable.row import Cell
 
 from google.cloud.bigtable.mutations_batcher import MutationsBatcher
 from google.cloud.bigtable.mutations import Mutation
@@ -50,6 +50,6 @@ __all__ = (
     "DeleteRangeFromColumn",
     "DeleteAllFromFamily",
     "DeleteAllFromRow",
-    "RowResponse",
-    "CellResponse",
+    "Row",
+    "Cell",
 )

--- a/google/cloud/bigtable/client.py
+++ b/google/cloud/bigtable/client.py
@@ -25,7 +25,7 @@ import google.auth.credentials
 if TYPE_CHECKING:
     from google.cloud.bigtable.mutations import Mutation, BulkMutationsEntry
     from google.cloud.bigtable.mutations_batcher import MutationsBatcher
-    from google.cloud.bigtable.row_response import RowResponse
+    from google.cloud.bigtable.row import Row
     from google.cloud.bigtable.read_rows_query import ReadRowsQuery
     from google.cloud.bigtable import RowKeySamples
     from google.cloud.bigtable.row_filters import RowFilter
@@ -109,7 +109,7 @@ class Table:
         idle_timeout: int | float | None = 300,
         per_request_timeout: int | float | None = None,
         metadata: list[tuple[str, str]] | None = None,
-    ) -> AsyncIterable[RowResponse]:
+    ) -> AsyncIterable[Row]:
         """
         Returns a generator to asynchronously stream back row data.
 
@@ -166,7 +166,7 @@ class Table:
         per_row_timeout: int | float | None = 10,
         per_request_timeout: int | float | None = None,
         metadata: list[tuple[str, str]] | None = None,
-    ) -> list[RowResponse]:
+    ) -> list[Row]:
         """
         Helper function that returns a full list instead of a generator
 
@@ -184,7 +184,7 @@ class Table:
         operation_timeout: int | float | None = 60,
         per_request_timeout: int | float | None = None,
         metadata: list[tuple[str, str]] | None = None,
-    ) -> RowResponse:
+    ) -> Row:
         """
         Helper function to return a single row
 
@@ -206,7 +206,7 @@ class Table:
         idle_timeout: int | float | None = 300,
         per_request_timeout: int | float | None = None,
         metadata: list[tuple[str, str]] | None = None,
-    ) -> AsyncIterable[RowResponse]:
+    ) -> AsyncIterable[Row]:
         """
         Runs a sharded query in parallel
 
@@ -410,7 +410,7 @@ class Table:
         *,
         operation_timeout: int | float | None = 60,
         metadata: list[tuple[str, str]] | None = None,
-    ) -> RowResponse:
+    ) -> Row:
         """
         Reads and modifies a row atomically according to input ReadModifyWriteRules,
         and returns the contents of all modified cells
@@ -429,7 +429,7 @@ class Table:
                 Failed requests will not be retried.
             - metadata: Strings which should be sent along with the request as metadata headers.
         Returns:
-            - RowResponse: containing cell data that was modified as part of the
+            - Row: containing cell data that was modified as part of the
                 operation
         Raises:
             - GoogleAPIError exceptions from grpc call

--- a/google/cloud/bigtable/mutations.py
+++ b/google/cloud/bigtable/mutations.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from google.cloud.bigtable.row_response import family_id, qualifier, row_key
+from google.cloud.bigtable.row import family_id, qualifier, row_key
 
 
 class Mutation:

--- a/google/cloud/bigtable/mutations_batcher.py
+++ b/google/cloud/bigtable/mutations_batcher.py
@@ -18,7 +18,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from google.cloud.bigtable.mutations import Mutation
-from google.cloud.bigtable.row_response import row_key
+from google.cloud.bigtable.row import row_key
 from google.cloud.bigtable.row_filters import RowFilter
 
 if TYPE_CHECKING:

--- a/google/cloud/bigtable/read_modify_write_rules.py
+++ b/google/cloud/bigtable/read_modify_write_rules.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from google.cloud.bigtable.row_response import family_id, qualifier
+from google.cloud.bigtable.row import family_id, qualifier
 
 
 class ReadModifyWriteRule:

--- a/google/cloud/bigtable/read_rows_query.py
+++ b/google/cloud/bigtable/read_rows_query.py
@@ -14,7 +14,7 @@
 #
 from __future__ import annotations
 from typing import TYPE_CHECKING, Any
-from .row_response import row_key
+from .row import row_key
 from dataclasses import dataclass
 from google.cloud.bigtable.row_filters import RowFilter
 

--- a/google/cloud/bigtable/row.py
+++ b/google/cloud/bigtable/row.py
@@ -40,7 +40,7 @@ class Row(Sequence["Cell"]):
     def __init__(
         self,
         key: row_key,
-        cells: list[Cell] | dict[tuple[family_id, qualifier], list[dict[str, Any]]],
+        cells: list[Cell],
     ):
         """
         Initializes a Row object
@@ -51,22 +51,8 @@ class Row(Sequence["Cell"]):
         self.row_key = key
         self._cells_map: dict[family_id, dict[qualifier, list[Cell]]] = OrderedDict()
         self._cells_list: list[Cell] = []
-        if isinstance(cells, dict):
-            # handle dict input
-            tmp_list = []
-            for (family, qualifier), cell_list in cells.items():
-                for cell_dict in cell_list:
-                    cell_obj = Cell(
-                        row=key, family=family, column_qualifier=qualifier, **cell_dict
-                    )
-                    tmp_list.append(cell_obj)
-            cells = tmp_list
         # add cells to internal stores using Bigtable native ordering
-        for cell in sorted(cells):
-            if cell.row_key != self.row_key:
-                raise ValueError(
-                    f"Cell row_key ({cell.row_key!r}) does not match Row key ({self.row_key!r})"
-                )
+        for cell in cells:
             if cell.family not in self._cells_map:
                 self._cells_map[cell.family] = OrderedDict()
             if cell.column_qualifier not in self._cells_map[cell.family]:

--- a/google/cloud/bigtable/row_response.py
+++ b/google/cloud/bigtable/row_response.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Sequence
+from typing import Sequence, Generator, Mapping, overload, Union, List, Tuple, Any
+from functools import total_ordering
 
 # Type aliases used internally for readability.
 row_key = bytes
@@ -24,7 +25,12 @@ qualifier = bytes
 row_value = bytes
 
 
-class RowResponse(Sequence["CellResponse"]):
+class RowResponse(
+    Sequence["CellResponse"],
+    Mapping[
+        Union[family_id, Tuple[family_id, Union[qualifier, str]]], List["CellResponse"]
+    ],
+):
     """
     Model class for row data returned from server
 
@@ -36,47 +42,237 @@ class RowResponse(Sequence["CellResponse"]):
     cells = row["family", "qualifier"]
     """
 
-    def __init__(self, key: row_key, cells: list[CellResponse]):
-        self.row_key = key
-        self.cells: OrderedDict[
-            family_id, OrderedDict[qualifier, list[CellResponse]]
-        ] = OrderedDict()
+    def __init__(
+        self,
+        key: row_key,
+        cells: list[CellResponse]
+        | dict[tuple[family_id, qualifier], list[dict[str, Any]]],
+    ):
         """Expected to be used internally only"""
-        pass
+        self.row_key = key
+        self._cells_map: dict[
+            family_id, dict[qualifier, list[CellResponse]]
+        ] = OrderedDict()
+        self._cells_list: list[CellResponse] = []
+        if isinstance(cells, dict):
+            # handle dict input
+            tmp_list = []
+            for (family, qualifier), cell_list in cells.items():
+                for cell_dict in cell_list:
+                    cell_obj = CellResponse._from_dict(
+                        key, family, qualifier, cell_dict
+                    )
+                    tmp_list.append(cell_obj)
+            cells = tmp_list
+        # add cells to internal stores using Bigtable native ordering
+        for cell in sorted(cells):
+            if cell.row_key != self.row_key:
+                raise ValueError(
+                    f"CellResponse row_key ({cell.row_key!r}) does not match RowResponse key ({self.row_key!r})"
+                )
+            if cell.family not in self._cells_map:
+                self._cells_map[cell.family] = OrderedDict()
+            if cell.column_qualifier not in self._cells_map[cell.family]:
+                self._cells_map[cell.family][cell.column_qualifier] = []
+            self._cells_map[cell.family][cell.column_qualifier].append(cell)
+            self._cells_list.append(cell)
 
     def get_cells(
-        self, family: str | None, qualifer: str | bytes | None
+        self, family: str | None = None, qualifier: str | bytes | None = None
     ) -> list[CellResponse]:
         """
         Returns cells sorted in Bigtable native order:
             - Family lexicographically ascending
-            - Qualifier lexicographically ascending
+            - Qualifier ascending
             - Timestamp in reverse chronological order
 
         If family or qualifier not passed, will include all
 
-        Syntactic sugar: cells = row["family", "qualifier"]
+        Can also be accessed through indexing:
+          cells = row["family", "qualifier"]
+          cells = row["family"]
         """
-        raise NotImplementedError
+        if family is None:
+            if qualifier is not None:
+                # get_cells(None, "qualifier") is not allowed
+                raise ValueError("Qualifier passed without family")
+            else:
+                # return all cells on get_cells()
+                return self._cells_list
+        if qualifier is None:
+            # return all cells in family on get_cells(family)
+            return list(self._get_all_from_family(family))
+        if isinstance(qualifier, str):
+            qualifier = qualifier.encode("utf-8")
+        # return cells in family and qualifier on get_cells(family, qualifier)
+        if family not in self._cells_map:
+            raise ValueError(f"Family '{family}' not found in row '{self.row_key!r}'")
+        if qualifier not in self._cells_map[family]:
+            raise ValueError(
+                f"Qualifier '{qualifier!r}' not found in family '{family}' in row '{self.row_key!r}'"
+            )
+        return self._cells_map[family][qualifier]
 
-    def get_index(self) -> dict[family_id, list[qualifier]]:
+    def _get_all_from_family(
+        self, family: family_id
+    ) -> Generator[CellResponse, None, None]:
         """
-        Returns a list of family and qualifiers for the object
+        Returns all cells in the row
         """
-        raise NotImplementedError
+        if family not in self._cells_map:
+            raise ValueError(f"Family '{family}' not found in row '{self.row_key!r}'")
+        qualifier_dict = self._cells_map.get(family, {})
+        for cell_batch in qualifier_dict.values():
+            for cell in cell_batch:
+                yield cell
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Human-readable string representation
 
-        (family, qualifier)   cells
-        (ABC, XYZ)            [b"123", b"456" ...(+5)]
-        (DEF, XYZ)            [b"123"]
-        (GHI, XYZ)            [b"123", b"456" ...(+2)]
+        {
+          (family='fam', qualifier=b'col'): [b'value', (+1 more),],
+          (family='fam', qualifier=b'col2'): [b'other'],
+        }
         """
-        raise NotImplementedError
+        output = ["{"]
+        for key in self.keys():
+            if len(self[key]) == 0:
+                output.append(f"  {key}: []")
+            elif len(self[key]) == 1:
+                output.append(
+                    f"  (family='{key[0]}', qualifier={key[1]}): [{self[key][0]}],"
+                )
+            else:
+                output.append(
+                    f"  (family='{key[0]}', qualifier={key[1]}): [{self[key][0]}, (+{len(self[key])-1} more)],"
+                )
+        output.append("}")
+        return "\n".join(output)
+
+    def __repr__(self):
+        cell_str_buffer = ["{"]
+        for key, cell_list in self.items():
+            repr_list = [cell.to_dict(use_nanoseconds=True) for cell in cell_list]
+            cell_str_buffer.append(f"  ('{key[0]}', {key[1]}): {repr_list},")
+        cell_str_buffer.append("}")
+        cell_str = "\n".join(cell_str_buffer)
+        output = f"RowResponse(key={self.row_key!r}, cells={cell_str})"
+        return output
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Returns a dictionary representation of the cell in the Bigtable Row
+        proto format
+
+        https://cloud.google.com/bigtable/docs/reference/data/rpc/google.bigtable.v2#row
+        """
+        families_list: list[dict[str, Any]] = []
+        for family in self._cells_map:
+            column_list: list[dict[str, Any]] = []
+            for qualifier in self._cells_map[family]:
+                cells_list: list[dict[str, Any]] = []
+                for cell in self._cells_map[family][qualifier]:
+                    cells_list.append(cell.to_dict())
+                column_list.append({"qualifier": qualifier, "cells": cells_list})
+            families_list.append({"name": family, "columns": column_list})
+        return {"key": self.row_key, "families": families_list}
+
+    # Sequence and Mapping methods
+    def __iter__(self):
+        # iterate as a sequence; yield all cells
+        for cell in self._cells_list:
+            yield cell
+
+    def __contains__(self, item):
+        if isinstance(item, family_id):
+            # check if family key is in RowResponse
+            return item in self._cells_map
+        elif (
+            isinstance(item, tuple)
+            and isinstance(item[0], family_id)
+            and isinstance(item[1], (qualifier, str))
+        ):
+            # check if (family, qualifier) pair is in RowResponse
+            qualifer = item[1] if isinstance(item[1], bytes) else item[1].encode()
+            return item[0] in self._cells_map and qualifer in self._cells_map[item[0]]
+        # check if CellResponse is in RowResponse
+        return item in self._cells_list
+
+    @overload
+    def __getitem__(
+        self,
+        index: family_id | tuple[family_id, qualifier | str],
+    ) -> List[CellResponse]:
+        # overload signature for type checking
+        pass
+
+    @overload
+    def __getitem__(self, index: int, /) -> CellResponse:
+        # overload signature for type checking
+        pass
+
+    @overload
+    def __getitem__(self, index: slice) -> list[CellResponse]:
+        # overload signature for type checking
+        pass
+
+    def __getitem__(self, index):
+        if isinstance(index, family_id):
+            return self.get_cells(family=index)
+        elif (
+            isinstance(index, tuple)
+            and isinstance(index[0], family_id)
+            and isinstance(index[1], (qualifier, str))
+        ):
+            return self.get_cells(family=index[0], qualifier=index[1])
+        elif isinstance(index, int) or isinstance(index, slice):
+            # index is int or slice
+            return self._cells_list[index]
+        else:
+            raise TypeError(
+                "Index must be family_id, (family_id, qualifier), int, or slice"
+            )
+
+    def __len__(self):
+        return len(self._cells_list)
+
+    def keys(self):
+        key_list = []
+        for family in self._cells_map:
+            for qualifier in self._cells_map[family]:
+                key_list.append((family, qualifier))
+        return key_list
+
+    def values(self):
+        return self._cells_list
+
+    def items(self):
+        for key in self.keys():
+            yield key, self[key]
+
+    def __eq__(self, other):
+        # for performance reasons, check row metadata
+        # before checking individual cells
+        if not isinstance(other, RowResponse):
+            return False
+        if self.row_key != other.row_key:
+            return False
+        if len(self._cells_list) != len(other._cells_list):
+            return False
+        keys, other_keys = self.keys(), other.keys()
+        if keys != other_keys:
+            return False
+        for key in keys:
+            if len(self[key]) != len(other[key]):
+                return False
+        # compare individual cell lists
+        if self._cells_list != other._cells_list:
+            return False
+        return True
 
 
+@total_ordering
 class CellResponse:
     """
     Model class for cell data
@@ -91,20 +287,51 @@ class CellResponse:
         value: row_value,
         row: row_key,
         family: family_id,
-        column_qualifier: qualifier,
+        column_qualifier: qualifier | str,
+        timestamp_ns: int,
         labels: list[str] | None = None,
-        timestamp: int | None = None,
     ):
+        """
+        CellResponse constructor
+
+        CellResponse objects are not intended to be constructed by users.
+        They are returned by the Bigtable backend.
+        """
         self.value = value
         self.row_key = row
         self.family = family
+        if isinstance(column_qualifier, str):
+            column_qualifier = column_qualifier.encode()
         self.column_qualifier = column_qualifier
-        self.labels = labels
-        self.timestamp = timestamp
+        self.timestamp_ns = timestamp_ns
+        self.labels = labels if labels is not None else []
 
-    def decode_value(self, encoding="UTF-8", errors=None) -> str:
-        """decode bytes to string"""
-        return self.value.decode(encoding, errors)
+    @staticmethod
+    def _from_dict(
+        row_key: bytes, family: str, qualifier: bytes, cell_dict: dict[str, Any]
+    ) -> CellResponse:
+        """
+        Helper function to create CellResponse from a dictionary
+
+        CellResponse objects are not intended to be constructed by users.
+        They are returned by the Bigtable backend.
+        """
+        # Bigtable backend will use microseconds for timestamps,
+        # but the Python library prefers nanoseconds where possible
+        timestamp = cell_dict.get(
+            "timestamp_ns", cell_dict.get("timestamp_micros", -1) * 1000
+        )
+        if timestamp < 0:
+            raise ValueError("invalid timestamp")
+        cell_obj = CellResponse(
+            cell_dict["value"],
+            row_key,
+            family,
+            qualifier,
+            timestamp,
+            cell_dict.get("labels", None),
+        )
+        return cell_obj
 
     def __int__(self) -> int:
         """
@@ -114,6 +341,24 @@ class CellResponse:
         """
         return int.from_bytes(self.value, byteorder="big", signed=True)
 
+    def to_dict(self, use_nanoseconds=False) -> dict[str, Any]:
+        """
+        Returns a dictionary representation of the cell in the Bigtable Cell
+        proto format
+
+        https://cloud.google.com/bigtable/docs/reference/data/rpc/google.bigtable.v2#cell
+        """
+        cell_dict: dict[str, Any] = {
+            "value": self.value,
+        }
+        if use_nanoseconds:
+            cell_dict["timestamp_ns"] = self.timestamp_ns
+        else:
+            cell_dict["timestamp_micros"] = self.timestamp_ns // 1000
+        if self.labels:
+            cell_dict["labels"] = self.labels
+        return cell_dict
+
     def __str__(self) -> str:
         """
         Allows casting cell to str
@@ -121,10 +366,54 @@ class CellResponse:
         """
         return str(self.value)
 
+    def __repr__(self):
+        return f"CellResponse(value={self.value!r}, row={self.row_key!r}, family='{self.family}', column_qualifier={self.column_qualifier!r}, timestamp_ns={self.timestamp_ns}, labels={self.labels})"
+
     """For Bigtable native ordering"""
 
     def __lt__(self, other) -> bool:
-        raise NotImplementedError
+        if not isinstance(other, CellResponse):
+            return NotImplemented
+        this_ordering = (
+            self.family,
+            self.column_qualifier,
+            -self.timestamp_ns,
+            self.value,
+            self.labels,
+        )
+        other_ordering = (
+            other.family,
+            other.column_qualifier,
+            -other.timestamp_ns,
+            other.value,
+            other.labels,
+        )
+        return this_ordering < other_ordering
 
     def __eq__(self, other) -> bool:
-        raise NotImplementedError
+        if not isinstance(other, CellResponse):
+            return NotImplemented
+        return (
+            self.row_key == other.row_key
+            and self.family == other.family
+            and self.column_qualifier == other.column_qualifier
+            and self.value == other.value
+            and self.timestamp_ns == other.timestamp_ns
+            and len(self.labels) == len(other.labels)
+            and all([label in other.labels for label in self.labels])
+        )
+
+    def __ne__(self, other) -> bool:
+        return not self == other
+
+    def __hash__(self):
+        return hash(
+            (
+                self.row_key,
+                self.family,
+                self.column_qualifier,
+                self.value,
+                self.timestamp_ns,
+                tuple(self.labels),
+            )
+        )

--- a/google/cloud/bigtable/row_response.py
+++ b/google/cloud/bigtable/row_response.py
@@ -269,9 +269,13 @@ class RowResponse(Sequence["CellResponse"]):
 
     def values(self):
         """
-        Returns the list of cells in the row
+        Returns the the cells in the row, broken into lists
+        corresponding to the family and qualifier
         """
-        return self._cells_list
+        result = []
+        for key in self.keys():
+            result.append(self[key])
+        return result
 
     def items(self):
         """

--- a/google/cloud/bigtable/row_response.py
+++ b/google/cloud/bigtable/row_response.py
@@ -117,7 +117,7 @@ class RowResponse(Sequence["CellResponse"]):
         self, family: family_id
     ) -> Generator[CellResponse, None, None]:
         """
-        Returns all cells in the row
+        Returns all cells in the row for the family_id
         """
         if family not in self._cells_map:
             raise ValueError(f"Family '{family}' not found in row '{self.row_key!r}'")

--- a/google/cloud/bigtable/row_response.py
+++ b/google/cloud/bigtable/row_response.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Sequence, Generator, Mapping, overload, Union, List, Tuple, Any
+from typing import Sequence, Generator, overload, Any
 from functools import total_ordering
 
 # Type aliases used internally for readability.
@@ -25,12 +25,7 @@ qualifier = bytes
 row_value = bytes
 
 
-class RowResponse(
-    Sequence["CellResponse"],
-    Mapping[
-        Union[family_id, Tuple[family_id, Union[qualifier, str]]], List["CellResponse"]
-    ],
-):
+class RowResponse(Sequence["CellResponse"]):
     """
     Model class for row data returned from server
 
@@ -203,7 +198,7 @@ class RowResponse(
     def __getitem__(
         self,
         index: family_id | tuple[family_id, qualifier | str],
-    ) -> List[CellResponse]:
+    ) -> list[CellResponse]:
         # overload signature for type checking
         pass
 

--- a/google/cloud/bigtable/row_response.py
+++ b/google/cloud/bigtable/row_response.py
@@ -217,7 +217,7 @@ class RowResponse(Sequence["CellResponse"]):
         pass
 
     @overload
-    def __getitem__(self, index: int, /) -> CellResponse:
+    def __getitem__(self, index: int) -> CellResponse:
         # overload signature for type checking
         pass
 

--- a/google/cloud/bigtable/row_response.py
+++ b/google/cloud/bigtable/row_response.py
@@ -136,7 +136,7 @@ class RowResponse(Sequence["CellResponse"]):
         }
         """
         output = ["{"]
-        for family,qualifier in self.get_column_components():
+        for family, qualifier in self.get_column_components():
             cell_list = self[family, qualifier]
             line = [f"  (family={family!r}, qualifier={qualifier!r}): "]
             if len(cell_list) == 0:
@@ -144,16 +144,14 @@ class RowResponse(Sequence["CellResponse"]):
             elif len(cell_list) == 1:
                 line.append(f"[{cell_list[0]}],")
             else:
-                line.append(
-                    f"[{cell_list[0]}, (+{len(cell_list)-1} more)],"
-                )
+                line.append(f"[{cell_list[0]}, (+{len(cell_list)-1} more)],")
             output.append("".join(line))
         output.append("}")
         return "\n".join(output)
 
     def __repr__(self):
         cell_str_buffer = ["{"]
-        for family,qualifier in self.get_column_components():
+        for family, qualifier in self.get_column_components():
             cell_list = self[family, qualifier]
             repr_list = [cell.to_dict() for cell in cell_list]
             cell_str_buffer.append(f"  ('{family}', {qualifier}): {repr_list},")
@@ -269,8 +267,6 @@ class RowResponse(Sequence["CellResponse"]):
                 key_list.append((family, qualifier))
         return key_list
 
-
-
     def __eq__(self, other):
         """
         Implements `==` operator
@@ -289,8 +285,8 @@ class RowResponse(Sequence["CellResponse"]):
             return False
         if components != other_components:
             return False
-        for family,qualifier in components:
-            if len(self[family, qualifier]) != len(other[family,qualifier]):
+        for family, qualifier in components:
+            if len(self[family, qualifier]) != len(other[family, qualifier]):
                 return False
         # compare individual cell lists
         if self._cells_list != other._cells_list:

--- a/google/cloud/bigtable/row_response.py
+++ b/google/cloud/bigtable/row_response.py
@@ -59,8 +59,8 @@ class RowResponse(Sequence["CellResponse"]):
             tmp_list = []
             for (family, qualifier), cell_list in cells.items():
                 for cell_dict in cell_list:
-                    cell_obj = CellResponse._from_dict(
-                        key, family, qualifier, cell_dict
+                    cell_obj = CellResponse(
+                        row=key, family=family, column_qualifier=qualifier, **cell_dict
                     )
                     tmp_list.append(cell_obj)
             cells = tmp_list
@@ -333,26 +333,6 @@ class CellResponse:
         self.column_qualifier = column_qualifier
         self.timestamp_micros = timestamp_micros
         self.labels = labels if labels is not None else []
-
-    @staticmethod
-    def _from_dict(
-        row_key: bytes, family: str, qualifier: bytes, cell_dict: dict[str, Any]
-    ) -> CellResponse:
-        """
-        Helper function to create CellResponse from a dictionary
-
-        CellResponse objects are not intended to be constructed by users.
-        They are returned by the Bigtable backend.
-        """
-        cell_obj = CellResponse(
-            cell_dict["value"],
-            row_key,
-            family,
-            qualifier,
-            cell_dict.get("timestamp_micros"),
-            cell_dict.get("labels", None),
-        )
-        return cell_obj
 
     def __int__(self) -> int:
         """

--- a/tests/unit/test_row.py
+++ b/tests/unit/test_row.py
@@ -90,8 +90,6 @@ class TestRow(unittest.TestCase):
             row_response.get_cells(family="1", qualifier=b"c")
 
     def test___repr__(self):
-        from google.cloud.bigtable.row import Cell
-        from google.cloud.bigtable.row import Row
 
         cell_str = (
             "{'value': b'1234', 'timestamp_micros': %d, 'labels': ['label1', 'label2']}"

--- a/tests/unit/test_row.py
+++ b/tests/unit/test_row.py
@@ -24,12 +24,12 @@ TEST_TIMESTAMP = time.time_ns() // 1000
 TEST_LABELS = ["label1", "label2"]
 
 
-class TestRowResponse(unittest.TestCase):
+class TestRow(unittest.TestCase):
     @staticmethod
     def _get_target_class():
-        from google.cloud.bigtable.row_response import RowResponse
+        from google.cloud.bigtable.row_response import Row
 
-        return RowResponse
+        return Row
 
     def _make_one(self, *args, **kwargs):
         if len(args) == 0:
@@ -45,9 +45,9 @@ class TestRowResponse(unittest.TestCase):
         timestamp=TEST_TIMESTAMP,
         labels=TEST_LABELS,
     ):
-        from google.cloud.bigtable.row_response import CellResponse
+        from google.cloud.bigtable.row_response import Cell
 
-        return CellResponse(value, row_key, family_id, qualifier, timestamp, labels)
+        return Cell(value, row_key, family_id, qualifier, timestamp, labels)
 
     def test_ctor(self):
         cells = [self._make_cell(), self._make_cell()]
@@ -123,27 +123,27 @@ class TestRowResponse(unittest.TestCase):
             row_response.get_cells(family="1", qualifier=b"c")
 
     def test__repr__(self):
-        from google.cloud.bigtable.row_response import CellResponse
-        from google.cloud.bigtable.row_response import RowResponse
+        from google.cloud.bigtable.row_response import Cell
+        from google.cloud.bigtable.row_response import Row
 
         cell_str = (
             "{'value': b'1234', 'timestamp_micros': %d, 'labels': ['label1', 'label2']}"
             % (TEST_TIMESTAMP)
         )
-        expected_prefix = "RowResponse(key=b'row', cells="
+        expected_prefix = "Row(key=b'row', cells="
         row = self._make_one(TEST_ROW_KEY, [self._make_cell()])
         self.assertIn(expected_prefix, repr(row))
         self.assertIn(cell_str, repr(row))
         expected_full = (
-            "RowResponse(key=b'row', cells={\n  ('cf1', b'col'): [{'value': b'1234', 'timestamp_micros': %d, 'labels': ['label1', 'label2']}],\n})"
+            "Row(key=b'row', cells={\n  ('cf1', b'col'): [{'value': b'1234', 'timestamp_micros': %d, 'labels': ['label1', 'label2']}],\n})"
             % (TEST_TIMESTAMP)
         )
         self.assertEqual(expected_full, repr(row))
         # should be able to construct instance from __repr__
         result = eval(repr(row))
         self.assertEqual(result, row)
-        self.assertIsInstance(result, RowResponse)
-        self.assertIsInstance(result[0], CellResponse)
+        self.assertIsInstance(result, Row)
+        self.assertIsInstance(result[0], Cell)
         # try with multiple cells
         row = self._make_one(TEST_ROW_KEY, [self._make_cell(), self._make_cell()])
         self.assertIn(expected_prefix, repr(row))
@@ -151,10 +151,10 @@ class TestRowResponse(unittest.TestCase):
         # should be able to construct instance from __repr__
         result = eval(repr(row))
         self.assertEqual(result, row)
-        self.assertIsInstance(result, RowResponse)
+        self.assertIsInstance(result, Row)
         self.assertEqual(len(result), 2)
-        self.assertIsInstance(result[0], CellResponse)
-        self.assertIsInstance(result[1], CellResponse)
+        self.assertIsInstance(result[0], Cell)
+        self.assertIsInstance(result[1], Cell)
 
     def test___str__(self):
         cells = {
@@ -230,9 +230,9 @@ class TestRowResponse(unittest.TestCase):
 
     def test_iteration(self):
         from types import GeneratorType
-        from google.cloud.bigtable.row_response import CellResponse
+        from google.cloud.bigtable.row_response import Cell
 
-        # should be able to iterate over the RowResponse as a list
+        # should be able to iterate over the Row as a list
         cell3 = self._make_cell(value=b"3")
         cell1 = self._make_cell(value=b"1")
         cell2 = self._make_cell(value=b"2")
@@ -245,7 +245,7 @@ class TestRowResponse(unittest.TestCase):
         # should be able to iterate over all cells
         idx = 0
         for cell in row_response:
-            self.assertIsInstance(cell, CellResponse)
+            self.assertIsInstance(cell, Cell)
             self.assertEqual(cell.value, result_list[idx].value)
             self.assertEqual(cell.value, str(idx + 1).encode())
             idx += 1
@@ -505,12 +505,12 @@ class TestRowResponse(unittest.TestCase):
             row_response.index(None)
 
 
-class TestCellResponse(unittest.TestCase):
+class TestCell(unittest.TestCase):
     @staticmethod
     def _get_target_class():
-        from google.cloud.bigtable.row_response import CellResponse
+        from google.cloud.bigtable.row_response import Cell
 
-        return CellResponse
+        return Cell
 
     def _make_one(self, *args, **kwargs):
         if len(args) == 0:
@@ -632,11 +632,11 @@ class TestCellResponse(unittest.TestCase):
         self.assertEqual(str(cell), str(test_value))
 
     def test___repr__(self):
-        from google.cloud.bigtable.row_response import CellResponse  # type: ignore # noqa: F401
+        from google.cloud.bigtable.row_response import Cell  # type: ignore # noqa: F401
 
         cell = self._make_one()
         expected = (
-            "CellResponse(value=b'1234', row=b'row', "
+            "Cell(value=b'1234', row=b'row', "
             + "family='cf1', column_qualifier=b'col', "
             + f"timestamp_micros={TEST_TIMESTAMP}, labels=['label1', 'label2'])"
         )
@@ -646,7 +646,7 @@ class TestCellResponse(unittest.TestCase):
         self.assertEqual(result, cell)
 
     def test___repr___no_labels(self):
-        from google.cloud.bigtable.row_response import CellResponse  # type: ignore # noqa: F401
+        from google.cloud.bigtable.row_response import Cell  # type: ignore # noqa: F401
 
         cell_no_labels = self._make_one(
             TEST_VALUE,
@@ -657,7 +657,7 @@ class TestCellResponse(unittest.TestCase):
             None,
         )
         expected = (
-            "CellResponse(value=b'1234', row=b'row', "
+            "Cell(value=b'1234', row=b'row', "
             + "family='cf1', column_qualifier=b'col', "
             + f"timestamp_micros={TEST_TIMESTAMP}, labels=[])"
         )

--- a/tests/unit/test_row.py
+++ b/tests/unit/test_row.py
@@ -27,7 +27,7 @@ TEST_LABELS = ["label1", "label2"]
 class TestRow(unittest.TestCase):
     @staticmethod
     def _get_target_class():
-        from google.cloud.bigtable.row_response import Row
+        from google.cloud.bigtable.row import Row
 
         return Row
 
@@ -45,7 +45,7 @@ class TestRow(unittest.TestCase):
         timestamp=TEST_TIMESTAMP,
         labels=TEST_LABELS,
     ):
-        from google.cloud.bigtable.row_response import Cell
+        from google.cloud.bigtable.row import Cell
 
         return Cell(value, row_key, family_id, qualifier, timestamp, labels)
 
@@ -123,8 +123,8 @@ class TestRow(unittest.TestCase):
             row_response.get_cells(family="1", qualifier=b"c")
 
     def test__repr__(self):
-        from google.cloud.bigtable.row_response import Cell
-        from google.cloud.bigtable.row_response import Row
+        from google.cloud.bigtable.row import Cell
+        from google.cloud.bigtable.row import Row
 
         cell_str = (
             "{'value': b'1234', 'timestamp_micros': %d, 'labels': ['label1', 'label2']}"
@@ -230,7 +230,7 @@ class TestRow(unittest.TestCase):
 
     def test_iteration(self):
         from types import GeneratorType
-        from google.cloud.bigtable.row_response import Cell
+        from google.cloud.bigtable.row import Cell
 
         # should be able to iterate over the Row as a list
         cell3 = self._make_cell(value=b"3")
@@ -508,7 +508,7 @@ class TestRow(unittest.TestCase):
 class TestCell(unittest.TestCase):
     @staticmethod
     def _get_target_class():
-        from google.cloud.bigtable.row_response import Cell
+        from google.cloud.bigtable.row import Cell
 
         return Cell
 
@@ -632,7 +632,7 @@ class TestCell(unittest.TestCase):
         self.assertEqual(str(cell), str(test_value))
 
     def test___repr__(self):
-        from google.cloud.bigtable.row_response import Cell  # type: ignore # noqa: F401
+        from google.cloud.bigtable.row import Cell  # type: ignore # noqa: F401
 
         cell = self._make_one()
         expected = (
@@ -646,7 +646,7 @@ class TestCell(unittest.TestCase):
         self.assertEqual(result, cell)
 
     def test___repr___no_labels(self):
-        from google.cloud.bigtable.row_response import Cell  # type: ignore # noqa: F401
+        from google.cloud.bigtable.row import Cell  # type: ignore # noqa: F401
 
         cell_no_labels = self._make_one(
             TEST_VALUE,

--- a/tests/unit/test_row_response.py
+++ b/tests/unit/test_row_response.py
@@ -486,8 +486,9 @@ class TestRowResponse(unittest.TestCase):
 
         row_response = self._make_one(TEST_ROW_KEY, [cell])
         self.assertEqual(len(row_response.get_column_components()), 1)
-        self.assertEqual(row_response.get_column_components(), [(TEST_FAMILY_ID, TEST_QUALIFIER)])
-
+        self.assertEqual(
+            row_response.get_column_components(), [(TEST_FAMILY_ID, TEST_QUALIFIER)]
+        )
 
     def test_index_of(self):
         # given a cell, should find index in underlying list

--- a/tests/unit/test_row_response.py
+++ b/tests/unit/test_row_response.py
@@ -1,0 +1,786 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import time
+
+TEST_VALUE = b"1234"
+TEST_ROW_KEY = b"row"
+TEST_FAMILY_ID = "cf1"
+TEST_QUALIFIER = b"col"
+TEST_TIMESTAMP = time.time_ns()
+TEST_LABELS = ["label1", "label2"]
+
+
+class TestRowResponse(unittest.TestCase):
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigtable.row_response import RowResponse
+
+        return RowResponse
+
+    def _make_one(self, *args, **kwargs):
+        if len(args) == 0:
+            args = (TEST_ROW_KEY, [self._make_cell()])
+        return self._get_target_class()(*args, **kwargs)
+
+    def _make_cell(
+        self,
+        value=TEST_VALUE,
+        row_key=TEST_ROW_KEY,
+        family_id=TEST_FAMILY_ID,
+        qualifier=TEST_QUALIFIER,
+        timestamp=TEST_TIMESTAMP,
+        labels=TEST_LABELS,
+    ):
+        from google.cloud.bigtable.row_response import CellResponse
+
+        return CellResponse(value, row_key, family_id, qualifier, timestamp, labels)
+
+    def test_ctor(self):
+        cells = [self._make_cell(), self._make_cell()]
+        row_response = self._make_one(TEST_ROW_KEY, cells)
+        self.assertEqual(list(row_response), cells)
+        self.assertEqual(row_response.row_key, TEST_ROW_KEY)
+
+    def test_ctor_dict(self):
+        cells = {
+            (TEST_FAMILY_ID, TEST_QUALIFIER): [
+                self._make_cell().to_dict(),
+                self._make_cell().to_dict(use_nanoseconds=True),
+            ]
+        }
+        row_response = self._make_one(TEST_ROW_KEY, cells)
+        self.assertEqual(row_response.row_key, TEST_ROW_KEY)
+        self.assertEqual(len(row_response), 2)
+        for i in range(2):
+            self.assertEqual(row_response[i].value, TEST_VALUE)
+            self.assertEqual(row_response[i].row_key, TEST_ROW_KEY)
+            self.assertEqual(row_response[i].family, TEST_FAMILY_ID)
+            self.assertEqual(row_response[i].column_qualifier, TEST_QUALIFIER)
+            self.assertEqual(row_response[i].labels, TEST_LABELS)
+        self.assertEqual(row_response[0].timestamp_ns, TEST_TIMESTAMP)
+        # second cell was initialized with use_nanoseconds=False, so it doesn't have full precision
+        self.assertEqual(row_response[1].timestamp_ns, TEST_TIMESTAMP // 1000 * 1000)
+
+    def test_ctor_bad_cell(self):
+        cells = [self._make_cell(), self._make_cell()]
+        cells[1].row_key = b"other"
+        with self.assertRaises(ValueError):
+            self._make_one(TEST_ROW_KEY, cells)
+
+    def test_cell_order(self):
+        # cells should be ordered on init
+        cell1 = self._make_cell(value=b"1")
+        cell2 = self._make_cell(value=b"2")
+        resp = self._make_one(TEST_ROW_KEY, [cell2, cell1])
+        output = list(resp)
+        self.assertEqual(output, [cell1, cell2])
+
+    def test_get_cells(self):
+        cell_list = []
+        for family_id in ["1", "2"]:
+            for qualifier in [b"a", b"b"]:
+                cell = self._make_cell(family_id=family_id, qualifier=qualifier)
+                cell_list.append(cell)
+        # test getting all cells
+        row_response = self._make_one(TEST_ROW_KEY, cell_list)
+        self.assertEqual(row_response.get_cells(), cell_list)
+        # test getting cells in a family
+        output = row_response.get_cells(family="1")
+        self.assertEqual(len(output), 2)
+        self.assertEqual(output[0].family, "1")
+        self.assertEqual(output[1].family, "1")
+        self.assertEqual(output[0], cell_list[0])
+        # test getting cells in a family/qualifier
+        # should accept bytes or str for qualifier
+        for q in [b"a", "a"]:
+            output = row_response.get_cells(family="1", qualifier=q)
+            self.assertEqual(len(output), 1)
+            self.assertEqual(output[0].family, "1")
+            self.assertEqual(output[0].column_qualifier, b"a")
+            self.assertEqual(output[0], cell_list[0])
+        # calling with just qualifier should raise an error
+        with self.assertRaises(ValueError):
+            row_response.get_cells(qualifier=b"a")
+        # test calling with bad family or qualifier
+        with self.assertRaises(ValueError):
+            row_response.get_cells(family="3", qualifier=b"a")
+        with self.assertRaises(ValueError):
+            row_response.get_cells(family="3")
+        with self.assertRaises(ValueError):
+            row_response.get_cells(family="1", qualifier=b"c")
+
+    def test__repr__(self):
+        from google.cloud.bigtable.row_response import CellResponse
+        from google.cloud.bigtable.row_response import RowResponse
+
+        cell_str = (
+            "{'value': b'1234', 'timestamp_ns': %d, 'labels': ['label1', 'label2']}"
+            % (TEST_TIMESTAMP)
+        )
+        expected_prefix = "RowResponse(key=b'row', cells="
+        row = self._make_one(TEST_ROW_KEY, [self._make_cell()])
+        self.assertIn(expected_prefix, repr(row))
+        self.assertIn(cell_str, repr(row))
+        expected_full = (
+            "RowResponse(key=b'row', cells={\n  ('cf1', b'col'): [{'value': b'1234', 'timestamp_ns': %d, 'labels': ['label1', 'label2']}],\n})"
+            % (TEST_TIMESTAMP)
+        )
+        self.assertEqual(expected_full, repr(row))
+        # should be able to construct instance from __repr__
+        result = eval(repr(row))
+        self.assertEqual(result, row)
+        self.assertIsInstance(result, RowResponse)
+        self.assertIsInstance(result[0], CellResponse)
+        # try with multiple cells
+        row = self._make_one(TEST_ROW_KEY, [self._make_cell(), self._make_cell()])
+        self.assertIn(expected_prefix, repr(row))
+        self.assertIn(cell_str, repr(row))
+        # should be able to construct instance from __repr__
+        result = eval(repr(row))
+        self.assertEqual(result, row)
+        self.assertIsInstance(result, RowResponse)
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], CellResponse)
+        self.assertIsInstance(result[1], CellResponse)
+
+    def test___str__(self):
+        cells = {
+            ("3", TEST_QUALIFIER): [
+                self._make_cell().to_dict(),
+                self._make_cell().to_dict(),
+                self._make_cell().to_dict(),
+            ]
+        }
+        cells[("1", TEST_QUALIFIER)] = [self._make_cell().to_dict()]
+
+        row_response = self._make_one(TEST_ROW_KEY, cells)
+        expected = (
+            "{\n"
+            + "  (family='1', qualifier=b'col'): [b'1234'],\n"
+            + "  (family='3', qualifier=b'col'): [b'1234', (+2 more)],\n"
+            + "}"
+        )
+        self.assertEqual(expected, str(row_response))
+
+    def test_to_dict(self):
+        from google.cloud.bigtable_v2.types import Row
+
+        cell1 = self._make_cell()
+        cell2 = self._make_cell()
+        cell2.value = b"other"
+        row = self._make_one(TEST_ROW_KEY, [cell1, cell2])
+        row_dict = row.to_dict()
+        expected_dict = {
+            "key": TEST_ROW_KEY,
+            "families": [
+                {
+                    "name": TEST_FAMILY_ID,
+                    "columns": [
+                        {
+                            "qualifier": TEST_QUALIFIER,
+                            "cells": [
+                                {
+                                    "value": TEST_VALUE,
+                                    "timestamp_micros": TEST_TIMESTAMP // 1000,
+                                    "labels": TEST_LABELS,
+                                },
+                                {
+                                    "value": b"other",
+                                    "timestamp_micros": TEST_TIMESTAMP // 1000,
+                                    "labels": TEST_LABELS,
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+        self.assertEqual(len(row_dict), len(expected_dict))
+        for key, value in expected_dict.items():
+            self.assertEqual(row_dict[key], value)
+        # should be able to construct a Cell proto from the dict
+        row_proto = Row(**row_dict)
+        self.assertEqual(row_proto.key, TEST_ROW_KEY)
+        self.assertEqual(len(row_proto.families), 1)
+        family = row_proto.families[0]
+        self.assertEqual(family.name, TEST_FAMILY_ID)
+        self.assertEqual(len(family.columns), 1)
+        column = family.columns[0]
+        self.assertEqual(column.qualifier, TEST_QUALIFIER)
+        self.assertEqual(len(column.cells), 2)
+        self.assertEqual(column.cells[0].value, TEST_VALUE)
+        self.assertEqual(column.cells[0].timestamp_micros, TEST_TIMESTAMP // 1000)
+        self.assertEqual(column.cells[0].labels, TEST_LABELS)
+        self.assertEqual(column.cells[1].value, cell2.value)
+        self.assertEqual(column.cells[1].timestamp_micros, TEST_TIMESTAMP // 1000)
+        self.assertEqual(column.cells[1].labels, TEST_LABELS)
+
+    def test_iteration(self):
+        from types import GeneratorType
+        from google.cloud.bigtable.row_response import CellResponse
+
+        # should be able to iterate over the RowResponse as a list
+        cell3 = self._make_cell(value=b"3")
+        cell1 = self._make_cell(value=b"1")
+        cell2 = self._make_cell(value=b"2")
+        row_response = self._make_one(TEST_ROW_KEY, [cell3, cell1, cell2])
+        self.assertEqual(len(row_response), 3)
+        # should create generator object
+        self.assertIsInstance(iter(row_response), GeneratorType)
+        result_list = list(row_response)
+        self.assertEqual(len(result_list), 3)
+        # should be able to iterate over all cells
+        idx = 0
+        for cell in row_response:
+            self.assertIsInstance(cell, CellResponse)
+            self.assertEqual(cell.value, result_list[idx].value)
+            self.assertEqual(cell.value, str(idx + 1).encode())
+            idx += 1
+
+    def test_contains_cell(self):
+        cell3 = self._make_cell(value=b"3")
+        cell1 = self._make_cell(value=b"1")
+        cell2 = self._make_cell(value=b"2")
+        cell4 = self._make_cell(value=b"4")
+        row_response = self._make_one(TEST_ROW_KEY, [cell3, cell1, cell2])
+        self.assertIn(cell1, row_response)
+        self.assertIn(cell2, row_response)
+        self.assertNotIn(cell4, row_response)
+        cell3_copy = self._make_cell(value=b"3")
+        self.assertIn(cell3_copy, row_response)
+
+    def test_contains_family_id(self):
+        new_family_id = "new_family_id"
+        cell = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        cell2 = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            new_family_id,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        row_response = self._make_one(TEST_ROW_KEY, [cell, cell2])
+        self.assertIn(TEST_FAMILY_ID, row_response)
+        self.assertIn("new_family_id", row_response)
+        self.assertIn(new_family_id, row_response)
+        self.assertNotIn("not_a_family_id", row_response)
+        self.assertNotIn(None, row_response)
+
+    def test_contains_family_qualifier_tuple(self):
+        new_family_id = "new_family_id"
+        new_qualifier = b"new_qualifier"
+        cell = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        cell2 = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            new_family_id,
+            new_qualifier,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        row_response = self._make_one(TEST_ROW_KEY, [cell, cell2])
+        self.assertIn((TEST_FAMILY_ID, TEST_QUALIFIER), row_response)
+        self.assertIn(("new_family_id", "new_qualifier"), row_response)
+        self.assertIn(("new_family_id", b"new_qualifier"), row_response)
+        self.assertIn((new_family_id, new_qualifier), row_response)
+
+        self.assertNotIn(("not_a_family_id", TEST_QUALIFIER), row_response)
+        self.assertNotIn((TEST_FAMILY_ID, "not_a_qualifier"), row_response)
+        self.assertNotIn((TEST_FAMILY_ID, new_qualifier), row_response)
+        self.assertNotIn(("not_a_family_id", "not_a_qualifier"), row_response)
+        self.assertNotIn((None, None), row_response)
+        self.assertNotIn(None, row_response)
+
+    def test_int_indexing(self):
+        # should be able to index into underlying list with an index number directly
+        cell_list = [self._make_cell(value=str(i).encode()) for i in range(10)]
+        sorted(cell_list)
+        row_response = self._make_one(TEST_ROW_KEY, cell_list)
+        self.assertEqual(len(row_response), 10)
+        for i in range(10):
+            self.assertEqual(row_response[i].value, str(i).encode())
+            # backwards indexing should work
+            self.assertEqual(row_response[-i - 1].value, str(9 - i).encode())
+        with self.assertRaises(IndexError):
+            row_response[10]
+        with self.assertRaises(IndexError):
+            row_response[-11]
+
+    def test_slice_indexing(self):
+        # should be able to index with a range of indices
+        cell_list = [self._make_cell(value=str(i).encode()) for i in range(10)]
+        sorted(cell_list)
+        row_response = self._make_one(TEST_ROW_KEY, cell_list)
+        self.assertEqual(len(row_response), 10)
+        self.assertEqual(len(row_response[0:10]), 10)
+        self.assertEqual(row_response[0:10], cell_list)
+        self.assertEqual(len(row_response[0:]), 10)
+        self.assertEqual(row_response[0:], cell_list)
+        self.assertEqual(len(row_response[:10]), 10)
+        self.assertEqual(row_response[:10], cell_list)
+        self.assertEqual(len(row_response[0:10:1]), 10)
+        self.assertEqual(row_response[0:10:1], cell_list)
+        self.assertEqual(len(row_response[0:10:2]), 5)
+        self.assertEqual(row_response[0:10:2], [cell_list[i] for i in range(0, 10, 2)])
+        self.assertEqual(len(row_response[0:10:3]), 4)
+        self.assertEqual(row_response[0:10:3], [cell_list[i] for i in range(0, 10, 3)])
+        self.assertEqual(len(row_response[10:0:-1]), 9)
+        self.assertEqual(len(row_response[10:0:-2]), 5)
+        self.assertEqual(row_response[10:0:-3], cell_list[10:0:-3])
+        self.assertEqual(len(row_response[0:100]), 10)
+
+    def test_family_indexing(self):
+        # should be able to retrieve cells in a family
+        new_family_id = "new_family_id"
+        cell = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        cell2 = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        cell3 = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            new_family_id,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        row_response = self._make_one(TEST_ROW_KEY, [cell, cell2, cell3])
+
+        self.assertEqual(len(row_response[TEST_FAMILY_ID]), 2)
+        self.assertEqual(row_response[TEST_FAMILY_ID][0], cell)
+        self.assertEqual(row_response[TEST_FAMILY_ID][1], cell2)
+        self.assertEqual(len(row_response[new_family_id]), 1)
+        self.assertEqual(row_response[new_family_id][0], cell3)
+        with self.assertRaises(ValueError):
+            row_response["not_a_family_id"]
+        with self.assertRaises(TypeError):
+            row_response[None]
+        with self.assertRaises(TypeError):
+            row_response[b"new_family_id"]
+
+    def test_family_qualifier_indexing(self):
+        # should be able to retrieve cells in a family/qualifier tuplw
+        new_family_id = "new_family_id"
+        new_qualifier = b"new_qualifier"
+        cell = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        cell2 = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        cell3 = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            new_family_id,
+            new_qualifier,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        row_response = self._make_one(TEST_ROW_KEY, [cell, cell2, cell3])
+
+        self.assertEqual(len(row_response[TEST_FAMILY_ID, TEST_QUALIFIER]), 2)
+        self.assertEqual(row_response[TEST_FAMILY_ID, TEST_QUALIFIER][0], cell)
+        self.assertEqual(row_response[TEST_FAMILY_ID, TEST_QUALIFIER][1], cell2)
+        self.assertEqual(len(row_response[new_family_id, new_qualifier]), 1)
+        self.assertEqual(row_response[new_family_id, new_qualifier][0], cell3)
+        self.assertEqual(len(row_response["new_family_id", "new_qualifier"]), 1)
+        self.assertEqual(len(row_response["new_family_id", b"new_qualifier"]), 1)
+        with self.assertRaises(ValueError):
+            row_response[new_family_id, "not_a_qualifier"]
+        with self.assertRaises(ValueError):
+            row_response["not_a_family_id", new_qualifier]
+        with self.assertRaises(TypeError):
+            row_response[None, None]
+        with self.assertRaises(TypeError):
+            row_response[b"new_family_id", b"new_qualifier"]
+
+    def test_keys(self):
+        # should be able to retrieve (family,qualifier) tuples as keys
+        new_family_id = "new_family_id"
+        new_qualifier = b"new_qualifier"
+        cell = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        cell2 = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        cell3 = self._make_cell(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            new_family_id,
+            new_qualifier,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        row_response = self._make_one(TEST_ROW_KEY, [cell, cell2, cell3])
+
+        self.assertEqual(len(row_response.keys()), 2)
+        self.assertEqual(
+            row_response.keys(),
+            [(TEST_FAMILY_ID, TEST_QUALIFIER), (new_family_id, new_qualifier)],
+        )
+
+        row_response = self._make_one(TEST_ROW_KEY, [])
+        self.assertEqual(len(row_response.keys()), 0)
+        self.assertEqual(row_response.keys(), [])
+
+        row_response = self._make_one(TEST_ROW_KEY, [cell])
+        self.assertEqual(len(row_response.keys()), 1)
+        self.assertEqual(row_response.keys(), [(TEST_FAMILY_ID, TEST_QUALIFIER)])
+
+    def test_values(self):
+        # values should return the list of all cells
+        cell_list = [self._make_cell(qualifier=str(i).encode()) for i in range(10)]
+        row_response = self._make_one(TEST_ROW_KEY, cell_list)
+        sorted(cell_list)
+
+        self.assertEqual(len(row_response.values()), 10)
+        self.assertEqual(row_response.values(), cell_list)
+
+    def test_items(self):
+        cell_list = [self._make_cell() for i in range(10)]
+        sorted(cell_list)
+        row_response = self._make_one(TEST_ROW_KEY, cell_list)
+
+        self.assertEqual(len(list(row_response.items())), 1)
+        self.assertEqual(
+            list(row_response.items())[0][0], (TEST_FAMILY_ID, TEST_QUALIFIER)
+        )
+        self.assertEqual(list(row_response.items())[0][1], cell_list)
+
+        row_response = self._make_one(TEST_ROW_KEY, [])
+        self.assertEqual(len(list(row_response.items())), 0)
+
+        cell_list = [self._make_cell(qualifier=str(i).encode()) for i in range(10)]
+        row_response = self._make_one(TEST_ROW_KEY, cell_list)
+        sorted(cell_list)
+        self.assertEqual(len(list(row_response.items())), 10)
+        keys = [t[0] for t in row_response.items()]
+        cells = [t[1] for t in row_response.items()]
+        for i in range(10):
+            self.assertEqual(keys[i], (TEST_FAMILY_ID, str(i).encode()))
+            self.assertEqual(len(cells[i]), 1)
+            self.assertEqual(cells[i][0], cell_list[i])
+
+    def test_index_of(self):
+        # given a cell, should find index in underlying list
+        cell_list = [self._make_cell(value=str(i).encode()) for i in range(10)]
+        sorted(cell_list)
+        row_response = self._make_one(TEST_ROW_KEY, cell_list)
+
+        self.assertEqual(row_response.index(cell_list[0]), 0)
+        self.assertEqual(row_response.index(cell_list[5]), 5)
+        self.assertEqual(row_response.index(cell_list[9]), 9)
+        with self.assertRaises(ValueError):
+            row_response.index(self._make_cell())
+        with self.assertRaises(ValueError):
+            row_response.index(None)
+
+
+class TestCellResponse(unittest.TestCase):
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.bigtable.row_response import CellResponse
+
+        return CellResponse
+
+    def _make_one(self, *args, **kwargs):
+        if len(args) == 0:
+            args = (
+                TEST_VALUE,
+                TEST_ROW_KEY,
+                TEST_FAMILY_ID,
+                TEST_QUALIFIER,
+                TEST_TIMESTAMP,
+                TEST_LABELS,
+            )
+        return self._get_target_class()(*args, **kwargs)
+
+    def test_ctor(self):
+        cell = self._make_one(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        self.assertEqual(cell.value, TEST_VALUE)
+        self.assertEqual(cell.row_key, TEST_ROW_KEY)
+        self.assertEqual(cell.family, TEST_FAMILY_ID)
+        self.assertEqual(cell.column_qualifier, TEST_QUALIFIER)
+        self.assertEqual(cell.timestamp_ns, TEST_TIMESTAMP)
+        self.assertEqual(cell.labels, TEST_LABELS)
+
+    def test_to_dict(self):
+        from google.cloud.bigtable_v2.types import Cell
+
+        cell = self._make_one()
+        cell_dict = cell.to_dict()
+        expected_dict = {
+            "value": TEST_VALUE,
+            "timestamp_micros": TEST_TIMESTAMP // 1000,
+            "labels": TEST_LABELS,
+        }
+        self.assertEqual(len(cell_dict), len(expected_dict))
+        for key, value in expected_dict.items():
+            self.assertEqual(cell_dict[key], value)
+        # should be able to construct a Cell proto from the dict
+        cell_proto = Cell(**cell_dict)
+        self.assertEqual(cell_proto.value, TEST_VALUE)
+        self.assertEqual(cell_proto.timestamp_micros, TEST_TIMESTAMP // 1000)
+        self.assertEqual(cell_proto.labels, TEST_LABELS)
+
+    def test_to_dict_nanos_timestamp(self):
+        cell = self._make_one()
+        cell_dict = cell.to_dict(use_nanoseconds=True)
+        expected_dict = {
+            "value": TEST_VALUE,
+            "timestamp_ns": TEST_TIMESTAMP,
+            "labels": TEST_LABELS,
+        }
+        self.assertEqual(len(cell_dict), len(expected_dict))
+        for key, value in expected_dict.items():
+            self.assertEqual(cell_dict[key], value)
+
+    def test_to_dict_no_labels(self):
+        from google.cloud.bigtable_v2.types import Cell
+
+        cell_no_labels = self._make_one(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            None,
+        )
+        cell_dict = cell_no_labels.to_dict()
+        expected_dict = {
+            "value": TEST_VALUE,
+            "timestamp_micros": TEST_TIMESTAMP // 1000,
+        }
+        self.assertEqual(len(cell_dict), len(expected_dict))
+        for key, value in expected_dict.items():
+            self.assertEqual(cell_dict[key], value)
+        # should be able to construct a Cell proto from the dict
+        cell_proto = Cell(**cell_dict)
+        self.assertEqual(cell_proto.value, TEST_VALUE)
+        self.assertEqual(cell_proto.timestamp_micros, TEST_TIMESTAMP // 1000)
+        self.assertEqual(cell_proto.labels, [])
+
+    def test_int_value(self):
+        test_int = 1234
+        bytes_value = test_int.to_bytes(4, "big", signed=True)
+        cell = self._make_one(
+            bytes_value,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        self.assertEqual(int(cell), test_int)
+        # ensure string formatting works
+        formatted = "%d" % cell
+        self.assertEqual(formatted, str(test_int))
+        self.assertEqual(int(formatted), test_int)
+
+    def test_int_value_negative(self):
+        test_int = -99999
+        bytes_value = test_int.to_bytes(4, "big", signed=True)
+        cell = self._make_one(
+            bytes_value,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        self.assertEqual(int(cell), test_int)
+        # ensure string formatting works
+        formatted = "%d" % cell
+        self.assertEqual(formatted, str(test_int))
+        self.assertEqual(int(formatted), test_int)
+
+    def test___str__(self):
+        test_value = b"helloworld"
+        cell = self._make_one(
+            test_value,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        self.assertEqual(str(cell), "b'helloworld'")
+        self.assertEqual(str(cell), str(test_value))
+
+    def test___repr__(self):
+        from google.cloud.bigtable.row_response import CellResponse  # type: ignore # noqa: F401
+
+        cell = self._make_one()
+        expected = (
+            "CellResponse(value=b'1234', row=b'row', "
+            + "family='cf1', column_qualifier=b'col', "
+            + f"timestamp_ns={TEST_TIMESTAMP}, labels=['label1', 'label2'])"
+        )
+        self.assertEqual(repr(cell), expected)
+        # should be able to construct instance from __repr__
+        result = eval(repr(cell))
+        self.assertEqual(result, cell)
+
+    def test___repr___no_labels(self):
+        from google.cloud.bigtable.row_response import CellResponse  # type: ignore # noqa: F401
+
+        cell_no_labels = self._make_one(
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            None,
+        )
+        expected = (
+            "CellResponse(value=b'1234', row=b'row', "
+            + "family='cf1', column_qualifier=b'col', "
+            + f"timestamp_ns={TEST_TIMESTAMP}, labels=[])"
+        )
+        self.assertEqual(repr(cell_no_labels), expected)
+        # should be able to construct instance from __repr__
+        result = eval(repr(cell_no_labels))
+        self.assertEqual(result, cell_no_labels)
+
+    def test_equality(self):
+        cell1 = self._make_one()
+        cell2 = self._make_one()
+        self.assertEqual(cell1, cell2)
+        self.assertTrue(cell1 == cell2)
+        args = (
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        for i in range(0, len(args)):
+            # try changing each argument
+            modified_cell = self._make_one(*args[:i], args[i] + args[i], *args[i + 1 :])
+            self.assertNotEqual(cell1, modified_cell)
+            self.assertFalse(cell1 == modified_cell)
+            self.assertTrue(cell1 != modified_cell)
+
+    def test_hash(self):
+        # class should be hashable
+        cell1 = self._make_one()
+        d = {cell1: 1}
+        cell2 = self._make_one()
+        self.assertEqual(d[cell2], 1)
+
+        args = (
+            TEST_VALUE,
+            TEST_ROW_KEY,
+            TEST_FAMILY_ID,
+            TEST_QUALIFIER,
+            TEST_TIMESTAMP,
+            TEST_LABELS,
+        )
+        for i in range(0, len(args)):
+            # try changing each argument
+            modified_cell = self._make_one(*args[:i], args[i] + args[i], *args[i + 1 :])
+            with self.assertRaises(KeyError):
+                d[modified_cell]
+
+    def test_ordering(self):
+        # create cell list in order from lowest to highest
+        higher_cells = []
+        i = 0
+        # families; alphebetical order
+        for family in ["z", "y", "x"]:
+            # qualifiers; lowest byte value first
+            for qualifier in [b"z", b"y", b"x"]:
+                # timestamps; newest first
+                for timestamp in [
+                    TEST_TIMESTAMP,
+                    TEST_TIMESTAMP + 1,
+                    TEST_TIMESTAMP + 2,
+                ]:
+                    cell = self._make_one(
+                        TEST_VALUE,
+                        TEST_ROW_KEY,
+                        family,
+                        qualifier,
+                        timestamp,
+                        TEST_LABELS,
+                    )
+                    # cell should be the highest priority encountered so far
+                    self.assertEqual(i, len(higher_cells))
+                    i += 1
+                    for other in higher_cells:
+                        self.assertLess(cell, other)
+                    higher_cells.append(cell)
+        # final order should be reverse of sorted order
+        expected_order = higher_cells
+        expected_order.reverse()
+        self.assertEqual(expected_order, sorted(higher_cells))

--- a/tests/unit/test_row_response.py
+++ b/tests/unit/test_row_response.py
@@ -490,13 +490,20 @@ class TestRowResponse(unittest.TestCase):
         self.assertEqual(row_response.keys(), [(TEST_FAMILY_ID, TEST_QUALIFIER)])
 
     def test_values(self):
-        # values should return the list of all cells
-        cell_list = [self._make_cell(qualifier=str(i).encode()) for i in range(10)]
+        # values should return the all cells, divided into lists
+        # according to (family,qualifier) pairs
+        cell_list = [self._make_cell(qualifier=str(i % 5).encode()) for i in range(10)]
         row_response = self._make_one(TEST_ROW_KEY, cell_list)
         sorted(cell_list)
 
-        self.assertEqual(len(row_response.values()), 10)
-        self.assertEqual(row_response.values(), cell_list)
+        values = list(row_response.values())
+        self.assertEqual(len(values), 5)
+        self.assertEqual(len(values[0]), 2)
+
+        keys = list(row_response.keys())
+        values = list(row_response.values())
+        for i in range(len(keys)):
+            self.assertEqual(row_response[keys[i]], values[i])
 
     def test_items(self):
         cell_list = [self._make_cell() for i in range(10)]

--- a/tests/unit/test_row_response.py
+++ b/tests/unit/test_row_response.py
@@ -445,7 +445,7 @@ class TestRowResponse(unittest.TestCase):
         with self.assertRaises(TypeError):
             row_response[b"new_family_id", b"new_qualifier"]
 
-    def test_keys(self):
+    def test_get_column_components(self):
         # should be able to retrieve (family,qualifier) tuples as keys
         new_family_id = "new_family_id"
         new_qualifier = b"new_qualifier"
@@ -475,60 +475,20 @@ class TestRowResponse(unittest.TestCase):
         )
         row_response = self._make_one(TEST_ROW_KEY, [cell, cell2, cell3])
 
-        self.assertEqual(len(row_response.keys()), 2)
+        self.assertEqual(len(row_response.get_column_components()), 2)
         self.assertEqual(
-            row_response.keys(),
+            row_response.get_column_components(),
             [(TEST_FAMILY_ID, TEST_QUALIFIER), (new_family_id, new_qualifier)],
         )
 
         row_response = self._make_one(TEST_ROW_KEY, [])
-        self.assertEqual(len(row_response.keys()), 0)
-        self.assertEqual(row_response.keys(), [])
+        self.assertEqual(len(row_response.get_column_components()), 0)
+        self.assertEqual(row_response.get_column_components(), [])
 
         row_response = self._make_one(TEST_ROW_KEY, [cell])
-        self.assertEqual(len(row_response.keys()), 1)
-        self.assertEqual(row_response.keys(), [(TEST_FAMILY_ID, TEST_QUALIFIER)])
+        self.assertEqual(len(row_response.get_column_components()), 1)
+        self.assertEqual(row_response.get_column_components(), [(TEST_FAMILY_ID, TEST_QUALIFIER)])
 
-    def test_values(self):
-        # values should return the all cells, divided into lists
-        # according to (family,qualifier) pairs
-        cell_list = [self._make_cell(qualifier=str(i % 5).encode()) for i in range(10)]
-        row_response = self._make_one(TEST_ROW_KEY, cell_list)
-        sorted(cell_list)
-
-        values = list(row_response.values())
-        self.assertEqual(len(values), 5)
-        self.assertEqual(len(values[0]), 2)
-
-        keys = list(row_response.keys())
-        values = list(row_response.values())
-        for i in range(len(keys)):
-            self.assertEqual(row_response[keys[i]], values[i])
-
-    def test_items(self):
-        cell_list = [self._make_cell() for i in range(10)]
-        sorted(cell_list)
-        row_response = self._make_one(TEST_ROW_KEY, cell_list)
-
-        self.assertEqual(len(list(row_response.items())), 1)
-        self.assertEqual(
-            list(row_response.items())[0][0], (TEST_FAMILY_ID, TEST_QUALIFIER)
-        )
-        self.assertEqual(list(row_response.items())[0][1], cell_list)
-
-        row_response = self._make_one(TEST_ROW_KEY, [])
-        self.assertEqual(len(list(row_response.items())), 0)
-
-        cell_list = [self._make_cell(qualifier=str(i).encode()) for i in range(10)]
-        row_response = self._make_one(TEST_ROW_KEY, cell_list)
-        sorted(cell_list)
-        self.assertEqual(len(list(row_response.items())), 10)
-        keys = [t[0] for t in row_response.items()]
-        cells = [t[1] for t in row_response.items()]
-        for i in range(10):
-            self.assertEqual(keys[i], (TEST_FAMILY_ID, str(i).encode()))
-            self.assertEqual(len(cells[i]), 1)
-            self.assertEqual(cells[i][0], cell_list[i])
 
     def test_index_of(self):
         # given a cell, should find index in underlying list


### PR DESCRIPTION
This PR implements the RowResponse and CellResponse classes, used to represent the data returned by read_rows queries

RowResponse implements Sequence, allowing it to be treated like a list of Cells (len, iteration, indexing, etc)

It also implements some properties of Mapping (allowing it to be indexed by `family` and `(family, qualifier)` keys, retrieving the list of keys, values, items, etc)

---

Note: This is merging into a new v3 branch, not main. I plan on making all PRs related to this rewrite to v3 and then merging v3 into main when development is complete