### PR TITLE
chore(tests): turn off fast fail for conformance tets

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         py-version: [ 3.8 ]
         client-type: [ "Async v3", "Legacy" ]
-        fail-fast: false
+      fail-fast: false
     name: "${{ matrix.client-type }} Client / Python ${{ matrix.py-version }}"
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         py-version: [ 3.8 ]
         client-type: [ "Async v3", "Legacy" ]
+        fail-fast: false
     name: "${{ matrix.client-type }} Client / Python ${{ matrix.py-version }}"
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Disable Github Actions fast-fail mode for conformance tests

Conformance tests will sometimes skip the v3 tests because the legacy tests fail first. We expect the legacy tests to be failing for now, and we always want the v3 conformance tests to run