### PR TITLE
feat: expose retryable error codes to users

### DIFF
--- a/google/cloud/bigtable/data/_async/_mutate_rows.py
+++ b/google/cloud/bigtable/data/_async/_mutate_rows.py
@@ -14,7 +14,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Sequence, TYPE_CHECKING
 import asyncio
 import functools
 
@@ -54,6 +54,7 @@ class _MutateRowsOperationAsync:
         mutation_entries: list["RowMutationEntry"],
         operation_timeout: float,
         attempt_timeout: float | None,
+        retryable_exceptions: Sequence[type[Exception]] = (),
     ):
         """
         Args:
@@ -83,8 +84,7 @@ class _MutateRowsOperationAsync:
         # create predicate for determining which errors are retryable
         self.is_retryable = retries.if_exception_type(
             # RPC level errors
-            core_exceptions.DeadlineExceeded,
-            core_exceptions.ServiceUnavailable,
+            *retryable_exceptions,
             # Entry level errors
             bt_exceptions._MutateRowsIncomplete,
         )

--- a/google/cloud/bigtable/data/_async/_read_rows.py
+++ b/google/cloud/bigtable/data/_async/_read_rows.py
@@ -21,7 +21,6 @@ from typing import (
     AsyncIterable,
     Awaitable,
     Sequence,
-    Type,
 )
 
 from google.cloud.bigtable_v2.types import ReadRowsRequest as ReadRowsRequestPB
@@ -44,12 +43,6 @@ from google.api_core import exceptions as core_exceptions
 
 if TYPE_CHECKING:
     from google.cloud.bigtable.data._async.client import TableAsync
-
-DEFAULT_READ_ROWS_RETRYABLE_ERRORS = (
-    core_exceptions.DeadlineExceeded,
-    core_exceptions.ServiceUnavailable,
-    core_exceptions.Aborted,
-)
 
 
 class _ResetRow(Exception):
@@ -87,9 +80,7 @@ class _ReadRowsOperationAsync:
         table: "TableAsync",
         operation_timeout: float,
         attempt_timeout: float,
-        retryable_exceptions: Sequence[
-            Type[Exception]
-        ] = DEFAULT_READ_ROWS_RETRYABLE_ERRORS,
+        retryable_exceptions: Sequence[type[Exception]] = (),
     ):
         self.attempt_timeout_gen = _attempt_timeout_generator(
             attempt_timeout, operation_timeout

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -497,6 +497,8 @@ class TableAsync:
         Raises:
           - RuntimeError if called outside of an async context (no running event loop)
         """
+        # NOTE: any changes to the signature of this method should also be reflected
+        # in client.get_table()
         # validate timeouts
         _validate_timeouts(
             default_operation_timeout, default_attempt_timeout, allow_none=True

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -1047,8 +1047,8 @@ class TableAsync:
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
                 Only idempotent mutations will be retried.
-                If None, uses the Table's default_read_rows_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded), 14 (ServiceUnavailable), and 10 (Aborted)
+                If None, uses the Table's default_retryable_error_codes, which defaults
+                to 4 (DeadlineExceeded), and 14 (ServiceUnavailable)
         Raises:
              - DeadlineExceeded: raised after operation timeout
                  will be chained with a RetryExceptionGroup containing all
@@ -1075,7 +1075,7 @@ class TableAsync:
         if all(mutation.is_idempotent() for mutation in mutations):
             # mutations are all idempotent and safe to retry
             predicate = retries.if_exception_type(
-                *_errors_from_codes(retryable_error_codes, self.default_mutate_rows_retryable_error_codes)
+                *_errors_from_codes(retryable_error_codes, self.default_retryable_error_codes)
             )
         else:
             # mutations should not be retried

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -370,31 +370,10 @@ class BigtableDataClientAsync(ClientWithProject):
         except KeyError:
             return False
 
-    def get_table(
-        self,
-        instance_id: str,
-        table_id: str,
-        app_profile_id: str | None = None,
-        *,
-        default_read_rows_operation_timeout: float = 600,
-        default_read_rows_attempt_timeout: float | None = None,
-        default_mutate_rows_operation_timeout: float = 600,
-        default_mutate_rows_attempt_timeout: float | None = None,
-        default_operation_timeout: float = 60,
-        default_attempt_timeout: float | None = None,
-        default_read_rows_retryable_errors: Sequence[
-            grpc.StatusCode | int | type[Exception]
-        ] = (DeadlineExceeded, ServiceUnavailable, Aborted),
-        default_mutate_rows_retryable_errors: Sequence[
-            grpc.StatusCode | int | type[Exception]
-        ] = (DeadlineExceeded, ServiceUnavailable),
-        default_retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]] = (
-            DeadlineExceeded,
-            ServiceUnavailable,
-        ),
-    ) -> TableAsync:
+    def get_table(self, instance_id: str, table_id: str, *args, **kwargs) -> TableAsync:
         """
-        Returns a table instance for making data API requests
+        Returns a table instance for making data API requests. All arguments are passed
+        directly to the TableAsync constructor.
 
         Args:
             instance_id: The Bigtable instance ID to associate with this client.
@@ -436,9 +415,8 @@ class BigtableDataClientAsync(ClientWithProject):
             self,
             instance_id,
             table_id,
-            app_profile_id,
-            default_operation_timeout=default_operation_timeout,
-            default_attempt_timeout=default_attempt_timeout,
+            *args,
+            **kwargs,
         )
 
     async def __aenter__(self):

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -969,6 +969,7 @@ class TableAsync:
         flow_control_max_bytes: int = 100 * _MB_SIZE,
         batch_operation_timeout: float | None = None,
         batch_attempt_timeout: float | None = None,
+        batch_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] | None = None
     ) -> MutationsBatcherAsync:
         """
         Returns a new mutations batcher instance.
