### PR TITLE
feat: replace internal dictionaries with protos in gapic calls

### DIFF
--- a/google/cloud/bigtable/data/_async/_mutate_rows.py
+++ b/google/cloud/bigtable/data/_async/_mutate_rows.py
@@ -43,6 +43,7 @@ class _EntryWithProto:
     """
     A dataclass to hold a RowMutationEntry and its corresponding proto representation.
     """
+
     entry: RowMutationEntry
     proto: types_pb.MutateRowsRequest.Entry
 
@@ -164,9 +165,7 @@ class _MutateRowsOperationAsync:
               retry after the attempt is complete
           - GoogleAPICallError: if the gapic rpc fails
         """
-        request_entries = [
-            self.mutations[idx].proto for idx in self.remaining_indices
-        ]
+        request_entries = [self.mutations[idx].proto for idx in self.remaining_indices]
         # track mutations in this request that have not been finalized yet
         active_request_indices = {
             req_idx: orig_idx for req_idx, orig_idx in enumerate(self.remaining_indices)

--- a/google/cloud/bigtable/data/_async/_mutate_rows.py
+++ b/google/cloud/bigtable/data/_async/_mutate_rows.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 import asyncio
+from dataclasses import dataclass
 import functools
 
 from google.api_core import exceptions as core_exceptions
 from google.api_core import retry_async as retries
+import google.cloud.bigtable_v2.types.bigtable as types_pb
 import google.cloud.bigtable.data.exceptions as bt_exceptions
 from google.cloud.bigtable.data._helpers import _make_metadata
 from google.cloud.bigtable.data._helpers import _convert_retry_deadline
@@ -34,6 +36,15 @@ if TYPE_CHECKING:
     )
     from google.cloud.bigtable.data.mutations import RowMutationEntry
     from google.cloud.bigtable.data._async.client import TableAsync
+
+
+@dataclass
+class _EntryWithProto:
+    """
+    A dataclass to hold a RowMutationEntry and its corresponding proto representation.
+    """
+    entry: RowMutationEntry
+    proto: types_pb.MutateRowsRequest.Entry
 
 
 class _MutateRowsOperationAsync:
@@ -104,7 +115,7 @@ class _MutateRowsOperationAsync:
         self.timeout_generator = _attempt_timeout_generator(
             attempt_timeout, operation_timeout
         )
-        self.mutations = [(m, m._to_pb()) for m in mutation_entries]
+        self.mutations = [_EntryWithProto(m, m._to_pb()) for m in mutation_entries]
         self.remaining_indices = list(range(len(self.mutations)))
         self.errors: dict[int, list[Exception]] = {}
 
@@ -135,7 +146,7 @@ class _MutateRowsOperationAsync:
                     cause_exc = exc_list[0]
                 else:
                     cause_exc = bt_exceptions.RetryExceptionGroup(exc_list)
-                entry = self.mutations[idx][0]
+                entry = self.mutations[idx].entry
                 all_errors.append(
                     bt_exceptions.FailedMutationEntryError(idx, entry, cause_exc)
                 )
@@ -154,7 +165,7 @@ class _MutateRowsOperationAsync:
           - GoogleAPICallError: if the gapic rpc fails
         """
         request_entries = [
-            self.mutations[idx][1] for idx in self.remaining_indices
+            self.mutations[idx].proto for idx in self.remaining_indices
         ]
         # track mutations in this request that have not been finalized yet
         active_request_indices = {
@@ -213,7 +224,7 @@ class _MutateRowsOperationAsync:
           - idx: the index of the mutation that failed
           - exc: the exception to add to the list
         """
-        entry = self.mutations[idx][0]
+        entry = self.mutations[idx].entry
         self.errors.setdefault(idx, []).append(exc)
         if (
             entry.is_idempotent()

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -1093,29 +1093,24 @@ class TableAsync:
         operation_timeout = operation_timeout or self.default_operation_timeout
         if operation_timeout <= 0:
             raise ValueError("operation_timeout must be greater than 0")
-        row_key = row_key.encode("utf-8") if isinstance(row_key, str) else row_key
         if true_case_mutations is not None and not isinstance(
             true_case_mutations, list
         ):
             true_case_mutations = [true_case_mutations]
-        true_case_dict = [m._to_dict() for m in true_case_mutations or []]
+        true_case_list = [m._to_pb() for m in true_case_mutations or []]
         if false_case_mutations is not None and not isinstance(
             false_case_mutations, list
         ):
             false_case_mutations = [false_case_mutations]
-        false_case_dict = [m._to_dict() for m in false_case_mutations or []]
+        false_case_list = [m._to_pb() for m in false_case_mutations or []]
         metadata = _make_metadata(self.table_name, self.app_profile_id)
         result = await self.client._gapic_client.check_and_mutate_row(
-            request={
-                "predicate_filter": predicate._to_dict()
-                if predicate is not None
-                else None,
-                "true_mutations": true_case_dict,
-                "false_mutations": false_case_dict,
-                "table_name": self.table_name,
-                "row_key": row_key,
-                "app_profile_id": self.app_profile_id,
-            },
+            true_mutations=true_case_list,
+            false_mutations=false_case_list,
+            predicate_filter=predicate._to_pb() if predicate is not None else None,
+            row_key=row_key.encode("utf-8") if isinstance(row_key, str) else row_key,
+            table_name=self.table_name,
+            app_profile_id=self.app_profile_id,
             metadata=metadata,
             timeout=operation_timeout,
         )

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -943,6 +943,7 @@ class TableAsync:
                  GoogleAPIError exceptions from any retries that failed
              - GoogleAPIError: raised on non-idempotent operations that cannot be
                  safely retried.
+            - ValueError if invalid arguments are provided
         """
         operation_timeout = operation_timeout or self.default_operation_timeout
         attempt_timeout = (
@@ -950,8 +951,11 @@ class TableAsync:
         )
         _validate_timeouts(operation_timeout, attempt_timeout)
 
-        if isinstance(mutations, Mutation):
+        if mutations and not isinstance(mutations, list):
             mutations = [mutations]
+        if not mutations:
+            raise ValueError("No mutations provided")
+
         if all(mutation.is_idempotent() for mutation in mutations):
             # mutations are all idempotent and safe to retry
             predicate = retries.if_exception_type(

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -951,9 +951,9 @@ class TableAsync:
         )
         _validate_timeouts(operation_timeout, attempt_timeout)
 
-        mutations_list = mutations if isinstance(mutations, list) else [mutations]
-        if not mutations_list:
+        if not mutations:
             raise ValueError("No mutations provided")
+        mutations_list = mutations if isinstance(mutations, list) else [mutations]
 
         if all(mutation.is_idempotent() for mutation in mutations_list):
             # mutations are all idempotent and safe to retry

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -995,7 +995,7 @@ class TableAsync:
             app_profile_id=self.app_profile_id,
             timeout=attempt_timeout,
             metadata=metadata,
-            retry=None
+            retry=None,
         )
 
     async def bulk_mutate_rows(
@@ -1032,6 +1032,7 @@ class TableAsync:
         Raises:
             - MutationsExceptionGroup if one or more mutations fails
                 Contains details about any failed entries in .exceptions
+            - ValueError if invalid arguments are provided
         """
         operation_timeout = (
             operation_timeout or self.default_mutate_rows_operation_timeout

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -951,12 +951,11 @@ class TableAsync:
         )
         _validate_timeouts(operation_timeout, attempt_timeout)
 
-        if mutations and not isinstance(mutations, list):
-            mutations = [mutations]
-        if not mutations:
+        mutations_list = mutations if isinstance(mutations, list) else [mutations]
+        if not mutations_list:
             raise ValueError("No mutations provided")
 
-        if all(mutation.is_idempotent() for mutation in mutations):
+        if all(mutation.is_idempotent() for mutation in mutations_list):
             # mutations are all idempotent and safe to retry
             predicate = retries.if_exception_type(
                 core_exceptions.DeadlineExceeded,
@@ -990,7 +989,7 @@ class TableAsync:
         # trigger rpc
         await deadline_wrapped(
             row_key=row_key.encode("utf-8") if isinstance(row_key, str) else row_key,
-            mutations=[mutation._to_pb() for mutation in mutations],
+            mutations=[mutation._to_pb() for mutation in mutations_list],
             table_name=self.table_name,
             app_profile_id=self.app_profile_id,
             timeout=attempt_timeout,

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -1145,25 +1145,21 @@ class TableAsync:
                 operation
         Raises:
             - GoogleAPIError exceptions from grpc call
+            - ValueError if invalid arguments are provided
         """
         operation_timeout = operation_timeout or self.default_operation_timeout
-        row_key = row_key.encode("utf-8") if isinstance(row_key, str) else row_key
         if operation_timeout <= 0:
             raise ValueError("operation_timeout must be greater than 0")
         if rules is not None and not isinstance(rules, list):
             rules = [rules]
         if not rules:
             raise ValueError("rules must contain at least one item")
-        # concert to dict representation
-        rules_dict = [rule._to_dict() for rule in rules]
         metadata = _make_metadata(self.table_name, self.app_profile_id)
         result = await self.client._gapic_client.read_modify_write_row(
-            request={
-                "rules": rules_dict,
-                "table_name": self.table_name,
-                "row_key": row_key,
-                "app_profile_id": self.app_profile_id,
-            },
+            rules=[rule._to_pb() for rule in rules],
+            row_key=row_key.encode("utf-8") if isinstance(row_key, str) else row_key,
+            table_name=self.table_name,
+            app_profile_id=self.app_profile_id,
             metadata=metadata,
             timeout=operation_timeout,
         )

--- a/google/cloud/bigtable/data/_async/mutations_batcher.py
+++ b/google/cloud/bigtable/data/_async/mutations_batcher.py
@@ -347,9 +347,6 @@ class MutationsBatcherAsync:
           - list of FailedMutationEntryError objects for mutations that failed.
               FailedMutationEntryError objects will not contain index information
         """
-        request = {"table_name": self._table.table_name}
-        if self._table.app_profile_id:
-            request["app_profile_id"] = self._table.app_profile_id
         try:
             operation = _MutateRowsOperationAsync(
                 self._table.client._gapic_client,

--- a/google/cloud/bigtable/data/mutations.py
+++ b/google/cloud/bigtable/data/mutations.py
@@ -19,8 +19,11 @@ from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from sys import getsizeof
 
+import google.cloud.bigtable_v2.types.bigtable as types_pb
+import google.cloud.bigtable_v2.types.data as data_pb
 
 from google.cloud.bigtable.data.read_modify_write_rules import _MAX_INCREMENT_VALUE
+
 
 # special value for SetCell mutation timestamps. If set, server will assign a timestamp
 _SERVER_SIDE_TIMESTAMP = -1
@@ -35,6 +38,12 @@ class Mutation(ABC):
     @abstractmethod
     def _to_dict(self) -> dict[str, Any]:
         raise NotImplementedError
+
+    def _to_pb(self) -> data_pb.Mutation:
+        """
+        Convert the mutation to protobuf
+        """
+        return data_pb.Mutation(**self._to_dict())
 
     def is_idempotent(self) -> bool:
         """
@@ -220,6 +229,12 @@ class RowMutationEntry:
             "row_key": self.row_key,
             "mutations": [mutation._to_dict() for mutation in self.mutations],
         }
