### PR TITLE
fix: update FLUSH_COUNT and MAX_MUTATION_SIZE to align with documentation

### DIFF
--- a/google/cloud/bigtable/batcher.py
+++ b/google/cloud/bigtable/batcher.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 
 FLUSH_COUNT = 1000  # after this many elements, send out the batch
 
-MAX_MUTATION_SIZE = 20 * 1024 * 1024  # 20MB # after this many bytes, send out the batch
+MAX_MUTATION_SIZE = 5 * 1024 * 1024  # 5MB # after this many bytes, send out the batch
 
 MAX_OUTSTANDING_BYTES = 100 * 1024 * 1024  # 100MB # max inflight byte size.
 

--- a/google/cloud/bigtable/batcher.py
+++ b/google/cloud/bigtable/batcher.py
@@ -23,7 +23,7 @@ from google.api_core.exceptions import from_grpc_status
 from dataclasses import dataclass
 
 
-FLUSH_COUNT = 100  # after this many elements, send out the batch
+FLUSH_COUNT = 1000  # after this many elements, send out the batch
 
 MAX_MUTATION_SIZE = 20 * 1024 * 1024  # 20MB # after this many bytes, send out the batch
 


### PR DESCRIPTION
This PR fix discrepancies between documentation and actual values of `FLUSH_COUNT` and `MAX_MUTATION_SIZE`

Of course we can instead update the documentation. However I do believe that `FLUSH_COUNT = 100` is quite low and doesn't have the same magnitude compared to `MAX_MUTATION_SIZE = 20MB`