@@ -989,6 +990,11 @@ class TableAsync:
           - batch_attempt_timeout: timeout for each individual request, in seconds. If None,
               table default_mutate_rows_attempt_timeout will be used, or batch_operation_timeout
               if that is also None.
+            - retryable_error_codes: a list of errors that will be retried if encountered.
+                Can be passed as a sequence of grpc.StatusCodes, int representations, or
+                the corresponding GoogleApiCallError Exception types.
+                If None, uses the Table's default_mutate_rows_retryable_error_codes, which defaults
+                to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
         Returns:
             - a MutationsBatcherAsync context manager that can batch requests
         """
@@ -1001,6 +1007,7 @@ class TableAsync:
             flow_control_max_bytes=flow_control_max_bytes,
             batch_operation_timeout=batch_operation_timeout,
             batch_attempt_timeout=batch_attempt_timeout,
+            batch_retryable_error_codes=batch_retryable_error_codes,
         )
 
     async def mutate_row(

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -598,8 +598,7 @@ class TableAsync:
             - retryable_error_codes: a list of errors that will be retried if encountered.
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
-                If None, uses the Table's default_read_rows_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded), 14 (ServiceUnavailable), and 10 (Aborted)
+                Defaults to the Table's default_read_rows_retryable_error_codes
         Returns:
             - an asynchronous iterator that yields rows returned by the query
         Raises:
@@ -653,8 +652,7 @@ class TableAsync:
             - retryable_error_codes: a list of errors that will be retried if encountered.
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
-                If None, uses the Table's default_read_rows_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded), 14 (ServiceUnavailable), and 10 (Aborted)
+                Defaults to the Table's default_read_rows_retryable_error_codes.
         Returns:
             - a list of Rows returned by the query
         Raises:
@@ -699,8 +697,7 @@ class TableAsync:
             - retryable_error_codes: a list of errors that will be retried if encountered.
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
-                If None, uses the Table's default_read_rows_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded), 14 (ServiceUnavailable), and 10 (Aborted)
+                Defaults to the Table's default_read_rows_retryable_error_codes.
         Returns:
             - a Row object if the row exists, otherwise None
         Raises:
@@ -756,8 +753,7 @@ class TableAsync:
             - retryable_error_codes: a list of errors that will be retried if encountered.
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
-                If None, uses the Table's default_read_rows_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded), 14 (ServiceUnavailable), and 10 (Aborted)
+                Defaults to the Table's default_read_rows_retryable_error_codes.
         Raises:
             - ShardedReadRowsExceptionGroup: if any of the queries failed
             - ValueError: if the query_list is empty
@@ -835,8 +831,7 @@ class TableAsync:
             - retryable_error_codes: a list of errors that will be retried if encountered.
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
-                If None, uses the Table's default_read_rows_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded), 14 (ServiceUnavailable), and 10 (Aborted)
+                Defaults to the Table's default_read_rows_retryable_error_codes.
         Returns:
             - a bool indicating whether the row exists
         Raises:
@@ -890,8 +885,7 @@ class TableAsync:
             - retryable_error_codes: a list of errors that will be retried if encountered.
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
-                If None, uses the Table's default_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
+                Defaults to the Table's default_retryable_error_codes.
         Returns:
             - a set of RowKeySamples the delimit contiguous sections of the table
         Raises:
@@ -978,8 +972,7 @@ class TableAsync:
           - batch_retryable_error_codes: a list of errors that will be retried if encountered.
               Can be passed as a sequence of grpc.StatusCodes, int representations, or
               the corresponding GoogleApiCallError Exception types.
-              If None, uses the Table's default_mutate_rows_retryable_error_codes, which defaults
-              to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
+              Defaults to the Table's default_mutate_rows_retryable_error_codes.
         Returns:
             - a MutationsBatcherAsync context manager that can batch requests
         """
@@ -1028,8 +1021,7 @@ class TableAsync:
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
                 Only idempotent mutations will be retried.
-                If None, uses the Table's default_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded), and 14 (ServiceUnavailable)
+                Defaults to the Table's default_retryable_error_codes.
         Raises:
              - DeadlineExceeded: raised after operation timeout
                  will be chained with a RetryExceptionGroup containing all
@@ -1122,8 +1114,7 @@ class TableAsync:
             - retryable_error_codes: a list of errors that will be retried if encountered.
                 Can be passed as a sequence of grpc.StatusCodes, int representations, or
                 the corresponding GoogleApiCallError Exception types.
