### PR TITLE
chore(docs): update `RowSet` to no longer reference deprecated `Table.yield_rows`

### DIFF
--- a/google/cloud/bigtable/row_set.py
+++ b/google/cloud/bigtable/row_set.py
@@ -22,7 +22,7 @@ class RowSet(object):
     """Convenience wrapper of google.bigtable.v2.RowSet
 
     Useful for creating a set of row keys and row ranges, which can
-    be passed to yield_rows method of class:`.Table.yield_rows`.
+    be passed to read_rows method of class:`.Table.read_rows`.
     """
 
     def __init__(self):


### PR DESCRIPTION
hallo!

i was reading the `RowSet` code and noticed that it referenced the `Table.yield_rows` method, which is mentioned to be deprecated here: https://github.com/googleapis/python-bigtable/blob/f974823bf8a74c2f8b1bc69997b13bc1acaf8bef/google/cloud/bigtable/table.py#L652-L654

this is a simple fix to update the docs to reference `Table.read_rows` ^^