+
+    def _to_pb(self) -> types_pb.MutateRowsRequest.Entry:
+        return types_pb.MutateRowsRequest.Entry(
+            row_key=self.row_key,
+            mutations=[mutation._to_pb() for mutation in self.mutations],
+        )
 
     def is_idempotent(self) -> bool:
         """Check if the mutation is idempotent"""

--- a/google/cloud/bigtable/data/read_modify_write_rules.py
+++ b/google/cloud/bigtable/data/read_modify_write_rules.py
@@ -69,7 +69,7 @@ class AppendValueRule(ReadModifyWriteRule):
         super().__init__(family, qualifier)
         self.append_value = append_value
 
-    def _to_dict(self) -> dict[str, str | bytes]:
+    def _to_dict(self) -> dict[str, str | bytes | int]:
         return {
             "family_name": self.family,
             "column_qualifier": self.qualifier,

--- a/google/cloud/bigtable/data/read_modify_write_rules.py
+++ b/google/cloud/bigtable/data/read_modify_write_rules.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import abc
 
+import google.cloud.bigtable_v2.types.data as data_pb
+
 # value must fit in 64-bit signed integer
 _MAX_INCREMENT_VALUE = (1 << 63) - 1
 
@@ -29,8 +31,11 @@ class ReadModifyWriteRule(abc.ABC):
         self.qualifier = qualifier
 
     @abc.abstractmethod
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, str | bytes | int]:
         raise NotImplementedError