-                If None, uses the Table's default_mutate_rows_retryable_error_codes, which defaults
-                to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
+                Defaults to the Table's default_mutate_rows_retryable_error_codes
         Raises:
             - MutationsExceptionGroup if one or more mutations fails
                 Contains details about any failed entries in .exceptions

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -411,13 +411,7 @@ class BigtableDataClientAsync(ClientWithProject):
                 the corresponding GoogleApiCallError Exception types.
                 Defaults to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
         """
-        return TableAsync(
-            self,
-            instance_id,
-            table_id,
-            *args,
-            **kwargs,
-        )
+        return TableAsync(self, instance_id, table_id, *args, **kwargs)
 
     async def __aenter__(self):
         self._start_background_channel_refresh()

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -397,9 +397,9 @@ class BigtableDataClientAsync(ClientWithProject):
         default_mutate_rows_attempt_timeout: float | None = None,
         default_operation_timeout: float = 60,
         default_attempt_timeout: float | None = None,
-        default_read_rows_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_READ_ROWS_RETRYABLE_ERROR_CODES,
-        default_mutate_rows_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_RETRYABLE_ERROR_CODES,
-        default_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_RETRYABLE_ERROR_CODES,
+        default_read_rows_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_READ_ROWS_RETRYABLE_ERRORS,
+        default_mutate_rows_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_RETRYABLE_ERRORS,
+        default_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_RETRYABLE_ERRORS,
     ) -> TableAsync:
         """
         Returns a table instance for making data API requests
@@ -479,9 +479,9 @@ class TableAsync:
         default_mutate_rows_attempt_timeout: float | None = 60,
         default_operation_timeout: float = 60,
         default_attempt_timeout: float | None = 20,
-        default_read_rows_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_READ_ROWS_RETRYABLE_ERROR_CODES,
-        default_mutate_rows_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_RETRYABLE_ERROR_CODES,
-        default_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_RETRYABLE_ERROR_CODES,
+        default_read_rows_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_READ_ROWS_RETRYABLE_ERRORS,
+        default_mutate_rows_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_RETRYABLE_ERRORS,
+        default_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] = DEFAULT_RETRYABLE_ERRORS,
     ):
         """
         Initialize a Table instance
@@ -1157,7 +1157,7 @@ class TableAsync:
             or operation_timeout
         )
         _validate_timeouts(operation_timeout, attempt_timeout)
-        retryable_excs = _errors_from_codes(retryable_error_codes, self.default_mutate_rows_retryable_error_codes),
+        retryable_excs = _errors_from_codes(retryable_error_codes, self.default_mutate_rows_retryable_error_codes)
 
         operation = _MutateRowsOperationAsync(
             self.client._gapic_client,

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -397,18 +397,12 @@ class BigtableDataClientAsync(ClientWithProject):
                 requests, in seconds. If not set, defaults to 20 seconds
             default_read_rows_retryable_errors: a list of errors that will be retried
                 if encountered during read_rows and related operations.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to 4 (DeadlineExceeded), 14 (ServiceUnavailable), and 10 (Aborted)
             default_mutate_rows_retryable_errors: a list of errors that will be retried
                 if encountered during mutate_rows and related operations.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
             default_retryable_errors: a list of errors that will be retried if
                 encountered during all other operations.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
         """
         return TableAsync(self, instance_id, table_id, *args, **kwargs)
@@ -443,13 +437,16 @@ class TableAsync:
         default_mutate_rows_attempt_timeout: float | None = 60,
         default_operation_timeout: float = 60,
         default_attempt_timeout: float | None = 20,
-        default_read_rows_retryable_errors: Sequence[
-            grpc.StatusCode | int | type[Exception]
-        ] = (DeadlineExceeded, ServiceUnavailable, Aborted),
-        default_mutate_rows_retryable_errors: Sequence[
-            grpc.StatusCode | int | type[Exception]
-        ] = (DeadlineExceeded, ServiceUnavailable),
-        default_retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]] = (
+        default_read_rows_retryable_errors: Sequence[type[Exception]] = (
+            DeadlineExceeded,
+            ServiceUnavailable,
+            Aborted,
+        ),
+        default_mutate_rows_retryable_errors: Sequence[type[Exception]] = (
+            DeadlineExceeded,
+            ServiceUnavailable,
+        ),
+        default_retryable_errors: Sequence[type[Exception]] = (
             DeadlineExceeded,
             ServiceUnavailable,
         ),
@@ -481,18 +478,12 @@ class TableAsync:
                 requests, in seconds. If not set, defaults to 20 seconds
             default_read_rows_retryable_errors: a list of errors that will be retried
                 if encountered during read_rows and related operations.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to 4 (DeadlineExceeded), 14 (ServiceUnavailable), and 10 (Aborted)
             default_mutate_rows_retryable_errors: a list of errors that will be retried
                 if encountered during mutate_rows and related operations.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
             default_retryable_errors: a list of errors that will be retried if
                 encountered during all other operations.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
         Raises:
           - RuntimeError if called outside of an async context (no running event loop)
@@ -558,7 +549,7 @@ class TableAsync:
         *,
         operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
         attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
-        retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
     ) -> AsyncIterable[Row]:
         """
@@ -579,8 +570,6 @@ class TableAsync:
                 Defaults to the Table's default_read_rows_attempt_timeout.
                 If None, defaults to operation_timeout.
             - retryable_errors: a list of errors that will be retried if encountered.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to the Table's default_read_rows_retryable_errors
         Returns:
             - an asynchronous iterator that yields rows returned by the query
@@ -611,7 +600,7 @@ class TableAsync:
         *,
         operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
         attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
-        retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
     ) -> list[Row]:
         """
