### PR TITLE
chore(build): Use python 3.10 for docs session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -367,7 +367,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.10")
 def docs(session):
     """Build the docs for this library."""
 


### PR DESCRIPTION
docs test container now requires python 3.10. Related: https://github.com/googleapis/python-bigquery/pull/2058
