### PR TITLE
fix: use single routing metadata header

### DIFF
--- a/google/cloud/bigtable_v2/services/bigtable/async_client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/async_client.py
@@ -340,11 +340,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -441,11 +443,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -563,11 +567,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -679,11 +685,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -838,11 +846,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -936,9 +946,11 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -1062,11 +1074,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -1172,11 +1186,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -1274,11 +1290,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -1377,11 +1395,13 @@ class BigtableAsyncClient:
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("instance_name", request.instance_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("instance_name", request.instance_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._client._validate_universe_domain()

--- a/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -817,9 +817,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata) + (
-                gapic_v1.routing_header.to_grpc_metadata(header_params),
-            )
+            metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -933,9 +933,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata) + (
-                gapic_v1.routing_header.to_grpc_metadata(header_params),
-            )
+            metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1070,9 +1070,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata) + (
-                gapic_v1.routing_header.to_grpc_metadata(header_params),
-            )
+            metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1201,9 +1201,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata) + (
-                gapic_v1.routing_header.to_grpc_metadata(header_params),
-            )
+            metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1375,9 +1375,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata) + (
-                gapic_v1.routing_header.to_grpc_metadata(header_params),
-            )
+            metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1477,9 +1477,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
-            metadata = tuple(metadata) + (
-                gapic_v1.routing_header.to_grpc_metadata(header_params),
-            )
+            metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1620,9 +1620,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata) + (
-                gapic_v1.routing_header.to_grpc_metadata(header_params),
-            )
+            metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1725,11 +1725,13 @@ class BigtableClient(metaclass=BigtableClientMeta):
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1824,11 +1826,13 @@ class BigtableClient(metaclass=BigtableClientMeta):
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata(
-                (("table_name", request.table_name),)
-            ),
-        )
+        metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (
+                gapic_v1.routing_header.to_grpc_metadata(
+                    (("table_name", request.table_name),)
+                ),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1933,9 +1937,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
-            metadata = tuple(metadata) + (
-                gapic_v1.routing_header.to_grpc_metadata(header_params),
-            )
+            metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
 
         # Validate the universe domain.
         self._validate_universe_domain()

--- a/owlbot.py
+++ b/owlbot.py
@@ -143,6 +143,17 @@ insert(
     escape='"'
 )
 
+# ----------------------------------------------------------------------------
+# Patch duplicate routing header: https://github.com/googleapis/gapic-generator-python/issues/2078
+# ----------------------------------------------------------------------------
+for file in ["client.py", "async_client.py"]:
+    s.replace(
+        f"google/cloud/bigtable_v2/services/bigtable/{file}",
+        "metadata \= tuple\(metadata\) \+ \(",
+        """metadata = tuple(metadata)
+        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
+            metadata += ("""
+    )
 
 # ----------------------------------------------------------------------------
 # Samples templates

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -1277,7 +1277,7 @@ class TestTableAsync:
             ("read_rows_sharded", ([ReadRowsQuery()],), "read_rows"),
             ("row_exists", (b"row_key",), "read_rows"),
             ("sample_row_keys", (), "sample_row_keys"),
-            ("mutate_row", (b"row_key", [mock.Mock()]), "mutate_row"),
+            ("mutate_row", (b"row_key", [mutations.DeleteAllFromRow()]), "mutate_row"),
             (
                 "bulk_mutate_rows",
                 ([mutations.RowMutationEntry(b"key", [mutations.DeleteAllFromRow()])],),
@@ -1286,7 +1286,7 @@ class TestTableAsync:
             ("check_and_mutate_row", (b"row_key", None), "check_and_mutate_row"),
             (
                 "read_modify_write_row",
-                (b"row_key", mock.Mock()),
+                (b"row_key", IncrementRule('f', 'q')),
                 "read_modify_write_row",
             ),
         ],

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -1286,7 +1286,7 @@ class TestTableAsync:
             ("check_and_mutate_row", (b"row_key", None), "check_and_mutate_row"),
             (
                 "read_modify_write_row",
-                (b"row_key", IncrementRule('f', 'q')),
+                (b"row_key", IncrementRule("f", "q")),
                 "read_modify_write_row",
             ),
         ],


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-bigtable/issues/1004, and adds a unit test to ensure only a single routing header is sent

A longer term fix is proposed in the gapic generator at https://github.com/googleapis/gapic-generator-python/pull/2079, but this patch will work until the upstream is updated