@@ -635,8 +624,6 @@ class TableAsync:
                 If None, defaults to the Table's default_read_rows_attempt_timeout,
                 or the operation_timeout if that is also None.
             - retryable_errors: a list of errors that will be retried if encountered.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to the Table's default_read_rows_retryable_errors.
         Returns:
             - a list of Rows returned by the query
@@ -661,7 +648,7 @@ class TableAsync:
         row_filter: RowFilter | None = None,
         operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
         attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
-        retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
     ) -> Row | None:
         """
@@ -681,8 +668,6 @@ class TableAsync:
                 Defaults to the Table's default_read_rows_attempt_timeout.
                 If None, defaults to operation_timeout.
             - retryable_errors: a list of errors that will be retried if encountered.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to the Table's default_read_rows_retryable_errors.
         Returns:
             - a Row object if the row exists, otherwise None
@@ -711,7 +696,7 @@ class TableAsync:
         *,
         operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
         attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
-        retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
     ) -> list[Row]:
         """
@@ -738,8 +723,6 @@ class TableAsync:
                 Defaults to the Table's default_read_rows_attempt_timeout.
                 If None, defaults to operation_timeout.
             - retryable_errors: a list of errors that will be retried if encountered.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to the Table's default_read_rows_retryable_errors.
         Raises:
             - ShardedReadRowsExceptionGroup: if any of the queries failed
@@ -799,7 +782,7 @@ class TableAsync:
         *,
         operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
         attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
-        retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.READ_ROWS,
     ) -> bool:
         """
@@ -817,8 +800,6 @@ class TableAsync:
                 Defaults to the Table's default_read_rows_attempt_timeout.
                 If None, defaults to operation_timeout.
             - retryable_errors: a list of errors that will be retried if encountered.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to the Table's default_read_rows_retryable_errors.
         Returns:
             - a bool indicating whether the row exists
@@ -848,7 +829,7 @@ class TableAsync:
         *,
         operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.DEFAULT,
         attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.DEFAULT,
-        retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.DEFAULT,
     ) -> RowKeySamples:
         """
@@ -872,8 +853,6 @@ class TableAsync:
                 Defaults to the Table's default_attempt_timeout.
                 If None, defaults to operation_timeout.
             - retryable_errors: a list of errors that will be retried if encountered.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to the Table's default_retryable_errors.
         Returns:
             - a set of RowKeySamples the delimit contiguous sections of the table
@@ -938,7 +917,7 @@ class TableAsync:
         flow_control_max_bytes: int = 100 * _MB_SIZE,
         batch_operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
         batch_attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
-        batch_retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        batch_retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
     ) -> MutationsBatcherAsync:
         """
@@ -961,8 +940,6 @@ class TableAsync:
               Defaults to the Table's default_mutate_rows_attempt_timeout.
               If None, defaults to batch_operation_timeout.
           - batch_retryable_errors: a list of errors that will be retried if encountered.
-              Can be passed as a sequence of grpc.StatusCodes, int representations, or
-              the corresponding GoogleApiCallError Exception types.
               Defaults to the Table's default_mutate_rows_retryable_errors.
         Returns:
             - a MutationsBatcherAsync context manager that can batch requests
@@ -986,7 +963,7 @@ class TableAsync:
         *,
         operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.DEFAULT,
         attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.DEFAULT,
-        retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.DEFAULT,
     ):
         """
@@ -1010,10 +987,8 @@ class TableAsync:
                 Defaults to the Table's default_attempt_timeout.
                 If None, defaults to operation_timeout.
             - retryable_errors: a list of errors that will be retried if encountered.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
-                Only idempotent mutations will be retried.
-                Defaults to the Table's default_retryable_errors.
+                Only idempotent mutations will be retried. Defaults to the Table's
+                default_retryable_errors.
         Raises:
              - DeadlineExceeded: raised after operation timeout
                  will be chained with a RetryExceptionGroup containing all
@@ -1076,7 +1051,7 @@ class TableAsync:
         *,
         operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
         attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
-        retryable_errors: Sequence[grpc.StatusCode | int | type[Exception]]
+        retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
     ):
         """
@@ -1104,8 +1079,6 @@ class TableAsync:
                 Defaults to the Table's default_mutate_rows_attempt_timeout.
                 If None, defaults to operation_timeout.
             - retryable_errors: a list of errors that will be retried if encountered.
-                Can be passed as a sequence of grpc.StatusCodes, int representations, or
-                the corresponding GoogleApiCallError Exception types.
                 Defaults to the Table's default_mutate_rows_retryable_errors
         Raises:
             - MutationsExceptionGroup if one or more mutations fails

--- a/google/cloud/bigtable/data/_async/mutations_batcher.py
+++ b/google/cloud/bigtable/data/_async/mutations_batcher.py
@@ -33,6 +33,7 @@ from google.cloud.bigtable.data._async._mutate_rows import (
 from google.cloud.bigtable.data.mutations import Mutation
 
 if TYPE_CHECKING:
+    import grpc
     from google.cloud.bigtable.data._async.client import TableAsync
 
 # used to make more readable default values
@@ -192,7 +193,7 @@ class MutationsBatcherAsync:
         flow_control_max_bytes: int = 100 * _MB_SIZE,
         batch_operation_timeout: float | None = None,
         batch_attempt_timeout: float | None = None,
-        batch_retryable_error_codes: Sequence[grpc.StatusCode | int | type[Exception]] | None = None
+        batch_retryable_error_codes: Sequence["grpc.StatusCode" | int | type[Exception]] | None = None
     ):
         """
         Args:

