### PR TITLE
[DRAFT] feat: use OperationTimeoutError instead of DeadlineExceeded

### DIFF
--- a/google/cloud/bigtable/data/__init__.py
+++ b/google/cloud/bigtable/data/__init__.py
@@ -39,6 +39,7 @@ from google.cloud.bigtable.data.exceptions import FailedQueryShardError
 from google.cloud.bigtable.data.exceptions import RetryExceptionGroup
 from google.cloud.bigtable.data.exceptions import MutationsExceptionGroup
 from google.cloud.bigtable.data.exceptions import ShardedReadRowsExceptionGroup
+from google.cloud.bigtable.data.exceptions import OperationTimeoutError
 
 from google.cloud.bigtable.data._helpers import TABLE_DEFAULT
 from google.cloud.bigtable.data._helpers import RowKeySamples
@@ -68,6 +69,7 @@ __all__ = (
     "RetryExceptionGroup",
     "MutationsExceptionGroup",
     "ShardedReadRowsExceptionGroup",
+    "OperationTimeoutError",
     "ShardedQuery",
     "TABLE_DEFAULT",
 )

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -574,7 +574,7 @@ class TableAsync:
         Returns:
             - an asynchronous iterator that yields rows returned by the query
         Raises:
-            - DeadlineExceeded: raised after operation timeout
+            - OperationTimeoutError: raised after operation timeout
                 will be chained with a RetryExceptionGroup containing GoogleAPIError exceptions
                 from any retries that failed
             - GoogleAPIError: raised if the request encounters an unrecoverable error
@@ -627,7 +627,7 @@ class TableAsync:
         Returns:
             - a list of Rows returned by the query
         Raises:
-            - DeadlineExceeded: raised after operation timeout
+            - OperationTimeoutError: raised after operation timeout
                 will be chained with a RetryExceptionGroup containing GoogleAPIError exceptions
                 from any retries that failed
             - GoogleAPIError: raised if the request encounters an unrecoverable error
@@ -671,7 +671,7 @@ class TableAsync:
         Returns:
             - a Row object if the row exists, otherwise None
         Raises:
-            - DeadlineExceeded: raised after operation timeout
+            - OperationTimeoutError: raised after operation timeout
                 will be chained with a RetryExceptionGroup containing GoogleAPIError exceptions
                 from any retries that failed
             - GoogleAPIError: raised if the request encounters an unrecoverable error
@@ -806,7 +806,7 @@ class TableAsync:
         Returns:
             - a bool indicating whether the row exists
         Raises:
-            - DeadlineExceeded: raised after operation timeout
+            - OperationTimeoutError: raised after operation timeout
                 will be chained with a RetryExceptionGroup containing GoogleAPIError exceptions
                 from any retries that failed
             - GoogleAPIError: raised if the request encounters an unrecoverable error
@@ -859,7 +859,7 @@ class TableAsync:
         Returns:
             - a set of RowKeySamples the delimit contiguous sections of the table
         Raises:
-            - DeadlineExceeded: raised after operation timeout
+            - OperationTimeoutError: raised after operation timeout
                 will be chained with a RetryExceptionGroup containing GoogleAPIError exceptions
                 from any retries that failed
             - GoogleAPIError: raised if the request encounters an unrecoverable error
@@ -981,7 +981,7 @@ class TableAsync:
                 Only idempotent mutations will be retried. Defaults to the Table's
                 default_retryable_errors.
         Raises:
-             - DeadlineExceeded: raised after operation timeout
+             - OperationTimeoutError: raised after operation timeout
                  will be chained with a RetryExceptionGroup containing all
                  GoogleAPIError exceptions from any retries that failed
              - GoogleAPIError: raised on non-idempotent operations that cannot be

--- a/google/cloud/bigtable/data/_helpers.py
+++ b/google/cloud/bigtable/data/_helpers.py
@@ -121,7 +121,7 @@ def _retry_exception_factory(
         timeout_val_str = f"of {timeout_val:0.1f}s " if timeout_val is not None else ""
         # if failed due to timeout, raise deadline exceeded as primary exception
         source_exc: Exception = OperationTimeoutError(
-            f"operation_timeout{timeout_val_str} exceeded",
+            f"operation_timeout {timeout_val_str}exceeded",
             cause=cause_exc,
         )
     elif exc_list:

--- a/google/cloud/bigtable/data/exceptions.py
+++ b/google/cloud/bigtable/data/exceptions.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from google.cloud.bigtable.data.read_rows_query import ReadRowsQuery
 
 
-class OperationTimeoutError(core_exceptions.RetryError):
+class OperationTimeoutError(core_exceptions.RetryError, core_exceptions.DeadlineExceeded):
     """Raised when a retryable operation times out"""
 
 

--- a/google/cloud/bigtable/data/exceptions.py
+++ b/google/cloud/bigtable/data/exceptions.py
@@ -28,6 +28,10 @@ if TYPE_CHECKING:
     from google.cloud.bigtable.data.read_rows_query import ReadRowsQuery
 
 
+class OperationTimeoutError(core_exceptions.RetryError):
+    """Raised when a retryable operation times out"""
+
+
 class InvalidChunk(core_exceptions.GoogleAPICallError):
     """Exception raised to invalid chunk data from back-end."""
 


### PR DESCRIPTION
In the current v3 alpha, operations that exceed the timeout raise a `DeadlineExceeded` error. This overloads the meanings of that error, since it is typically used to denote an expired rpc, not entire operation. 

This PR changes the exception raised to a new OperationTimeoutError, which is used only for timed out operations. The new exception is a subclass of `api_core.exceptions.RetryError`, to align with other libraries

Fixes https://github.com/googleapis/python-bigtable/issues/913
