### PR TITLE
[DRAFT] chore: update conformance tests

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-version: [ "main" ]
+        test-version: [ "v0.0.3" ]
         py-version: [ 3.8 ]
         client-type: [ "async", "sync" ]
         include:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-version: [ "v0.0.2" ]
+        test-version: [ "HEAD" ]
         py-version: [ 3.8 ]
         client-type: [ "async", "sync" ]
         include:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -26,15 +26,11 @@ jobs:
       matrix:
         test-version: [ "v0.0.2" ]
         py-version: [ 3.8 ]
-        client-type: [ "async", "sync", "legacy" ]
+        client-type: [ "async", "sync" ]
         include:
           - client-type: "sync"
             # sync client does not support concurrent streams
             test_args: "-skip _Generic_MultiStream"
-          - client-type: "legacy"
-            # legacy client is synchronous and does not support concurrent streams
-            # legacy client does not expose mutate_row. Disable those tests
-            test_args: "-skip _Generic_MultiStream -skip TestMutateRow_"
       fail-fast: false
     name: "${{ matrix.client-type }} client / python ${{ matrix.py-version }} / test tag ${{ matrix.test-version }}"
     steps:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-version: [ "HEAD" ]
+        test-version: [ "main" ]
         py-version: [ 3.8 ]
         client-type: [ "async", "sync" ]
         include:

--- a/test_proxy/handlers/grpc_handler.py
+++ b/test_proxy/handlers/grpc_handler.py
@@ -108,7 +108,6 @@ class TestProxyGrpcServer(test_proxy_pb2_grpc.CloudBigtableV2TestProxyServicer):
         if isinstance(client_response, dict) and "error" in client_response:
             entries = [bigtable_pb2.MutateRowsResponse.Entry(index=exc_dict.get("index",1), status=Status(code=exc_dict.get("code", 5))) for exc_dict in client_response.get("subexceptions", [])]
             status = Status(code=client_response.get("code", 5), message=client_response["error"])
-        # TODO: protos were updated. entry is now entries: https://github.com/googleapis/cndb-client-testing-protos/commit/e6205a2bba04acc10d12421a1402870b4a525fb3
         response = test_proxy_pb2.MutateRowsResult(status=status, entry=entries)
         return response
 
@@ -142,5 +141,4 @@ class TestProxyGrpcServer(test_proxy_pb2_grpc.CloudBigtableV2TestProxyServicer):
         else:
             for sample in client_response:
                 sample_list.append(bigtable_pb2.SampleRowKeysResponse(offset_bytes=sample[1], row_key=sample[0]))
-        # TODO: protos were updated. sample is now samples: https://github.com/googleapis/cndb-client-testing-protos/commit/e6205a2bba04acc10d12421a1402870b4a525fb3
         return test_proxy_pb2.SampleRowKeysResult(status=status, sample=sample_list)

--- a/test_proxy/handlers/grpc_handler.py
+++ b/test_proxy/handlers/grpc_handler.py
@@ -107,9 +107,7 @@ class TestProxyGrpcServer(test_proxy_pb2_grpc.CloudBigtableV2TestProxyServicer):
         entries = []
         if isinstance(client_response, dict) and "error" in client_response:
             entries = [bigtable_pb2.MutateRowsResponse.Entry(index=exc_dict.get("index",1), status=Status(code=exc_dict.get("code", 5))) for exc_dict in client_response.get("subexceptions", [])]
-            if not entries:
-                # only return failure on the overall request if there are failed entries
-                status = Status(code=client_response.get("code", 5), message=client_response["error"])
+            status = Status(code=client_response.get("code", 5), message=client_response["error"])
         # TODO: protos were updated. entry is now entries: https://github.com/googleapis/cndb-client-testing-protos/commit/e6205a2bba04acc10d12421a1402870b4a525fb3
         response = test_proxy_pb2.MutateRowsResult(status=status, entry=entries)
         return response


### PR DESCRIPTION
- remove legacy client conformance tests (https://github.com/googleapis/python-bigtable/issues/1054)
- update test tag to test against latest runner
---
## currently failing tests (7)
- `*_WithRetryInfo`
  - missing server-specified backoff values (must read from `exception.details`)
- `*_WithRoutingCookie`
  - if routing cookie is passed with exception, it should be passed as metadata in subsequent attempts
- `TestReadRows_ReverseScans_FeatureFlag_Enabled`/`TestReadRows_NoRetry_OutOfOrderError_Reverse`/`TestReadRows_Retry_LastScannedRow_Reverse`
  -  missing reverse read rows