### PR TITLE
fix: registering duplicate instance

### DIFF
--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -350,7 +350,7 @@ class BigtableDataClientAsync(ClientWithProject):
             instance_name, owner.table_name, owner.app_profile_id
         )
         self._instance_owners.setdefault(instance_key, set()).add(id(owner))
-        if instance_name not in self._active_instances:
+        if instance_key not in self._active_instances:
             self._active_instances.add(instance_key)
             if self._channel_refresh_tasks:
                 # refresh tasks already running


### PR DESCRIPTION
Previously, creating multiple Table objects pointed at the same `(instance, table, app_profile_id)` would cause duplicate ping_and_warm calls, even though the table should already be warm. This was because the registration logic was checking for the presence of the `instance_name`, even though the `_active_instances` store was actually storing `instance_keys`

This PR fixes the bug, and adds a new unit test