### PR TITLE
fix: allow empty headers for btql routing

### DIFF
--- a/google/cloud/bigtable_v2/services/bigtable/async_client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/async_client.py
@@ -344,7 +344,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -463,7 +463,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -603,7 +603,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -737,7 +737,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -914,7 +914,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1028,7 +1028,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -1165,7 +1165,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(

--- a/google/cloud/bigtable_v2/services/bigtable/async_client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/async_client.py
@@ -1496,7 +1496,8 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:
+            # execute_query currently requires empty header support. TODO: remove after support is added
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:

--- a/google/cloud/bigtable_v2/services/bigtable/async_client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/async_client.py
@@ -344,7 +344,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -463,7 +463,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -603,7 +603,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -737,7 +737,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -914,7 +914,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1028,7 +1028,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -1165,7 +1165,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(

--- a/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -1893,7 +1893,8 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:
+            # execute_query currently requires empty header support. TODO: remove after support is adde
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:

--- a/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -768,7 +768,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -884,7 +884,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1021,7 +1021,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1152,7 +1152,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1326,7 +1326,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1437,7 +1437,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -1571,7 +1571,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(

--- a/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -768,7 +768,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -884,7 +884,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1021,7 +1021,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1152,7 +1152,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1326,7 +1326,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1437,7 +1437,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -1571,7 +1571,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(

--- a/owlbot.py
+++ b/owlbot.py
@@ -113,18 +113,3 @@ s.replace(
 INSTALL_LIBRARY_FROM_SOURCE = False""")
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
-
-# ----------------------------------------------------------------------------
-# Customize execute_query rpc to support empty app_profile_id headers
-# ----------------------------------------------------------------------------
-
-s.replace(
-    "google/cloud/bigtable_v2/services/bigtable/client.py",
-    "if request.app_profile_id:",
-    "if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing"
-)
-s.replace(
-    "google/cloud/bigtable_v2/services/bigtable/async_client.py",
-    "if request.app_profile_id:",
-    "if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing"
-)

--- a/owlbot.py
+++ b/owlbot.py
@@ -113,3 +113,18 @@ s.replace(
 INSTALL_LIBRARY_FROM_SOURCE = False""")
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
+
+# ----------------------------------------------------------------------------
+# Customize execute_query rpc to support empty app_profile_id headers
+# ----------------------------------------------------------------------------
+
+s.replace(
+    "google/cloud/bigtable_v2/services/bigtable/client.py",
+    "if request.app_profile_id:",
+    "if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing"
+)
+s.replace(
+    "google/cloud/bigtable_v2/services/bigtable/async_client.py",
+    "if request.app_profile_id:",
+    "if request.app_profile_id is not None:  # temporary fix: support empty headers for btql routing"
+)

--- a/tests/system/data/test_system_async.py
+++ b/tests/system/data/test_system_async.py
@@ -1014,3 +1014,16 @@ class TestSystemAsync:
         assert len(row_list) == bool(
             expect_match
         ), f"row {type(cell_value)}({cell_value}) not found with {type(filter_input)}({filter_input}) filter"
+
+    @CrossSync.pytest
+    @pytest.mark.usefixtures("client")
+    @CrossSync.Retry(
+        predicate=retry.if_exception_type(ClientError), initial=1, maximum=5
+    )
+    async def test_execute_query_simple(self, client, table_id, instance_id):
+        result = await client.execute_query("SELECT 1 AS a, 'foo' AS b", instance_id)
+        rows = [r async for r in result]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["a"] == 1
+        assert row["b"] == "foo"

--- a/tests/system/data/test_system_autogen.py
+++ b/tests/system/data/test_system_autogen.py
@@ -826,3 +826,15 @@ class TestSystem:
         assert len(row_list) == bool(
             expect_match
         ), f"row {type(cell_value)}({cell_value}) not found with {type(filter_input)}({filter_input}) filter"
+
+    @pytest.mark.usefixtures("client")
+    @CrossSync._Sync_Impl.Retry(
+        predicate=retry.if_exception_type(ClientError), initial=1, maximum=5
+    )
+    def test_execute_query_simple(self, client, table_id, instance_id):
+        result = client.execute_query("SELECT 1 AS a, 'foo' AS b", instance_id)
+        rows = [r for r in result]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["a"] == 1
+        assert row["b"] == "foo"

--- a/tests/unit/gapic/bigtable_v2/test_bigtable.py
+++ b/tests/unit/gapic/bigtable_v2/test_bigtable.py
@@ -6869,7 +6869,10 @@ def test_execute_query_routing_parameters_request_1_grpc():
         assert args[0] == request_msg
 
         # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {"name": "projects/sample1/instances/sample2", "app_profile_id": ""}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -7896,7 +7899,10 @@ async def test_execute_query_routing_parameters_request_1_grpc_asyncio():
         assert args[0] == request_msg
 
         # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {"name": "projects/sample1/instances/sample2", "app_profile_id": ""}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -9918,7 +9924,10 @@ def test_execute_query_routing_parameters_request_1_rest():
         assert args[0] == request_msg
 
         # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {"name": "projects/sample1/instances/sample2", "app_profile_id": ""}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )

--- a/tests/unit/gapic/bigtable_v2/test_bigtable.py
+++ b/tests/unit/gapic/bigtable_v2/test_bigtable.py
@@ -6868,7 +6868,8 @@ def test_execute_query_routing_parameters_request_1_grpc():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
+        expected_headers = {"name": "projects/sample1/instances/sample2", "app_profile_id": ""}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -7894,7 +7895,8 @@ async def test_execute_query_routing_parameters_request_1_grpc_asyncio():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
+        expected_headers = {"name": "projects/sample1/instances/sample2", "app_profile_id": ""}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -9915,7 +9917,8 @@ def test_execute_query_routing_parameters_request_1_rest():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
+        expected_headers = {"name": "projects/sample1/instances/sample2", "app_profile_id": ""}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )


### PR DESCRIPTION
Normally, gapic clients treat empty strings as unset values for routing headers. This causes issues with btql, which requires the header to be sent to the backend, even if empty. 

This PR patches the gapic code to allow empty `app_profile_id` headers for the `execute_query` rpc. Long term, we will have to find a solution on the backend, so empty headers aren't needed

Fixes https://github.com/googleapis/python-bigtable/issues/1073