### PR TITLE
fix: improve backup name regex when listing backups 

### DIFF
--- a/google/cloud/bigtable/backup.py
+++ b/google/cloud/bigtable/backup.py
@@ -28,7 +28,7 @@ _BACKUP_NAME_RE = re.compile(
     r"^projects/(?P<project>[^/]+)/"
     r"instances/(?P<instance_id>[a-z][-a-z0-9]*)/"
     r"clusters/(?P<cluster_id>[a-z][-a-z0-9]*)/"
-    r"backups/(?P<backup_id>[a-z][a-z0-9_\-]*[a-z0-9])$"
+    r"backups/(?P<backup_id>[_a-zA-Z0-9][-_.a-zA-Z0-9]*)$"
 )
 
 _TABLE_NAME_RE = re.compile(


### PR DESCRIPTION
Change the regular expression to match the format specified in the Bigtable Admin API documentation: https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.clusters.backups/create

Fixes #969 