### PR TITLE
chore(docs): added generated docs for async client

### DIFF
--- a/docs/async_data_client.rst
+++ b/docs/async_data_client.rst
@@ -1,0 +1,6 @@
+Bigtable Data Client Async
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.bigtable.data._async.client
+  :members:
+  :show-inheritance:

--- a/docs/async_data_exceptions.rst
+++ b/docs/async_data_exceptions.rst
@@ -1,0 +1,6 @@
+Custom Exceptions
+~~~~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.bigtable.data.exceptions
+  :members:
+  :show-inheritance:

--- a/docs/async_data_mutations.rst
+++ b/docs/async_data_mutations.rst
@@ -1,0 +1,6 @@
+Mutations
+~~~~~~~~~
+
+.. automodule:: google.cloud.bigtable.data.mutations
+  :members:
+  :show-inheritance:

--- a/docs/async_data_mutations_batcher.rst
+++ b/docs/async_data_mutations_batcher.rst
@@ -1,0 +1,6 @@
+Mutations Batcher Async
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.bigtable.data._async.mutations_batcher
+  :members:
+  :show-inheritance:

--- a/docs/async_data_read_modify_write_rules.rst
+++ b/docs/async_data_read_modify_write_rules.rst
@@ -1,0 +1,6 @@
+Read Modify Write Rules
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.bigtable.data.read_modify_write_rules
+  :members:
+  :show-inheritance:

--- a/docs/async_data_read_rows_query.rst
+++ b/docs/async_data_read_rows_query.rst
@@ -1,0 +1,6 @@
+Read Rows Query
+~~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.bigtable.data.read_rows_query
+  :members:
+  :show-inheritance:

--- a/docs/async_data_row.rst
+++ b/docs/async_data_row.rst
@@ -1,0 +1,6 @@
+Rows and Cells
+~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.bigtable.data.row
+  :members:
+  :show-inheritance:

--- a/docs/async_data_row_filters.rst
+++ b/docs/async_data_row_filters.rst
@@ -1,0 +1,62 @@
+Bigtable Row Filters
+====================
+
+It is possible to use a
+:class:`RowFilter <google.cloud.bigtable.data.row_filters.RowFilter>`
+when constructing a :class:`ReadRowsQuery <google.cloud.bigtable.data.read_rows_query.ReadRowsQuery>`
+
+The following basic filters
+are provided:
+
+* :class:`SinkFilter <.data.row_filters.SinkFilter>`
+* :class:`PassAllFilter <.data.row_filters.PassAllFilter>`
+* :class:`BlockAllFilter <.data.row_filters.BlockAllFilter>`
+* :class:`RowKeyRegexFilter <.data.row_filters.RowKeyRegexFilter>`
+* :class:`RowSampleFilter <.data.row_filters.RowSampleFilter>`
+* :class:`FamilyNameRegexFilter <.data.row_filters.FamilyNameRegexFilter>`
+* :class:`ColumnQualifierRegexFilter <.data.row_filters.ColumnQualifierRegexFilter>`
+* :class:`TimestampRangeFilter <.data.row_filters.TimestampRangeFilter>`
+* :class:`ColumnRangeFilter <.data.row_filters.ColumnRangeFilter>`
+* :class:`ValueRegexFilter <.data.row_filters.ValueRegexFilter>`
+* :class:`ValueRangeFilter <.data.row_filters.ValueRangeFilter>`
+* :class:`CellsRowOffsetFilter <.data.row_filters.CellsRowOffsetFilter>`
+* :class:`CellsRowLimitFilter <.data.row_filters.CellsRowLimitFilter>`
+* :class:`CellsColumnLimitFilter <.data.row_filters.CellsColumnLimitFilter>`
+* :class:`StripValueTransformerFilter <.data.row_filters.StripValueTransformerFilter>`
+* :class:`ApplyLabelFilter <.data.row_filters.ApplyLabelFilter>`
+
+In addition, these filters can be combined into composite filters with
+
+* :class:`RowFilterChain <.data.row_filters.RowFilterChain>`
+* :class:`RowFilterUnion <.data.row_filters.RowFilterUnion>`
+* :class:`ConditionalRowFilter <.data.row_filters.ConditionalRowFilter>`
+
+These rules can be nested arbitrarily, with a basic filter at the lowest
+level. For example:
+
+.. code:: python
+
+    # Filter in a specified column (matching any column family).
+    col1_filter = ColumnQualifierRegexFilter(b'columnbia')
+
+    # Create a filter to label results.
+    label1 = u'label-red'
+    label1_filter = ApplyLabelFilter(label1)
+
+    # Combine the filters to label all the cells in columnbia.
+    chain1 = RowFilterChain(filters=[col1_filter, label1_filter])
+
+    # Create a similar filter to label cells blue.
+    col2_filter = ColumnQualifierRegexFilter(b'columnseeya')
+    label2 = u'label-blue'
+    label2_filter = ApplyLabelFilter(label2)
+    chain2 = RowFilterChain(filters=[col2_filter, label2_filter])
+
+    # Bring our two labeled columns together.
+    row_filter = RowFilterUnion(filters=[chain1, chain2])
+
+----
+
+.. automodule:: google.cloud.bigtable.data.row_filters
+  :members:
+  :show-inheritance:

