### PR TITLE
fix: grpc channel refresh

### DIFF
--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -164,8 +164,8 @@ class BigtableDataClientAsync(ClientWithProject):
         if "pool_size" in kwargs:
             warnings.warn("pool_size no longer supported")
         # set up client info headers for veneer library
-        client_info = DEFAULT_CLIENT_INFO
-        client_info.client_library_version = self._client_version()
+        self.client_info = DEFAULT_CLIENT_INFO
+        self.client_info.client_library_version = self._client_version()
         # parse client options
         if type(client_options) is dict:
             client_options = client_options_lib.from_dict(client_options)
@@ -196,7 +196,7 @@ class BigtableDataClientAsync(ClientWithProject):
         self._gapic_client = CrossSync.GapicClient(
             credentials=credentials,
             client_options=client_options,
-            client_info=client_info,
+            client_info=self.client_info,
             transport=lambda *args, **kwargs: TransportType(
                 *args, **kwargs, channel=custom_channel
             ),
@@ -371,6 +371,9 @@ class BigtableDataClientAsync(ClientWithProject):
             await self._ping_and_warm_instances(channel=new_channel)
             # cycle channel out of use, with long grace window before closure
             self.transport._grpc_channel = new_channel
+            # invalidate caches
+            self.transport._stubs = {}
+            self.transport._prep_wrapped_messages(self.client_info)
             # give old_channel a chance to complete existing rpcs
             if CrossSync.is_async:
                 await old_channel.close(grace_period)

--- a/google/cloud/bigtable/data/_sync_autogen/client.py
+++ b/google/cloud/bigtable/data/_sync_autogen/client.py
@@ -114,8 +114,8 @@ class BigtableDataClient(ClientWithProject):
         """
         if "pool_size" in kwargs:
             warnings.warn("pool_size no longer supported")
-        client_info = DEFAULT_CLIENT_INFO
-        client_info.client_library_version = self._client_version()
+        self.client_info = DEFAULT_CLIENT_INFO
+        self.client_info.client_library_version = self._client_version()
         if type(client_options) is dict:
             client_options = client_options_lib.from_dict(client_options)
         client_options = cast(
@@ -143,7 +143,7 @@ class BigtableDataClient(ClientWithProject):
         self._gapic_client = CrossSync._Sync_Impl.GapicClient(
             credentials=credentials,
             client_options=client_options,
-            client_info=client_info,
+            client_info=self.client_info,
             transport=lambda *args, **kwargs: TransportType(
                 *args, **kwargs, channel=custom_channel
             ),
@@ -284,6 +284,8 @@ class BigtableDataClient(ClientWithProject):
             new_channel = self.transport.create_channel()
             self._ping_and_warm_instances(channel=new_channel)
             self.transport._grpc_channel = new_channel
+            self.transport._stubs = {}
+            self.transport._prep_wrapped_messages(self.client_info)
             if grace_period:
                 self._is_closed.wait(grace_period)
             old_channel.close()

--- a/tests/system/data/test_system_async.py
+++ b/tests/system/data/test_system_async.py
@@ -225,6 +225,8 @@ class TestSystemAsync:
                 refresh_interval_max=1,
                 sync_executor=client._executor,
             )
+            # let task run
+            await CrossSync.yield_to_event_loop()
             async with client.get_table(instance_id, table_id) as table:
                 rows = await table.read_rows({})
                 first_channel = client.transport.grpc_channel

--- a/tests/system/data/test_system_async.py
+++ b/tests/system/data/test_system_async.py
@@ -231,7 +231,7 @@ class TestSystemAsync:
                 rows = await table.read_rows({})
                 first_channel = client.transport.grpc_channel
                 assert len(rows) == 2
-                await asyncio.sleep(2)
+                await CrossSync.sleep(2)
                 rows_after_refresh = await table.read_rows({})
                 assert len(rows_after_refresh) == 2
                 assert client.transport.grpc_channel is not first_channel


### PR DESCRIPTION
There's a bug in the grpc channel refresh, where future rpcs would still use the previous channel, even after it was closed. This PR adds logic to invalidate the caches, and adds system tests to catch similar issues in the future
