### PR TITLE
fix: mutations batcher race condition

### DIFF
--- a/google/cloud/bigtable/batcher.py
+++ b/google/cloud/bigtable/batcher.py
@@ -347,7 +347,9 @@ class MutationsBatcher(object):
             self.flow_control.control_flow(batch_info)
             future = self._executor.submit(self._flush_rows, rows_to_flush)
             # schedule release of resources from flow control
-            future.add_done_callback(partial(self._batch_completed_callback, copy(batch_info)))
+            future.add_done_callback(
+                partial(self._batch_completed_callback, copy(batch_info))
+            )
 
     def _batch_completed_callback(self, batch_info, future):
         """Callback for when the mutation has finished to clean up the current batch

--- a/google/cloud/bigtable/batcher.py
+++ b/google/cloud/bigtable/batcher.py
@@ -51,7 +51,7 @@ class _MutationsBatchQueue(object):
         self.total_size = 0
         self.max_mutation_bytes = max_mutation_bytes
         self.flush_count = flush_count
-        self.lock = threading.Lock()
+        self._lock = threading.Lock()
 
     def get(self):
         """
@@ -59,7 +59,7 @@ class _MutationsBatchQueue(object):
 
         If the queue is empty, return None.
         """
-        with self.lock:
+        with self._lock:
             try:
                 row = self._queue.get_nowait()
                 mutation_size = row.get_mutations_size()
@@ -71,7 +71,7 @@ class _MutationsBatchQueue(object):
 
     def get_all(self):
         """Get all items from the queue."""
-        with self.lock:
+        with self._lock:
             items = []
             while not self._queue.empty():
                 items.append(self._queue.get_nowait())
@@ -84,7 +84,7 @@ class _MutationsBatchQueue(object):
 
         mutation_count = len(item._get_mutations())
 
-        with self.lock:
+        with self._lock:
             self._queue.put(item)
 
             self.total_size += item.get_mutations_size()
@@ -92,7 +92,7 @@ class _MutationsBatchQueue(object):
 
     def full(self):
         """Check if the queue is full."""
-        with self.lock:
+        with self._lock:
             if (
                 self.total_mutation_count >= self.flush_count
                 or self.total_size >= self.max_mutation_bytes

--- a/google/cloud/bigtable/batcher.py
+++ b/google/cloud/bigtable/batcher.py
@@ -18,6 +18,9 @@ import queue
 import concurrent.futures
 import atexit
 
+from functools import partial
+from copy import copy
+
 from google.api_core.exceptions import from_grpc_status
 from dataclasses import dataclass
 
@@ -344,7 +347,15 @@ class MutationsBatcher(object):
             self.flow_control.control_flow(batch_info)
             future = self._executor.submit(self._flush_rows, rows_to_flush)
             # schedule release of resources from flow control
-            future.add_done_callback(lambda f: self.flow_control.release(batch_info))
+            future.add_done_callback(partial(self._batch_completed_callback, copy(batch_info)))
+
+    def _batch_completed_callback(self, batch_info, future):
+        """Callback for when the mutation has finished to clean up the current batch
+        and release items from the flow controller.
+        Raise exceptions if there's any.
+        Release the resources locked by the flow control and allow enqueued tasks to be run.
+        """
+        self.flow_control.release(batch_info)
 
     def _row_fits_in_batch(self, row, batch_info):
         """Checks if a row can fit in the current batch.

--- a/google/cloud/bigtable/batcher.py
+++ b/google/cloud/bigtable/batcher.py
@@ -330,7 +330,9 @@ class MutationsBatcher(object):
             )
             # fill up batch with rows
             next_row = self._rows.get()
-            while next_row is not None and self._row_fits_in_batch(next_row, batch_info):
+            while next_row is not None and self._row_fits_in_batch(
+                next_row, batch_info
+            ):
                 rows_to_flush.append(next_row)
                 batch_info.mutations_count += len(next_row._get_mutations())
                 batch_info.rows_count += 1

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -58,7 +58,7 @@ def location_id():
 
 @pytest.fixture(scope="session")
 def serve_nodes():
-    return 3
+    return 1
 
 
 @pytest.fixture(scope="session")

--- a/tests/system/test_data_api.py
+++ b/tests/system/test_data_api.py
@@ -395,16 +395,11 @@ def test_mutations_batcher_threading(data_table, rows_to_delete):
     num_sent = 20
     all_results = []
 
-    max_elements_per_batch = 2
-
     def callback(results):
         all_results.extend(results)
-        assert len(results) <= max_elements_per_batch
 
     # override flow control max elements