--- a/docs/async_data_usage.rst
+++ b/docs/async_data_usage.rst
@@ -1,0 +1,14 @@
+Using the Async Data Client
+===========================
+
+.. toctree::
+  :maxdepth: 2
+
+  async_data_client
+  async_data_mutations_batcher
+  async_data_read_rows_query
+  async_data_row
+  async_data_row_filters
+  async_data_mutations
+  async_data_read_modify_write_rules
+  async_data_exceptions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Using the API
    :maxdepth: 2
 
    usage
+   async_data_usage
 
 
 API Reference

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,5 +1,5 @@
-Using the Standard Client
-=========================
+Using the Sync Client
+=====================
 
 .. toctree::
   :maxdepth: 2

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,5 +1,5 @@
-Using the API
-=============
+Using the Standard Client
+=========================
 
 .. toctree::
   :maxdepth: 2

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -1150,7 +1150,7 @@ class TableAsync:
                 applied to row_key. Entries are applied in order,
                 meaning that earlier mutations can be masked by later
                 ones. Must contain at least one entry if
-                `true_case_mutations is empty, and at most 100000.
+                `true_case_mutations` is empty, and at most 100000.
             - operation_timeout: the time budget for the entire operation, in seconds.
                 Failed requests will not be retried. Defaults to the Table's default_operation_timeout
         Returns:

--- a/google/cloud/bigtable/data/row.py
+++ b/google/cloud/bigtable/data/row.py
@@ -147,10 +147,12 @@ class Row:
         """
         Human-readable string representation
 
-        {
-          (family='fam', qualifier=b'col'): [b'value', (+1 more),],
-          (family='fam', qualifier=b'col2'): [b'other'],
-        }
+        .. code-block:: python
+
+            {
+              (family='fam', qualifier=b'col'): [b'value', (+1 more),],
+              (family='fam', qualifier=b'col2'): [b'other'],
+            }
         """
         output = ["{"]
         for family, qualifier in self._get_column_components():


### PR DESCRIPTION
Added autogenerated sphinx docs pages for async data client

Currently serving them in the Using the API section:

![image](https://github.com/googleapis/python-bigtable/assets/3914119/f8c44c63-a847-46c1-8845-5a878c1138e4)

---

To view docs locally:
- run `nox -s docs` to generate html pages
- run `python -m http.server -d ./docs/_build/html` to start a local server on `localhost:8000`


BEGIN_COMMIT_OVERRIDE
chore(docs): added generated docs for async client
END_COMMIT_OVERRIDE