### PR TITLE
feat: throw better error on invalid metadata response

### DIFF
--- a/google/cloud/bigtable/data/execute_query/metadata.py
+++ b/google/cloud/bigtable/data/execute_query/metadata.py
@@ -369,6 +369,8 @@ def _pb_metadata_to_metadata_types(
 ) -> Metadata:
     if "proto_schema" in metadata_pb:
         fields: List[Tuple[Optional[str], SqlType.Type]] = []
+        if not metadata_pb.proto_schema.columns:
+            raise ValueError("Invalid empty ResultSetMetadata received.")
         for column_metadata in metadata_pb.proto_schema.columns:
             fields.append(
                 (column_metadata.name, _pb_type_to_metadata_type(column_metadata.type))

--- a/tests/unit/data/execute_query/test_metadata.py
+++ b/tests/unit/data/execute_query/test_metadata.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from google.cloud.bigtable.data.execute_query.metadata import (
+    _pb_metadata_to_metadata_types,
+)
+from google.cloud.bigtable_v2.types.data import ResultSetMetadata
+
+
+def test_empty_metadata_fails_parsing():
+    invalid_md_proto = ResultSetMetadata({"proto_schema": {"columns": []}})
+    with pytest.raises(ValueError):
+        _pb_metadata_to_metadata_types(invalid_md_proto)


### PR DESCRIPTION
Right now this manifests as a vague error later on. This message is more specific.

We don't expect this to happen, it would be an invalid response from the backend.