+
+    def _to_pb(self) -> data_pb.ReadModifyWriteRule:
+        return data_pb.ReadModifyWriteRule(**self._to_dict())
 
 
 class IncrementRule(ReadModifyWriteRule):
@@ -44,7 +49,7 @@ class IncrementRule(ReadModifyWriteRule):
         super().__init__(family, qualifier)
         self.increment_amount = increment_amount
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, str | bytes | int]:
         return {
             "family_name": self.family,
             "column_qualifier": self.qualifier,
@@ -64,7 +69,7 @@ class AppendValueRule(ReadModifyWriteRule):
         super().__init__(family, qualifier)
         self.append_value = append_value
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, str | bytes]:
         return {
             "family_name": self.family,
             "column_qualifier": self.qualifier,

--- a/tests/unit/data/_async/test__mutate_rows.py
+++ b/tests/unit/data/_async/test__mutate_rows.py
@@ -75,6 +75,7 @@ class TestMutateRowsOperation:
         """
         test that constructor sets all the attributes correctly
         """
+        from google.cloud.bigtable.data._async._mutate_rows import _EntryWithProto
         from google.cloud.bigtable.data.exceptions import _MutateRowsIncomplete
         from google.api_core.exceptions import DeadlineExceeded
         from google.api_core.exceptions import ServiceUnavailable
@@ -102,7 +103,7 @@ class TestMutateRowsOperation:
         assert str(table.table_name) in metadata[0][1]
         assert str(table.app_profile_id) in metadata[0][1]
         # entries should be passed down
-        entries_w_pb = [(e, e._to_pb()) for e in entries]
+        entries_w_pb = [_EntryWithProto(e, e._to_pb()) for e in entries]
         assert instance.mutations == entries_w_pb
         # timeout_gen should generate per-attempt timeout
         assert next(instance.timeout_generator) == attempt_timeout

--- a/tests/unit/data/_async/test__mutate_rows.py
+++ b/tests/unit/data/_async/test__mutate_rows.py
@@ -102,7 +102,8 @@ class TestMutateRowsOperation:
         assert str(table.table_name) in metadata[0][1]
         assert str(table.app_profile_id) in metadata[0][1]
         # entries should be passed down
-        assert instance.mutations == entries
+        entries_w_pb = [(e, e._to_pb()) for e in entries]
+        assert instance.mutations == entries_w_pb
         # timeout_gen should generate per-attempt timeout
         assert next(instance.timeout_generator) == attempt_timeout
         # ensure predicate is set
@@ -305,7 +306,7 @@ class TestMutateRowsOperation:
         assert mock_gapic_fn.call_count == 1
         _, kwargs = mock_gapic_fn.call_args
         assert kwargs["timeout"] == expected_timeout
-        assert kwargs["entries"] == [mutation._to_dict()]
+        assert kwargs["entries"] == [mutation._to_pb()]
 
     @pytest.mark.asyncio
     async def test_run_attempt_empty_request(self):

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -2142,7 +2142,7 @@ class TestMutateRow:
                 with mock.patch.object(
                     client._gapic_client, "mutate_row", AsyncMock()
                 ) as read_rows:
-                    await table.mutate_row("rk", {})
+                    await table.mutate_row("rk", mock.Mock())
                 kwargs = read_rows.call_args_list[0].kwargs
                 metadata = kwargs["metadata"]
                 goog_metadata = None
@@ -2155,6 +2155,15 @@ class TestMutateRow:
                     assert "app_profile_id=profile" in goog_metadata
                 else:
                     assert "app_profile_id=" not in goog_metadata
+
+    @pytest.mark.parametrize("mutations", [[], None])
+    @pytest.mark.asyncio
+    async def test_mutate_row_no_mutations(self, mutations):
+        async with self._make_client() as client:
+            async with client.get_table("instance", "table") as table:
+                with pytest.raises(ValueError) as e:
+                    await table.mutate_row("key", mutations=mutations)
+                    assert e.value.args[0] == "No mutations provided"
 
 
 class TestBulkMutateRows:

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -2748,18 +2748,18 @@ class TestReadModifyWriteRow:
         [
             (
                 AppendValueRule("f", "c", b"1"),
-                [AppendValueRule("f", "c", b"1")._to_dict()],
+                [AppendValueRule("f", "c", b"1")._to_pb()],
             ),
             (
                 [AppendValueRule("f", "c", b"1")],
-                [AppendValueRule("f", "c", b"1")._to_dict()],
+                [AppendValueRule("f", "c", b"1")._to_pb()],
             ),
-            (IncrementRule("f", "c", 1), [IncrementRule("f", "c", 1)._to_dict()]),
+            (IncrementRule("f", "c", 1), [IncrementRule("f", "c", 1)._to_pb()]),
             (
                 [AppendValueRule("f", "c", b"1"), IncrementRule("f", "c", 1)],
                 [
-                    AppendValueRule("f", "c", b"1")._to_dict(),
-                    IncrementRule("f", "c", 1)._to_dict(),
+                    AppendValueRule("f", "c", b"1")._to_pb(),
+                    IncrementRule("f", "c", 1)._to_pb(),
                 ],
             ),
         ],
@@ -2777,7 +2777,7 @@ class TestReadModifyWriteRow:
                     await table.read_modify_write_row("key", call_rules)
                 assert mock_gapic.call_count == 1
                 found_kwargs = mock_gapic.call_args_list[0][1]
-                assert found_kwargs["request"]["rules"] == expected_rules
+                assert found_kwargs["rules"] == expected_rules
 
     @pytest.mark.parametrize("rules", [[], None])
     @pytest.mark.asyncio
@@ -2801,15 +2801,14 @@ class TestReadModifyWriteRow:
                 ) as mock_gapic:
                     await table.read_modify_write_row(row_key, mock.Mock())
                     assert mock_gapic.call_count == 1
