### PR TITLE
chore: revert sync client customizations

### DIFF
--- a/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -817,9 +817,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
+            metadata = tuple(metadata) + (
+                gapic_v1.routing_header.to_grpc_metadata(header_params),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -933,9 +933,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
+            metadata = tuple(metadata) + (
+                gapic_v1.routing_header.to_grpc_metadata(header_params),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1070,9 +1070,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
+            metadata = tuple(metadata) + (
+                gapic_v1.routing_header.to_grpc_metadata(header_params),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1201,9 +1201,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
+            metadata = tuple(metadata) + (
+                gapic_v1.routing_header.to_grpc_metadata(header_params),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1375,9 +1375,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
+            metadata = tuple(metadata) + (
+                gapic_v1.routing_header.to_grpc_metadata(header_params),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1477,9 +1477,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
-            metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
+            metadata = tuple(metadata) + (
+                gapic_v1.routing_header.to_grpc_metadata(header_params),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1620,9 +1620,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             )
 
         if header_params:
-            metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
+            metadata = tuple(metadata) + (
+                gapic_v1.routing_header.to_grpc_metadata(header_params),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1937,9 +1937,9 @@ class BigtableClient(metaclass=BigtableClientMeta):
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
-            metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (gapic_v1.routing_header.to_grpc_metadata(header_params),)
+            metadata = tuple(metadata) + (
+                gapic_v1.routing_header.to_grpc_metadata(header_params),
+            )
 
         # Validate the universe domain.
         self._validate_universe_domain()

--- a/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -1725,13 +1725,11 @@ class BigtableClient(metaclass=BigtableClientMeta):
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (
-                gapic_v1.routing_header.to_grpc_metadata(
-                    (("table_name", request.table_name),)
-                ),
-            )
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("table_name", request.table_name),)
+            ),
+        )
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1826,13 +1824,11 @@ class BigtableClient(metaclass=BigtableClientMeta):
 
         # Certain fields should be provided within the metadata header;
         # add these here.
-        metadata = tuple(metadata)
-        if all(m[0] != gapic_v1.routing_header.ROUTING_METADATA_KEY for m in metadata):
-            metadata += (
-                gapic_v1.routing_header.to_grpc_metadata(
-                    (("table_name", request.table_name),)
-                ),
-            )
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("table_name", request.table_name),)
+            ),
+        )
 
         # Validate the universe domain.
         self._validate_universe_domain()

--- a/owlbot.py
+++ b/owlbot.py
@@ -146,7 +146,7 @@ insert(
 # ----------------------------------------------------------------------------
 # Patch duplicate routing header: https://github.com/googleapis/gapic-generator-python/issues/2078
 # ----------------------------------------------------------------------------
-for file in ["client.py", "async_client.py"]:
+for file in ["async_client.py"]:
     s.replace(
         f"google/cloud/bigtable_v2/services/bigtable/{file}",
         "metadata \= tuple\(metadata\) \+ \(",


### PR DESCRIPTION
We [recently made some changes](https://github.com/googleapis/python-bigtable/pull/1005) to the generated client and async_client to remove the possibility of double headers. This PR reverts the change for the sync client, since the fix is only currently needed for the async client, and we only have proper tests in place for async

A long-term fix for both is being worked on at https://github.com/googleapis/gapic-generator-python/pull/2079
