### PR TITLE
feat: Refactor Metadata, add system tests, remove preview warning

### DIFF
--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -610,10 +610,6 @@ class BigtableDataClientAsync(ClientWithProject):
             google.cloud.bigtable.data.exceptions.ParameterTypeInferenceFailed: Raised if
                 a parameter is passed without an explicit type, and the type cannot be infered
         """
-        warnings.warn(
-            "ExecuteQuery is in preview and may change in the future.",
-            category=RuntimeWarning,
-        )
         instance_name = self._gapic_client.instance_path(self.project, instance_id)
         converted_param_types = _to_param_types(parameters, parameter_types)
         prepare_request = {

--- a/google/cloud/bigtable/data/_sync_autogen/client.py
+++ b/google/cloud/bigtable/data/_sync_autogen/client.py
@@ -471,10 +471,6 @@ class BigtableDataClient(ClientWithProject):
             google.cloud.bigtable.data.exceptions.ParameterTypeInferenceFailed: Raised if
                 a parameter is passed without an explicit type, and the type cannot be infered
         """
-        warnings.warn(
-            "ExecuteQuery is in preview and may change in the future.",
-            category=RuntimeWarning,
-        )
         instance_name = self._gapic_client.instance_path(self.project, instance_id)
         converted_param_types = _to_param_types(parameters, parameter_types)
         prepare_request = {

--- a/google/cloud/bigtable/data/execute_query/__init__.py
+++ b/google/cloud/bigtable/data/execute_query/__init__.py
@@ -20,7 +20,6 @@ from google.cloud.bigtable.data.execute_query._sync_autogen.execute_query_iterat
 )
 from google.cloud.bigtable.data.execute_query.metadata import (
     Metadata,
-    ProtoMetadata,
     SqlType,
 )
 from google.cloud.bigtable.data.execute_query.values import (
@@ -39,7 +38,6 @@ __all__ = [
     "QueryResultRow",
     "Struct",
     "Metadata",
-    "ProtoMetadata",
     "ExecuteQueryIteratorAsync",
     "ExecuteQueryIterator",
 ]

--- a/google/cloud/bigtable/data/execute_query/metadata.py
+++ b/google/cloud/bigtable/data/execute_query/metadata.py
@@ -299,14 +299,6 @@ class SqlType:
 
 class Metadata:
     """
-    Base class for metadata returned by the ExecuteQuery operation.
-    """
-
-    pass
-
-
-class ProtoMetadata(Metadata):
-    """
     Metadata class for the ExecuteQuery operation.
 
     Args:
@@ -335,7 +327,7 @@ class ProtoMetadata(Metadata):
     def __init__(
         self, columns: Optional[List[Tuple[Optional[str], SqlType.Type]]] = None
     ):
-        self._columns: List[ProtoMetadata.Column] = []
+        self._columns: List[Metadata.Column] = []
         self._column_indexes: Dict[str, List[int]] = defaultdict(list)
         self._duplicate_names: Set[str] = set()
 
@@ -345,7 +337,7 @@ class ProtoMetadata(Metadata):
                     if column_name in self._column_indexes:
                         self._duplicate_names.add(column_name)
                     self._column_indexes[column_name].append(len(self._columns))
-                self._columns.append(ProtoMetadata.Column(column_name, column_type))
+                self._columns.append(Metadata.Column(column_name, column_type))
 
     def __getitem__(self, index_or_name: Union[str, int]) -> Column:
         if isinstance(index_or_name, str):
@@ -381,7 +373,7 @@ def _pb_metadata_to_metadata_types(
             fields.append(
                 (column_metadata.name, _pb_type_to_metadata_type(column_metadata.type))
             )
-        return ProtoMetadata(fields)
+        return Metadata(fields)
     raise ValueError("Invalid ResultSetMetadata object received.")
 
 

--- a/tests/system/data/test_system_autogen.py
+++ b/tests/system/data/test_system_autogen.py
@@ -869,6 +869,30 @@ class TestSystem:
         assert row["a"] == 1
         assert row["b"] == "foo"
 
+    @pytest.mark.usefixtures("table")
+    @CrossSync._Sync_Impl.Retry(
+        predicate=retry.if_exception_type(ClientError), initial=1, maximum=5
+    )
+    def test_execute_against_table(self, client, instance_id, table_id, temp_rows):
+        temp_rows.add_row(b"row_key_1")
+        result = client.execute_query("SELECT * FROM `" + table_id + "`", instance_id)
+        rows = [r for r in result]
+        assert len(rows) == 1
+        assert rows[0]["_key"] == b"row_key_1"
+        family_map = rows[0][TEST_FAMILY]
+        assert len(family_map) == 1
+        assert family_map[b"q"] == b"test-value"
+        assert len(rows[0][TEST_FAMILY_2]) == 0
+        md = result.metadata
+        assert len(md) == 3
+        assert md["_key"].column_type == SqlType.Bytes()
+        assert md[TEST_FAMILY].column_type == SqlType.Map(
+            SqlType.Bytes(), SqlType.Bytes()
+        )
+        assert md[TEST_FAMILY_2].column_type == SqlType.Map(
+            SqlType.Bytes(), SqlType.Bytes()
+        )
+
     @pytest.mark.usefixtures("client")
     @CrossSync._Sync_Impl.Retry(
         predicate=retry.if_exception_type(ClientError), initial=1, maximum=5
@@ -945,3 +969,26 @@ class TestSystem:
             date_pb2.Date(year=2025, month=1, day=17),
             None,
         ]
+
+    @pytest.mark.usefixtures("table")
+    @CrossSync._Sync_Impl.Retry(
+        predicate=retry.if_exception_type(ClientError), initial=1, maximum=5
+    )
+    def test_execute_metadata_on_empty_response(
+        self, client, instance_id, table_id, temp_rows
+    ):
+        temp_rows.add_row(b"row_key_1")
+        result = client.execute_query(
+            "SELECT * FROM `" + table_id + "` WHERE _key='non-existent'", instance_id
+        )
+        rows = [r for r in result]
+        assert len(rows) == 0
+        md = result.metadata
+        assert len(md) == 3
+        assert md["_key"].column_type == SqlType.Bytes()
+        assert md[TEST_FAMILY].column_type == SqlType.Map(
+            SqlType.Bytes(), SqlType.Bytes()
+        )
+        assert md[TEST_FAMILY_2].column_type == SqlType.Map(
+            SqlType.Bytes(), SqlType.Bytes()
+        )

--- a/tests/unit/data/execute_query/test_query_result_row_reader.py
+++ b/tests/unit/data/execute_query/test_query_result_row_reader.py
@@ -18,7 +18,7 @@ from google.cloud.bigtable_v2.types.data import Value as PBValue
 from google.cloud.bigtable.data.execute_query._reader import _QueryResultRowReader
 
 from google.cloud.bigtable.data.execute_query.metadata import (
-    ProtoMetadata,
+    Metadata,
     SqlType,
     _pb_metadata_to_metadata_types,
 )
@@ -37,9 +37,7 @@ from tests.unit.data.execute_query.sql_helpers import (
 
 class TestQueryResultRowReader:
     def test__single_values_received(self):
-        metadata = ProtoMetadata(
-            [("test1", SqlType.Int64()), ("test2", SqlType.Int64())]
-        )
+        metadata = Metadata([("test1", SqlType.Int64()), ("test2", SqlType.Int64())])
         values = [
             proto_rows_bytes(int_val(1), int_val(2)),
             proto_rows_bytes(int_val(3), int_val(4)),
@@ -61,9 +59,7 @@ class TestQueryResultRowReader:
             proto_rows_bytes(int_val(7), int_val(8)),
         ]
 
-        metadata = ProtoMetadata(
-            [("test1", SqlType.Int64()), ("test2", SqlType.Int64())]
-        )
+        metadata = Metadata([("test1", SqlType.Int64()), ("test2", SqlType.Int64())])
         reader = _QueryResultRowReader()
 
         result = reader.consume(values[0:1], metadata)
@@ -89,9 +85,7 @@ class TestQueryResultRowReader:
         assert result[0][1] == result[0]["test2"] == 8
 
     def test__received_values_are_passed_to_parser_in_batches(self):
-        metadata = ProtoMetadata(
-            [("test1", SqlType.Int64()), ("test2", SqlType.Int64())]
-        )
+        metadata = Metadata([("test1", SqlType.Int64()), ("test2", SqlType.Int64())])
 
         # TODO move to a SqlType test
         assert SqlType.Struct([("a", SqlType.Int64())]) == SqlType.Struct(
@@ -128,7 +122,7 @@ class TestQueryResultRowReader:
             )
 
     def test__parser_errors_are_forwarded(self):
-        metadata = ProtoMetadata([("test1", SqlType.Int64())])
+        metadata = Metadata([("test1", SqlType.Int64())])
 
         values = [str_val("test")]
 
@@ -236,7 +230,7 @@ class TestQueryResultRowReader:
         ]
         results = reader.consume(
             batches,
-            ProtoMetadata([("test1", SqlType.Int64()), ("test2", SqlType.Int64())]),
+            Metadata([("test1", SqlType.Int64()), ("test2", SqlType.Int64())]),
         )
         assert len(results) == 4
         [row1, row2, row3, row4] = results
@@ -250,9 +244,9 @@ class TestQueryResultRowReader:
         assert row4["test2"] == 8
 
 
-class TestProtoMetadata:
+class TestMetadata:
     def test__duplicate_column_names(self):
-        metadata = ProtoMetadata(
+        metadata = Metadata(
             [
                 ("test1", SqlType.Int64()),
                 ("test2", SqlType.Bytes()),


### PR DESCRIPTION
Removes ProtoMetadata because all of it's functionality is generic and ok to expose to users (column names and types). The original reason for this was to support other schema types in the future, while hiding them from users. The metadata will always have columns and types though, so this isn't currently necessary

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