-                    found_kwargs = mock_gapic.call_args_list[0][1]
-                    request = found_kwargs["request"]
+                    kwargs = mock_gapic.call_args_list[0][1]
                     assert (
-                        request["table_name"]
+                        kwargs["table_name"]
                         == f"projects/{project}/instances/{instance}/tables/{table_id}"
                     )
-                    assert request["app_profile_id"] is None
-                    assert request["row_key"] == row_key.encode()
-                    assert found_kwargs["timeout"] > 1
+                    assert kwargs["app_profile_id"] is None
+                    assert kwargs["row_key"] == row_key.encode()
+                    assert kwargs["timeout"] > 1
 
     @pytest.mark.asyncio
     async def test_read_modify_write_call_overrides(self):
@@ -2829,11 +2828,10 @@ class TestReadModifyWriteRow:
                         operation_timeout=expected_timeout,
                     )
                     assert mock_gapic.call_count == 1
-                    found_kwargs = mock_gapic.call_args_list[0][1]
-                    request = found_kwargs["request"]
-                    assert request["app_profile_id"] is profile_id
-                    assert request["row_key"] == row_key
-                    assert found_kwargs["timeout"] == expected_timeout
+                    kwargs = mock_gapic.call_args_list[0][1]
+                    assert kwargs["app_profile_id"] is profile_id
+                    assert kwargs["row_key"] == row_key
+                    assert kwargs["timeout"] == expected_timeout
 
     @pytest.mark.asyncio
     async def test_read_modify_write_string_key(self):
