### PR TITLE
chore: use default app profile

### DIFF
--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -472,6 +472,7 @@ class BigtableDataClientAsync(ClientWithProject):
             table_id: The ID of the table. table_id is combined with the
                 instance_id and the client's project to fully specify the table
             app_profile_id: The app profile to associate with requests.
+                If not set, will use "default".
                 https://cloud.google.com/bigtable/docs/app-profiles
             default_read_rows_operation_timeout: The default timeout for read rows
                 operations, in seconds. If not set, defaults to 600 seconds (10 minutes)
@@ -542,6 +543,7 @@ class BigtableDataClientAsync(ClientWithProject):
                 detected automatically (i.e. the value can be None, an empty list or
                 an empty dict).
             app_profile_id: The app profile to associate with requests.
+                If not set, will use "default".
                 https://cloud.google.com/bigtable/docs/app-profiles
             operation_timeout: the time budget for the entire operation, in seconds.
                 Failed requests will be retried within the budget.
@@ -571,6 +573,8 @@ class BigtableDataClientAsync(ClientWithProject):
         pb_params = _format_execute_query_params(parameters, parameter_types)
 
         instance_name = self._gapic_client.instance_path(self.project, instance_id)
+        if app_profile_id is None:
+            app_profile_id = "default"
 
         request_body = {
             "instance_name": instance_name,
@@ -662,6 +666,7 @@ class TableAsync:
             table_id: The ID of the table. table_id is combined with the
                 instance_id and the client's project to fully specify the table
             app_profile_id: The app profile to associate with requests.
+                If not set, will use "default".
                 https://cloud.google.com/bigtable/docs/app-profiles
             default_read_rows_operation_timeout: The default timeout for read rows
                 operations, in seconds. If not set, defaults to 600 seconds (10 minutes)
@@ -713,7 +718,9 @@ class TableAsync:
         self.table_name = self.client._gapic_client.table_path(
             self.client.project, instance_id, table_id
         )
-        self.app_profile_id = app_profile_id
+        self.app_profile_id = (
+            app_profile_id if app_profile_id is not None else "default"
+        )
 
         self.default_operation_timeout = default_operation_timeout
         self.default_attempt_timeout = default_attempt_timeout

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -718,9 +718,7 @@ class TableAsync:
         self.table_name = self.client._gapic_client.table_path(
             self.client.project, instance_id, table_id
         )
-        self.app_profile_id = (
-            app_profile_id if app_profile_id is not None else ""
-        )
+        self.app_profile_id = app_profile_id if app_profile_id is not None else ""
 
         self.default_operation_timeout = default_operation_timeout
         self.default_attempt_timeout = default_attempt_timeout

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -472,7 +472,7 @@ class BigtableDataClientAsync(ClientWithProject):
             table_id: The ID of the table. table_id is combined with the
                 instance_id and the client's project to fully specify the table
             app_profile_id: The app profile to associate with requests.
-                If not set, will use "default".
+                If not set, will use empty string.
                 https://cloud.google.com/bigtable/docs/app-profiles
             default_read_rows_operation_timeout: The default timeout for read rows
                 operations, in seconds. If not set, defaults to 600 seconds (10 minutes)
@@ -543,7 +543,7 @@ class BigtableDataClientAsync(ClientWithProject):
                 detected automatically (i.e. the value can be None, an empty list or
                 an empty dict).
             app_profile_id: The app profile to associate with requests.
-                If not set, will use "default".
+                If not set, will use empty string.
                 https://cloud.google.com/bigtable/docs/app-profiles
             operation_timeout: the time budget for the entire operation, in seconds.
                 Failed requests will be retried within the budget.
@@ -574,7 +574,7 @@ class BigtableDataClientAsync(ClientWithProject):
 
         instance_name = self._gapic_client.instance_path(self.project, instance_id)
         if app_profile_id is None:
-            app_profile_id = "default"
+            app_profile_id = ""
 
         request_body = {
             "instance_name": instance_name,
@@ -666,7 +666,7 @@ class TableAsync:
             table_id: The ID of the table. table_id is combined with the
                 instance_id and the client's project to fully specify the table
             app_profile_id: The app profile to associate with requests.
-                If not set, will use "default".
+                If not set, will use empty string.
                 https://cloud.google.com/bigtable/docs/app-profiles
             default_read_rows_operation_timeout: The default timeout for read rows
                 operations, in seconds. If not set, defaults to 600 seconds (10 minutes)
@@ -719,7 +719,7 @@ class TableAsync:
             self.client.project, instance_id, table_id
         )
         self.app_profile_id = (
-            app_profile_id if app_profile_id is not None else "default"
+            app_profile_id if app_profile_id is not None else ""
         )
 
         self.default_operation_timeout = default_operation_timeout

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -1069,7 +1069,7 @@ class TestTableAsync:
         await CrossSync.yield_to_event_loop()
         assert table.table_id == expected_table_id
         assert table.instance_id == expected_instance_id
-        assert table.app_profile_id is None
+        assert table.app_profile_id == "default"
         assert table.client is client
         assert table.default_operation_timeout == 60
         assert table.default_read_rows_operation_timeout == 600
@@ -1290,7 +1290,7 @@ class TestTableAsync:
         if include_app_profile:
             assert "app_profile_id=profile" in routing_str
         else:
-            assert "app_profile_id=" not in routing_str
+            assert "app_profile_id=default" in routing_str
 
 
 @CrossSync.convert_class(
@@ -2938,7 +2938,7 @@ class TestReadModifyWriteRowAsync:
                         kwargs["table_name"]
                         == f"projects/{project}/instances/{instance}/tables/{table_id}"
                     )
-                    assert kwargs["app_profile_id"] is None
+                    assert kwargs["app_profile_id"] == "default"
                     assert kwargs["row_key"] == row_key.encode()
                     assert kwargs["timeout"] > 1
 

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -1069,7 +1069,7 @@ class TestTableAsync:
         await CrossSync.yield_to_event_loop()
         assert table.table_id == expected_table_id
         assert table.instance_id == expected_instance_id
-        assert table.app_profile_id == "default"
+        assert table.app_profile_id == ""
         assert table.client is client
         assert table.default_operation_timeout == 60
         assert table.default_read_rows_operation_timeout == 600
@@ -1290,7 +1290,7 @@ class TestTableAsync:
         if include_app_profile:
             assert "app_profile_id=profile" in routing_str
         else:
-            assert "app_profile_id=default" in routing_str
+            assert "app_profile_id=" in routing_str
 
 
 @CrossSync.convert_class(
@@ -2938,7 +2938,7 @@ class TestReadModifyWriteRowAsync:
                         kwargs["table_name"]
                         == f"projects/{project}/instances/{instance}/tables/{table_id}"
                     )
-                    assert kwargs["app_profile_id"] == "default"
+                    assert kwargs["app_profile_id"] == ""
                     assert kwargs["row_key"] == row_key.encode()
                     assert kwargs["timeout"] > 1
 


### PR DESCRIPTION
previously, users could create a Table with `TableAsync(app_profile_id=None)`, which omits the app_profile_id field from all request headers. Now, `TableAsync(app_profile_id=None)` will use set `TableAsync.app_profile_id` to the strung "default" in request headers