-    with mock.patch(
-        "google.cloud.bigtable.batcher.MAX_OUTSTANDING_ELEMENTS", max_elements_per_batch
-    ):
+    with mock.patch("google.cloud.bigtable.batcher.MAX_OUTSTANDING_ELEMENTS", 2):
         with MutationsBatcher(
             data_table,
             flush_count=5,

--- a/tests/system/test_data_api.py
+++ b/tests/system/test_data_api.py
@@ -399,7 +399,7 @@ def test_mutations_batcher_threading(data_table, rows_to_delete):
 
     def callback(results):
         all_results.extend(results)
-        assert results <= max_elements_per_batch
+        assert len(results) <= max_elements_per_batch
 
     # override flow control max elements
     with mock.patch(

--- a/tests/system/test_data_api.py
+++ b/tests/system/test_data_api.py
@@ -402,12 +402,21 @@ def test_mutations_batcher_threading(data_table, rows_to_delete):
         assert results <= max_elements_per_batch
 
     # override flow control max elements
-    with mock.patch("google.cloud.bigtable.batcher.MAX_OUTSTANDING_ELEMENTS", max_elements_per_batch):
-        with MutationsBatcher(data_table, flush_count=5, flush_interval=0.07, batch_completed_callback=callback) as batcher:
+    with mock.patch(
+        "google.cloud.bigtable.batcher.MAX_OUTSTANDING_ELEMENTS", max_elements_per_batch
+    ):
+        with MutationsBatcher(
+            data_table,
+            flush_count=5,
+            flush_interval=0.07,
+            batch_completed_callback=callback,
+        ) as batcher:
             # send mutations in a way that timed flushes and count flushes interleave
             for i in range(num_sent):
                 row = data_table.direct_row("row{}".format(i))
-                row.set_cell(COLUMN_FAMILY_ID1, COL_NAME1, "val{}".format(i).encode("utf-8"))
+                row.set_cell(
+                    COLUMN_FAMILY_ID1, COL_NAME1, "val{}".format(i).encode("utf-8")
+                )
                 rows_to_delete.append(row)
                 batcher.mutate(row)
                 time.sleep(0.01)

--- a/tests/system/test_data_api.py
+++ b/tests/system/test_data_api.py
@@ -388,22 +388,28 @@ def test_mutations_batcher_threading(data_table, rows_to_delete):
     Test the mutations batcher by sending a bunch of mutations using different
     flush methods
     """
+    import mock
     import time
     from google.cloud.bigtable.batcher import MutationsBatcher
 
     num_sent = 20
     all_results = []
 
+    max_elements_per_batch = 2
+
     def callback(results):
         all_results.extend(results)
+        assert results <= max_elements_per_batch
 
-    with MutationsBatcher(data_table, flush_count=5, flush_interval=0.07, batch_completed_callback=callback) as batcher:
-        # send mutations in a way that timed flushes and count flushes interleave
-        for i in range(num_sent):
-            row = data_table.direct_row("row{}".format(i))
-            row.set_cell(COLUMN_FAMILY_ID1, COL_NAME1, "val{}".format(i).encode("utf-8"))
-            rows_to_delete.append(row)
-            batcher.mutate(row)
-            time.sleep(0.01)
+    # override flow control max elements
+    with mock.patch("google.cloud.bigtable.batcher.MAX_OUTSTANDING_ELEMENTS", max_elements_per_batch):
+        with MutationsBatcher(data_table, flush_count=5, flush_interval=0.07, batch_completed_callback=callback) as batcher:
+            # send mutations in a way that timed flushes and count flushes interleave
+            for i in range(num_sent):
+                row = data_table.direct_row("row{}".format(i))
+                row.set_cell(COLUMN_FAMILY_ID1, COL_NAME1, "val{}".format(i).encode("utf-8"))
+                rows_to_delete.append(row)
+                batcher.mutate(row)
+                time.sleep(0.01)
     # ensure all mutations were sent
     assert len(all_results) == num_sent

--- a/tests/system/test_data_api.py
+++ b/tests/system/test_data_api.py
@@ -381,3 +381,29 @@ def test_access_with_non_admin_client(data_client, data_instance_id, data_table_
     instance = data_client.instance(data_instance_id)
     table = instance.table(data_table_id)
     assert table.read_row("nonesuch") is None  # no raise
+
+
+def test_mutations_batcher_threading(data_table, rows_to_delete):
+    """
+    Test the mutations batcher by sending a bunch of mutations using different
+    flush methods
+    """
+    import time
+    from google.cloud.bigtable.batcher import MutationsBatcher
+
+    num_sent = 20
+    all_results = []
+
+    def callback(results):
+        all_results.extend(results)
+
+    with MutationsBatcher(data_table, flush_count=5, flush_interval=0.07, batch_completed_callback=callback) as batcher:
+        # send mutations in a way that timed flushes and count flushes interleave
+        for i in range(num_sent):
+            row = data_table.direct_row("row{}".format(i))
+            row.set_cell(COLUMN_FAMILY_ID1, COL_NAME1, "val{}".format(i).encode("utf-8"))
+            rows_to_delete.append(row)
+            batcher.mutate(row)
+            time.sleep(0.01)
+    # ensure all mutations were sent
+    assert len(all_results) == num_sent


### PR DESCRIPTION
There was a race condition found in the threaded mutations batcher. The batcher would check the state of the queue, and then read from the queue as separate steps, which left room for other threads to change the state in between

This PR addresses the problem with the following changes:
-  `queue.get` will now return None if the queue is empty. This allows us to check the state and get the next items in an atomic operation, replacing the need for `queue.empty`
- rewrote the `_flush_async` implementation, to simplify it and make it more thread-safe