--- a/google/cloud/bigtable/data/_async/mutations_batcher.py
+++ b/google/cloud/bigtable/data/_async/mutations_batcher.py
@@ -194,7 +194,8 @@ class MutationsBatcherAsync:
         flow_control_max_bytes: int = 100 * _MB_SIZE,
         batch_operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
         batch_attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
-        batch_retryable_error_codes: Sequence["grpc.StatusCode" | int | type[Exception]] | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS
+        batch_retryable_errors: Sequence["grpc.StatusCode" | int | type[Exception]]
+        | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
     ):
         """
         Args:
@@ -211,15 +212,17 @@ class MutationsBatcherAsync:
           - batch_attempt_timeout: timeout for each individual request, in seconds.
               If TABLE_DEFAULT, defaults to the Table's default_mutate_rows_attempt_timeout.
               If None, defaults to batch_operation_timeout.
-          - batch_retryable_error_codes: a list of errors that will be retried if encountered.
+          - batch_retryable_errors: a list of errors that will be retried if encountered.
               Can be passed as a sequence of grpc.StatusCodes, int representations, or
               the corresponding GoogleApiCallError Exception types.
-              Defaults to the Table's default_mutate_rows_retryable_error_codes.
+              Defaults to the Table's default_mutate_rows_retryable_errors.
         """
         self._operation_timeout, self._attempt_timeout = _get_timeouts(
             batch_operation_timeout, batch_attempt_timeout, table
         )
-        self._retryable_errors: list[type[Exception]] = _get_retryable_errors(batch_retryable_error_codes, table)
+        self._retryable_errors: list[type[Exception]] = _get_retryable_errors(
+            batch_retryable_errors, table
+        )
 
         self.closed: bool = False
         self._table = table

--- a/google/cloud/bigtable/data/_async/mutations_batcher.py
+++ b/google/cloud/bigtable/data/_async/mutations_batcher.py
@@ -194,7 +194,7 @@ class MutationsBatcherAsync:
         flow_control_max_bytes: int = 100 * _MB_SIZE,
         batch_operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
         batch_attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