@@ -2845,8 +2843,8 @@ class TestReadModifyWriteRow:
                 ) as mock_gapic:
                     await table.read_modify_write_row(row_key, mock.Mock())
                     assert mock_gapic.call_count == 1
-                    found_kwargs = mock_gapic.call_args_list[0][1]
-                    assert found_kwargs["request"]["row_key"] == row_key.encode()
+                    kwargs = mock_gapic.call_args_list[0][1]
+                    assert kwargs["row_key"] == row_key.encode()
 
     @pytest.mark.asyncio
     async def test_read_modify_write_row_building(self):

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -2029,18 +2029,17 @@ class TestMutateRow:
                     )
                     assert mock_gapic.call_count == 1
                     kwargs = mock_gapic.call_args_list[0].kwargs
-                    request = mock_gapic.call_args[0][0]
                     assert (
-                        request["table_name"]
+                        kwargs["table_name"]
                         == "projects/project/instances/instance/tables/table"
                     )
-                    assert request["row_key"] == b"row_key"
+                    assert kwargs["row_key"] == b"row_key"
                     formatted_mutations = (
-                        [mutation._to_dict() for mutation in mutation_arg]
+                        [mutation._to_pb() for mutation in mutation_arg]
                         if isinstance(mutation_arg, list)
-                        else [mutation_arg._to_dict()]
+                        else [mutation_arg._to_pb()]
                     )
