### PR TITLE
fix: Allow protobuf 6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,13 +37,13 @@ version = version["__version__"]
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 2.16.0, <3.0.0dev",
-    "google-cloud-core >= 1.4.4, <3.0.0dev",
-    "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",
-    "grpc-google-iam-v1 >= 0.12.4, <1.0.0dev",
-    "proto-plus >= 1.22.3, <2.0.0dev",
-    "proto-plus >= 1.25.0, <2.0.0dev; python_version>='3.13'",
-    "protobuf>=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "google-api-core[grpc] >= 2.16.0, <3.0.0",
+    "google-cloud-core >= 1.4.4, <3.0.0",
+    "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpc-google-iam-v1 >= 0.12.4, <1.0.0",
+    "proto-plus >= 1.22.3, <2.0.0",
+    "proto-plus >= 1.25.0, <2.0.0; python_version>='3.13'",
+    "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 extras = {"libcst": "libcst >= 0.2.5"}
 


### PR DESCRIPTION
See https://pypi.org/project/protobuf/6.30.0/
See https://github.com/googleapis/gapic-generator-python/pull/2347 for removing `dev` in `setup.py`