-        batch_retryable_errors: Sequence["grpc.StatusCode" | int | type[Exception]]
+        batch_retryable_errors: Sequence[type[Exception]]
         | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
     ):
         """
@@ -213,8 +213,6 @@ class MutationsBatcherAsync:
               If TABLE_DEFAULT, defaults to the Table's default_mutate_rows_attempt_timeout.
               If None, defaults to batch_operation_timeout.
           - batch_retryable_errors: a list of errors that will be retried if encountered.
-              Can be passed as a sequence of grpc.StatusCodes, int representations, or
-              the corresponding GoogleApiCallError Exception types.
               Defaults to the Table's default_mutate_rows_retryable_errors.
         """
         self._operation_timeout, self._attempt_timeout = _get_timeouts(

--- a/google/cloud/bigtable/data/_async/mutations_batcher.py
+++ b/google/cloud/bigtable/data/_async/mutations_batcher.py
@@ -214,8 +214,7 @@ class MutationsBatcherAsync:
           - batch_retryable_error_codes: a list of errors that will be retried if encountered.
               Can be passed as a sequence of grpc.StatusCodes, int representations, or
               the corresponding GoogleApiCallError Exception types.
-              If TABLE_DEFAULT, uses the Table's default_mutate_rows_retryable_error_codes, which defaults
-              to 4 (DeadlineExceeded) and 14 (ServiceUnavailable)
+              Defaults to the Table's default_mutate_rows_retryable_error_codes.
         """
         self._operation_timeout, self._attempt_timeout = _get_timeouts(
             batch_operation_timeout, batch_attempt_timeout, table

--- a/google/cloud/bigtable/data/_async/mutations_batcher.py
+++ b/google/cloud/bigtable/data/_async/mutations_batcher.py
@@ -34,7 +34,6 @@ from google.cloud.bigtable.data._async._mutate_rows import (
 from google.cloud.bigtable.data.mutations import Mutation
 
 if TYPE_CHECKING:
-    import grpc
     from google.cloud.bigtable.data._async.client import TableAsync
 
 # used to make more readable default values

--- a/google/cloud/bigtable/data/_async/mutations_batcher.py
+++ b/google/cloud/bigtable/data/_async/mutations_batcher.py
@@ -23,7 +23,7 @@ from collections import deque
 from google.cloud.bigtable.data.mutations import RowMutationEntry
 from google.cloud.bigtable.data.exceptions import MutationsExceptionGroup
 from google.cloud.bigtable.data.exceptions import FailedMutationEntryError
-from google.cloud.bigtable.data._helpers import _errors_from_codes
+from google.cloud.bigtable.data._helpers import _get_retryable_errors
 from google.cloud.bigtable.data._helpers import _get_timeouts
 from google.cloud.bigtable.data._helpers import TABLE_DEFAULT
 
@@ -194,7 +194,7 @@ class MutationsBatcherAsync:
         flow_control_max_bytes: int = 100 * _MB_SIZE,
         batch_operation_timeout: float | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
         batch_attempt_timeout: float | None | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS,
-        batch_retryable_error_codes: Sequence["grpc.StatusCode" | int | type[Exception]] | TABLE_DEFAULT.MUTATE_ROWS = TABLE_DEFAULT.MUTATE_ROWS
+        batch_retryable_error_codes: Sequence["grpc.StatusCode" | int | type[Exception]] | TABLE_DEFAULT = TABLE_DEFAULT.MUTATE_ROWS
     ):
         """
         Args:
@@ -219,7 +219,7 @@ class MutationsBatcherAsync:
         self._operation_timeout, self._attempt_timeout = _get_timeouts(
             batch_operation_timeout, batch_attempt_timeout, table
         )
-        self._retryable_errors: list[type[Exception]] = _errors_from_codes(batch_retryable_error_codes, table.default_mutate_rows_retryable_error_codes)
+        self._retryable_errors: list[type[Exception]] = _get_retryable_errors(batch_retryable_error_codes, table)
 
         self.closed: bool = False
         self._table = table

--- a/google/cloud/bigtable/data/_helpers.py
+++ b/google/cloud/bigtable/data/_helpers.py
@@ -13,7 +13,7 @@
 #
 from __future__ import annotations
 
-from typing import Callable, Any
+from typing import Callable, Sequence, Any
 import time
 
 from google.api_core import exceptions as core_exceptions
@@ -135,3 +135,14 @@ def _validate_timeouts(
     elif attempt_timeout is not None:
         if attempt_timeout <= 0:
             raise ValueError("attempt_timeout must be greater than 0")
+
+def _errors_from_codes(
+    call_codes: Sequence["grpc.StatusCode" | int | type[Exception]],
+    table_default_codes: Sequence["grpc.StatusCode" | int | type[Exception]]
+) -> list[type[Exception]]:
+    retry_codes = call_codes if call_codes is not None else table_default_codes
+    return [
+        e if isinstance(e, type) else type(core_exceptions.from_grpc_status(e, ""))
+        for e in retry_codes
+    ]
+

--- a/google/cloud/bigtable/data/_helpers.py
+++ b/google/cloud/bigtable/data/_helpers.py
@@ -11,18 +11,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+Helper functions used in various places in the library.
+"""
 from __future__ import annotations
 
-from typing import Callable, Sequence, Any
+from typing import Callable, Sequence, Any, TYPE_CHECKING
 import time
 
 from google.api_core import exceptions as core_exceptions
 from google.cloud.bigtable.data.exceptions import RetryExceptionGroup
 
-"""
-Helper functions used in various places in the library.
-"""
-
+if TYPE_CHECKING:
+    import grpc
 
 def _make_metadata(
     table_name: str, app_profile_id: str | None
@@ -137,7 +138,7 @@ def _validate_timeouts(
             raise ValueError("attempt_timeout must be greater than 0")
 
 def _errors_from_codes(
-    call_codes: Sequence["grpc.StatusCode" | int | type[Exception]],
+    call_codes: Sequence["grpc.StatusCode" | int | type[Exception]] | None,
     table_default_codes: Sequence["grpc.StatusCode" | int | type[Exception]]
 ) -> list[type[Exception]]:
     retry_codes = call_codes if call_codes is not None else table_default_codes

--- a/google/cloud/bigtable/data/_helpers.py
+++ b/google/cloud/bigtable/data/_helpers.py
@@ -149,7 +149,9 @@ def _convert_retry_deadline(
 
 
 def _get_timeouts(
-        operation: float | TABLE_DEFAULT, attempt: float | None | TABLE_DEFAULT, table: "TableAsync"
+    operation: float | TABLE_DEFAULT,
+    attempt: float | None | TABLE_DEFAULT,
+    table: "TableAsync",
 ) -> tuple[float, float]:
     """
     Convert passed in timeout values to floats, using table defaults if necessary.
@@ -224,11 +226,11 @@ def _get_retryable_errors(
 ) -> list[type[Exception]]:
     # load table defaults if necessary
     if call_codes == TABLE_DEFAULT.DEFAULT:
-        call_codes = table.default_retryable_error_codes
+        call_codes = table.default_retryable_errors
     elif call_codes == TABLE_DEFAULT.READ_ROWS:
-        call_codes = table.default_read_rows_retryable_error_codes
+        call_codes = table.default_read_rows_retryable_errors
     elif call_codes == TABLE_DEFAULT.MUTATE_ROWS:
-        call_codes = table.default_mutate_rows_retryable_error_codes
+        call_codes = table.default_mutate_rows_retryable_errors
 
     return [
         e if isinstance(e, type) else type(core_exceptions.from_grpc_status(e, ""))

--- a/tests/unit/data/_async/test__mutate_rows.py
+++ b/tests/unit/data/_async/test__mutate_rows.py
@@ -46,9 +46,10 @@ class TestMutateRowsOperation:
         if not args:
             kwargs["gapic_client"] = kwargs.pop("gapic_client", mock.Mock())
             kwargs["table"] = kwargs.pop("table", AsyncMock())
-            kwargs["mutation_entries"] = kwargs.pop("mutation_entries", [])
             kwargs["operation_timeout"] = kwargs.pop("operation_timeout", 5)
             kwargs["attempt_timeout"] = kwargs.pop("attempt_timeout", 0.1)
+            kwargs["retryable_exceptions"] = kwargs.pop("retryable_exceptions", ())
+            kwargs["mutation_entries"] = kwargs.pop("mutation_entries", [])
         return self._target_class()(*args, **kwargs)
 
     async def _mock_stream(self, mutation_list, error_dict):
@@ -77,15 +78,21 @@ class TestMutateRowsOperation:
         """
         from google.cloud.bigtable.data.exceptions import _MutateRowsIncomplete
         from google.api_core.exceptions import DeadlineExceeded
-        from google.api_core.exceptions import ServiceUnavailable
+        from google.api_core.exceptions import Aborted
 
         client = mock.Mock()
         table = mock.Mock()
         entries = [_make_mutation(), _make_mutation()]
         operation_timeout = 0.05
         attempt_timeout = 0.01
+        retryable_exceptions = ()
         instance = self._make_one(
-            client, table, entries, operation_timeout, attempt_timeout
+            client,
+            table,
+            entries,
+            operation_timeout,
+            attempt_timeout,
+            retryable_exceptions,
         )
         # running gapic_fn should trigger a client call
         assert client.mutate_rows.call_count == 0
@@ -107,8 +114,8 @@ class TestMutateRowsOperation:
         assert next(instance.timeout_generator) == attempt_timeout
         # ensure predicate is set
         assert instance.is_retryable is not None
-        assert instance.is_retryable(DeadlineExceeded("")) is True
-        assert instance.is_retryable(ServiceUnavailable("")) is True
+        assert instance.is_retryable(DeadlineExceeded("")) is False
+        assert instance.is_retryable(Aborted("")) is False
         assert instance.is_retryable(_MutateRowsIncomplete("")) is True
         assert instance.is_retryable(RuntimeError("")) is False
         assert instance.remaining_indices == list(range(len(entries)))
@@ -229,7 +236,7 @@ class TestMutateRowsOperation:
 
     @pytest.mark.parametrize(
         "exc_type",
-        [core_exceptions.DeadlineExceeded, core_exceptions.ServiceUnavailable],
+        [core_exceptions.DeadlineExceeded, RuntimeError],
     )
     @pytest.mark.asyncio
     async def test_mutate_rows_exception_retryable_eventually_pass(self, exc_type):
@@ -253,7 +260,12 @@ class TestMutateRowsOperation:
         ) as attempt_mock:
             attempt_mock.side_effect = [expected_cause] * num_retries + [None]
             instance = self._make_one(
-                client, table, entries, operation_timeout, operation_timeout
+                client,
+                table,
+                entries,
+                operation_timeout,
+                operation_timeout,
+                retryable_exceptions=(exc_type,),
             )
             await instance.start()
             assert attempt_mock.call_count == num_retries + 1

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -1229,7 +1229,7 @@ class TestTableAsync:
             with mock.patch(retry_fn_path) as retry_fn_mock:
                 async with BigtableDataClientAsync() as client:
                     table = client.get_table("instance-id", "table-id")
-                    expected_predicate = lambda a: a in expected_retryables
+                    expected_predicate = lambda a: a in expected_retryables  # noqa
                     predicate_builder_mock.return_value = expected_predicate
                     retry_fn_mock.side_effect = RuntimeError("stop early")
                     with pytest.raises(Exception):

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -842,6 +842,39 @@ class TestBigtableDataClientAsync:
         await client.close()
 
     @pytest.mark.asyncio
+    async def test_get_table_arg_passthrough(self):
+        """
+        All arguments passed in get_table should be sent to constructor
+        """
+        async with self._make_one(project="project-id") as client:
+            with mock.patch(
+                "google.cloud.bigtable.data._async.client.TableAsync.__init__",
+            ) as mock_constructor:
+                mock_constructor.return_value = None
+                assert not client._active_instances
+                expected_table_id = "table-id"
+                expected_instance_id = "instance-id"
+                expected_app_profile_id = "app-profile-id"
+                expected_args = (1, "test", {"test": 2})
+                expected_kwargs = {"hello": "world", "test": 2}
+
+                client.get_table(
+                    expected_instance_id,
+                    expected_table_id,
+                    expected_app_profile_id,
+                    *expected_args,
+                    **expected_kwargs,
+                )
+                mock_constructor.assert_called_once_with(
+                    client,
+                    expected_instance_id,
+                    expected_table_id,
+                    expected_app_profile_id,
+                    *expected_args,
+                    **expected_kwargs,
+                )
+
+    @pytest.mark.asyncio
     async def test_get_table_context_manager(self):
         from google.cloud.bigtable.data._async.client import TableAsync
         from google.cloud.bigtable.data._async.client import _WarmedInstanceKey

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -1874,7 +1874,10 @@ class TestSampleRowKeys:
         expected_timeout = 99
         async with self._make_client() as client:
             async with client.get_table(
-                "i", "t", default_operation_timeout=expected_timeout
+                "i",
+                "t",
+                default_operation_timeout=expected_timeout,
+                default_attempt_timeout=expected_timeout,
             ) as table:
                 with mock.patch.object(
                     table.client._gapic_client, "sample_row_keys", AsyncMock()

--- a/tests/unit/data/_async/test_mutations_batcher.py
+++ b/tests/unit/data/_async/test_mutations_batcher.py
@@ -1170,7 +1170,7 @@ class TestMutationsBatcherAsync:
                     table, batch_retryable_errors=input_retryables
                 ) as instance:
                     assert instance._retryable_errors == expected_retryables
-                    expected_predicate = lambda a: a in expected_retryables
+                    expected_predicate = lambda a: a in expected_retryables  # noqa
                     predicate_builder_mock.return_value = expected_predicate
                     retry_fn_mock.side_effect = RuntimeError("stop early")
                     mutation = _make_mutation(count=1, size=1)

--- a/tests/unit/data/_async/test_mutations_batcher.py
+++ b/tests/unit/data/_async/test_mutations_batcher.py
@@ -286,10 +286,17 @@ class TestMutationsBatcherAsync:
         return MutationsBatcherAsync
 
     def _make_one(self, table=None, **kwargs):
+        from google.api_core.exceptions import DeadlineExceeded
+        from google.api_core.exceptions import ServiceUnavailable
+
         if table is None:
             table = mock.Mock()
             table.default_mutate_rows_operation_timeout = 10
             table.default_mutate_rows_attempt_timeout = 10
+            table.default_mutate_rows_retryable_errors = (
+                DeadlineExceeded,
+                ServiceUnavailable,
+            )
 
         return self._get_target_class()(table, **kwargs)
 
@@ -302,6 +309,7 @@ class TestMutationsBatcherAsync:
         table = mock.Mock()
         table.default_mutate_rows_operation_timeout = 10
         table.default_mutate_rows_attempt_timeout = 8
+        table.default_mutate_rows_retryable_errors = [Exception]
         async with self._make_one(table) as instance:
             assert instance._table == table
             assert instance.closed is False
@@ -323,6 +331,9 @@ class TestMutationsBatcherAsync:
             assert (
                 instance._attempt_timeout == table.default_mutate_rows_attempt_timeout
             )
+            assert (
+                instance._retryable_errors == table.default_mutate_rows_retryable_errors
+            )
             await asyncio.sleep(0)
             assert flush_timer_mock.call_count == 1
             assert flush_timer_mock.call_args[0][0] == 5
@@ -343,6 +354,7 @@ class TestMutationsBatcherAsync:
         flow_control_max_bytes = 12
         operation_timeout = 11
         attempt_timeout = 2
+        retryable_errors = [Exception]
         async with self._make_one(
             table,
             flush_interval=flush_interval,
@@ -352,6 +364,7 @@ class TestMutationsBatcherAsync:
             flow_control_max_bytes=flow_control_max_bytes,
             batch_operation_timeout=operation_timeout,
             batch_attempt_timeout=attempt_timeout,
+            batch_retryable_errors=retryable_errors,
         ) as instance:
             assert instance._table == table
             assert instance.closed is False
@@ -371,6 +384,7 @@ class TestMutationsBatcherAsync:
             assert instance._entries_processed_since_last_raise == 0
             assert instance._operation_timeout == operation_timeout
             assert instance._attempt_timeout == attempt_timeout
+            assert instance._retryable_errors == retryable_errors
             await asyncio.sleep(0)
             assert flush_timer_mock.call_count == 1
             assert flush_timer_mock.call_args[0][0] == flush_interval
@@ -386,6 +400,7 @@ class TestMutationsBatcherAsync:
         table = mock.Mock()
         table.default_mutate_rows_operation_timeout = 10
         table.default_mutate_rows_attempt_timeout = 8
+        table.default_mutate_rows_retryable_errors = ()
         flush_interval = None
         flush_limit_count = None
         flush_limit_bytes = None
@@ -442,7 +457,7 @@ class TestMutationsBatcherAsync:
         batcher_init_signature.pop("table")
         # both should have same number of arguments
         assert len(get_batcher_signature.keys()) == len(batcher_init_signature.keys())
-        assert len(get_batcher_signature) == 7  # update if expected params change
+        assert len(get_batcher_signature) == 8  # update if expected params change
         # both should have same argument names
         assert set(get_batcher_signature.keys()) == set(batcher_init_signature.keys())
         # both should have same default values
@@ -882,6 +897,7 @@ class TestMutationsBatcherAsync:
         table.app_profile_id = "test-app-profile"
         table.default_mutate_rows_operation_timeout = 17
         table.default_mutate_rows_attempt_timeout = 13
+        table.default_mutate_rows_retryable_errors = ()
         async with self._make_one(table) as instance:
             batch = [_make_mutation()]
             result = await instance._execute_mutate_rows(batch)
@@ -911,6 +927,7 @@ class TestMutationsBatcherAsync:
         table = mock.Mock()
         table.default_mutate_rows_operation_timeout = 17
         table.default_mutate_rows_attempt_timeout = 13
+        table.default_mutate_rows_retryable_errors = ()
         async with self._make_one(table) as instance:
             batch = [_make_mutation()]
             result = await instance._execute_mutate_rows(batch)


### PR DESCRIPTION
This PR adds the option to set retryable error codes at the rpc level, or at the table level

Users can donfigure retryable errors using grpc.StatusCode objects, int codes corresponding to a grpc status, or an Exception type

Fixes: https://github.com/googleapis/python-bigtable/issues/787

Blocked on https://github.com/googleapis/python-bigtable/pull/880; if we decide to change how table defaults are configured, that will have implications for this change as well
