### PR TITLE
feat: surface `retry` param to `Table.read_row` api

### DIFF
--- a/google/cloud/bigtable/table.py
+++ b/google/cloud/bigtable/table.py
@@ -533,7 +533,7 @@ class Table(object):
             for cluster_id, value_pb in table_pb.cluster_states.items()
         }
 
-    def read_row(self, row_key, filter_=None):
+    def read_row(self, row_key, filter_=None, retry=DEFAULT_RETRY_READ_ROWS):
         """Read a single row from this table.
 
         For example:
@@ -550,6 +550,14 @@ class Table(object):
         :param filter_: (Optional) The filter to apply to the contents of the
                         row. If unset, returns the entire row.
 
+        :type retry: :class:`~google.api_core.retry.Retry`
+        :param retry:
+            (Optional) Retry delay and deadline arguments. To override, the
+            default value :attr:`DEFAULT_RETRY_READ_ROWS` can be used and
+            modified with the :meth:`~google.api_core.retry.Retry.with_delay`
+            method or the :meth:`~google.api_core.retry.Retry.with_deadline`
+            method.
+
         :rtype: :class:`.PartialRowData`, :data:`NoneType <types.NoneType>`
         :returns: The contents of the row if any chunks were returned in
                   the response, otherwise :data:`None`.
@@ -558,7 +566,9 @@ class Table(object):
         """
         row_set = RowSet()
         row_set.add_row_key(row_key)
-        result_iter = iter(self.read_rows(filter_=filter_, row_set=row_set))
+        result_iter = iter(
+            self.read_rows(filter_=filter_, row_set=row_set, retry=retry)
+        )
         row = next(result_iter, None)
         if next(result_iter, None) is not None:
             raise ValueError("More than one row was returned.")


### PR DESCRIPTION
### what ? (￣^￣ゞ
this pr surfaces a `retry` param for `Table.read_row`. this param defaults to `DEFAULT_RETRY_READ_ROWS` just as it does for `Table.read_rows`. it then passes forward into the `Table.read_rows` call

### why ? („• ᴗ •„)
in the case where a caller may want to override the default `retry` param for the `Table.read_row` api, they currently *must* switch to using `Table.read_rows` and add their own code for pulling the first item out of the iterator and guarding against multi-row responses (which are functionalities that `Table.read_row` already provides)

in an ideal world, the `Table.read_row` helper method can accept and pass along the retry param so that clients don't need to write their own duplicate implementations wrapping `Table.read_rows`~

### related issue ౨ৎ⋆˚｡⋆
implements #941 