### PR TITLE
fix: require google-cloud-core 1.4.4

### DIFF
--- a/samples/hello_happybase/requirements.txt
+++ b/samples/hello_happybase/requirements.txt
@@ -1,1 +1,2 @@
 google-cloud-happybase==0.33.0
+six==1.16.0 # See https://github.com/googleapis/google-cloud-python-happybase/issues/128

--- a/samples/quickstart_happybase/requirements.txt
+++ b/samples/quickstart_happybase/requirements.txt
@@ -1,1 +1,2 @@
 google-cloud-happybase==0.33.0
+six==1.16.0 # See https://github.com/googleapis/google-cloud-python-happybase/issues/128

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ version = version["__version__"]
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.34.0, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "google-cloud-core >= 1.4.1, <3.0.0dev",
+    "google-cloud-core >= 1.4.4, <3.0.0dev",
     "grpc-google-iam-v1 >= 0.12.4, <1.0.0dev",
     "proto-plus >= 1.22.0, <2.0.0dev",
     "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -6,7 +6,7 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 google-api-core==1.34.0
-google-cloud-core==1.4.1
+google-cloud-core==1.4.4
 grpc-google-iam-v1==0.12.4
 proto-plus==1.22.0
 libcst==0.2.5


### PR DESCRIPTION
The dependency `six` was added in `google-cloud-core==1.4.4` . The `google-cloud-core==1.4.1` doesn't declare the dependency on `six`. 

https://github.com/googleapis/python-bigtable/blob/4105df762f1318c49bba030063897f0c50e4daee/setup.py#L41

Fixes https://github.com/googleapis/python-bigtable/issues/864 🦕