-                    assert request["mutations"] == formatted_mutations
+                    assert kwargs["mutations"] == formatted_mutations
                     assert kwargs["timeout"] == expected_attempt_timeout
                     # make sure gapic layer is not retrying
                     assert kwargs["retry"] is None

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -2229,7 +2229,7 @@ class TestBulkMutateRows:
                         kwargs["table_name"]
                         == "projects/project/instances/instance/tables/table"
                     )
-                    assert kwargs["entries"] == [bulk_mutation._to_dict()]
+                    assert kwargs["entries"] == [bulk_mutation._to_pb()]
                     assert kwargs["timeout"] == expected_attempt_timeout
 
     @pytest.mark.asyncio
@@ -2253,8 +2253,8 @@ class TestBulkMutateRows:
                         kwargs["table_name"]
                         == "projects/project/instances/instance/tables/table"
                     )
-                    assert kwargs["entries"][0] == entry_1._to_dict()
-                    assert kwargs["entries"][1] == entry_2._to_dict()
+                    assert kwargs["entries"][0] == entry_1._to_pb()
+                    assert kwargs["entries"][1] == entry_2._to_pb()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/unit/data/test_read_modify_write_rules.py
+++ b/tests/unit/data/test_read_modify_write_rules.py
@@ -36,6 +36,9 @@ class TestBaseReadModifyWriteRule:
             self._target_class()(family="foo", qualifier=b"bar")
 
     def test__to_dict(self):
+        """
+        to_dict not implemented in base class
+        """
         with pytest.raises(NotImplementedError):
             self._target_class()._to_dict(mock.Mock())
 
@@ -97,6 +100,27 @@ class TestIncrementRule:
         }
         assert instance._to_dict() == expected
 
+    @pytest.mark.parametrize(
+        "args,expected",
+        [
+            (("fam", b"qual", 1), ("fam", b"qual", 1)),
+            (("fam", b"qual", -12), ("fam", b"qual", -12)),
+            (("fam", "qual", 1), ("fam", b"qual", 1)),
+            (("fam", "qual", 0), ("fam", b"qual", 0)),
+            (("", "", 0), ("", b"", 0)),
+            (("f", b"q"), ("f", b"q", 1)),
+        ],
+    )
+    def test__to_pb(self, args, expected):
+        import google.cloud.bigtable_v2.types.data as data_pb
+
+        instance = self._target_class()(*args)
+        pb_result = instance._to_pb()
+        assert isinstance(pb_result, data_pb.ReadModifyWriteRule)
+        assert pb_result.family_name == expected[0]
+        assert pb_result.column_qualifier == expected[1]
+        assert pb_result.increment_amount == expected[2]
+
 
 class TestAppendValueRule:
     def _target_class(self):
@@ -142,3 +166,21 @@ class TestAppendValueRule:
             "append_value": expected[2],
         }
         assert instance._to_dict() == expected
+
+    @pytest.mark.parametrize(
+        "args,expected",
+        [
+            (("fam", b"qual", b"val"), ("fam", b"qual", b"val")),
+            (("fam", "qual", b"val"), ("fam", b"qual", b"val")),
+            (("", "", b""), ("", b"", b"")),
+        ],
+    )
+    def test__to_pb(self, args, expected):
+        import google.cloud.bigtable_v2.types.data as data_pb
+
+        instance = self._target_class()(*args)
+        pb_result = instance._to_pb()
+        assert isinstance(pb_result, data_pb.ReadModifyWriteRule)
+        assert pb_result.family_name == expected[0]
+        assert pb_result.column_qualifier == expected[1]
+        assert pb_result.append_value == expected[2]


### PR DESCRIPTION
Replace dicts with protos in the following rpc calls:
- [x] mutate_row
- [x] check_and_mutate
- [x] read_modify_write
- [x] MutateRowsOperationAsync

This will help us catch errors with easier type checking, and should have minor performance benefits

Fixes https://github.com/googleapis/python-bigtable/issues/779
