### PR TITLE
chore: add owlbot rule to preserve app_profile_id header

### DIFF
--- a/google/cloud/bigtable_v2/services/bigtable/async_client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/async_client.py
@@ -386,7 +386,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -510,7 +510,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -655,7 +655,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -794,7 +794,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -974,7 +974,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1093,7 +1093,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -1235,7 +1235,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1584,7 +1584,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -1704,7 +1704,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:

--- a/google/cloud/bigtable_v2/services/bigtable/async_client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/async_client.py
@@ -1584,9 +1584,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id is not None:
-            # prepare_query currently requires app_profile_id header to be set
-            # even when the request param is unpopulated TODO: remove after support is added
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -1706,9 +1704,7 @@ class BigtableAsyncClient:
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id is not None:
-            # execute_query currently requires app_profile_id header to be set
-            # even when the request param is unpopulated TODO: remove after support is added
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:

--- a/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -862,7 +862,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -983,7 +983,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1125,7 +1125,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1261,7 +1261,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1438,7 +1438,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -1554,7 +1554,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -1693,7 +1693,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("table_name"):
             header_params["table_name"] = regex_match.group("table_name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         routing_param_regex = re.compile(
@@ -2033,7 +2033,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -2150,7 +2150,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id:
+        if True:  # always attach app_profile_id, even if empty string
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:

--- a/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -2033,9 +2033,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id is not None:
-            # prepare_query currently requires app_profile_id header to be set
-            # even when the request param is unpopulated TODO: remove after support is added
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:
@@ -2152,9 +2150,7 @@ class BigtableClient(metaclass=BigtableClientMeta):
         if regex_match and regex_match.group("name"):
             header_params["name"] = regex_match.group("name")
 
-        if request.app_profile_id is not None:
-            # execute_query currently requires app_profile_id header to be set
-            # even when the request param is unpopulated TODO: remove after support is added
+        if request.app_profile_id:
             header_params["app_profile_id"] = request.app_profile_id
 
         if header_params:

--- a/owlbot.py
+++ b/owlbot.py
@@ -97,6 +97,18 @@ templated_files = common.py_library(
 
 s.move(templated_files, excludes=[".coveragerc", "README.rst", ".github/release-please.yml", "noxfile.py"])
 
+
+# ----------------------------------------------------------------------------
+# Always supply app_profile_id in routing headers: https://github.com/googleapis/python-bigtable/pull/1109
+# ----------------------------------------------------------------------------
+for file in ["async_client.py", "client.py"]:
+    s.replace(
+        f"google/cloud/bigtable_v2/services/bigtable/{file}",
+        "if request.app_profile_id:",
+        "if True:  # always attach app_profile_id, even if empty string. TODO: remove after support is added"
+    )
+ 
+
 # ----------------------------------------------------------------------------
 # Samples templates
 # ----------------------------------------------------------------------------

--- a/owlbot.py
+++ b/owlbot.py
@@ -100,12 +100,13 @@ s.move(templated_files, excludes=[".coveragerc", "README.rst", ".github/release-
 
 # ----------------------------------------------------------------------------
 # Always supply app_profile_id in routing headers: https://github.com/googleapis/python-bigtable/pull/1109
+# TODO: remove after backend no longer requires empty strings
 # ----------------------------------------------------------------------------
 for file in ["async_client.py", "client.py"]:
     s.replace(
         f"google/cloud/bigtable_v2/services/bigtable/{file}",
         "if request.app_profile_id:",
-        "if True:  # always attach app_profile_id, even if empty string. TODO: remove after support is added"
+        "if True:  # always attach app_profile_id, even if empty string"
     )
  
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -123,8 +123,8 @@ s.replace(
     """,
     """
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
-            "app_profile_id": ""
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
         }
     """
 )

--- a/owlbot.py
+++ b/owlbot.py
@@ -137,7 +137,7 @@ s.replace(
     """,
     """
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
             "app_profile_id": ""
         }
     """

--- a/owlbot.py
+++ b/owlbot.py
@@ -108,7 +108,12 @@ for file in ["async_client.py", "client.py"]:
         "if request.app_profile_id:",
         "if True:  # always attach app_profile_id, even if empty string"
     )
- 
+# fix tests
+s.replace(
+    "tests/unit/gapic/bigtable_v2/test_bigtable.py",
+    'expected_headers = {"name": "projects/sample1/instances/sample2"}',
+    'expected_headers = {"name": "projects/sample1/instances/sample2", "app_profile_id": ""}'
+)
 
 # ----------------------------------------------------------------------------
 # Samples templates

--- a/owlbot.py
+++ b/owlbot.py
@@ -114,6 +114,34 @@ s.replace(
     'expected_headers = {"name": "projects/sample1/instances/sample2"}',
     'expected_headers = {"name": "projects/sample1/instances/sample2", "app_profile_id": ""}'
 )
+s.replace(
+    "tests/unit/gapic/bigtable_v2/test_bigtable.py",
+    """
+        expected_headers = {
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+        }
+    """,
+    """
+        expected_headers = {
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
+            "app_profile_id": ""
+        }
+    """
+)
+s.replace(
+    "tests/unit/gapic/bigtable_v2/test_bigtable.py",
+    """
+        expected_headers = {
+            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+        }
+    """,
+    """
+        expected_headers = {
+            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "app_profile_id": ""
+        }
+    """
+)
 
 # ----------------------------------------------------------------------------
 # Samples templates

--- a/tests/system/data/test_system_async.py
+++ b/tests/system/data/test_system_async.py
@@ -207,6 +207,10 @@ class TestSystemAsync:
         assert len(results) == 1
         assert results[0] is None
 
+    @pytest.mark.skipif(
+        bool(os.environ.get(BIGTABLE_EMULATOR)),
+        reason="emulator mode doesn't refresh channel",
+    )
     @CrossSync.pytest
     async def test_channel_refresh(self, table_id, instance_id, temp_rows):
         """

--- a/tests/system/data/test_system_autogen.py
+++ b/tests/system/data/test_system_autogen.py
@@ -165,6 +165,10 @@ class TestSystem:
         assert len(results) == 1
         assert results[0] is None
 
+    @pytest.mark.skipif(
+        bool(os.environ.get(BIGTABLE_EMULATOR)),
+        reason="emulator mode doesn't refresh channel",
+    )
     def test_channel_refresh(self, table_id, instance_id, temp_rows):
         """change grpc channel to refresh after 1 second. Schedule a read_rows call after refresh,
         to ensure new channel works"""

--- a/tests/unit/data/_async/test_client.py
+++ b/tests/unit/data/_async/test_client.py
@@ -1311,7 +1311,8 @@ class TestTableAsync:
         if include_app_profile:
             assert "app_profile_id=profile" in routing_str
         else:
-            assert "app_profile_id=" not in routing_str
+            # empty app_profile_id should send empty string
+            assert "app_profile_id=" in routing_str
 
 
 @CrossSync.convert_class(

--- a/tests/unit/data/_sync_autogen/test_client.py
+++ b/tests/unit/data/_sync_autogen/test_client.py
@@ -1052,7 +1052,7 @@ class TestTable:
         if include_app_profile:
             assert "app_profile_id=profile" in routing_str
         else:
-            assert "app_profile_id=" not in routing_str
+            assert "app_profile_id=" in routing_str
 
 
 @CrossSync._Sync_Impl.add_mapping_decorator("TestReadRows")

--- a/tests/unit/gapic/bigtable_v2/test_bigtable.py
+++ b/tests/unit/gapic/bigtable_v2/test_bigtable.py
@@ -7442,11 +7442,7 @@ def test_prepare_query_routing_parameters_request_1_grpc():
 
         assert args[0] == request_msg
 
-        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {
-            "name": "projects/sample1/instances/sample2",
-            "app_profile_id": "",
-        }
+        expected_headers = {"name": "projects/sample1/instances/sample2"}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -7498,11 +7494,7 @@ def test_execute_query_routing_parameters_request_1_grpc():
 
         assert args[0] == request_msg
 
-        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {
-            "name": "projects/sample1/instances/sample2",
-            "app_profile_id": "",
-        }
+        expected_headers = {"name": "projects/sample1/instances/sample2"}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -8556,11 +8548,7 @@ async def test_prepare_query_routing_parameters_request_1_grpc_asyncio():
 
         assert args[0] == request_msg
 
-        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {
-            "name": "projects/sample1/instances/sample2",
-            "app_profile_id": "",
-        }
+        expected_headers = {"name": "projects/sample1/instances/sample2"}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -8623,11 +8611,7 @@ async def test_execute_query_routing_parameters_request_1_grpc_asyncio():
 
         assert args[0] == request_msg
 
-        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {
-            "name": "projects/sample1/instances/sample2",
-            "app_profile_id": "",
-        }
+        expected_headers = {"name": "projects/sample1/instances/sample2"}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -10878,11 +10862,7 @@ def test_prepare_query_routing_parameters_request_1_rest():
 
         assert args[0] == request_msg
 
-        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {
-            "name": "projects/sample1/instances/sample2",
-            "app_profile_id": "",
-        }
+        expected_headers = {"name": "projects/sample1/instances/sample2"}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -10932,11 +10912,7 @@ def test_execute_query_routing_parameters_request_1_rest():
 
         assert args[0] == request_msg
 
-        # expect app_profile_id while temporary patch is in place: https://github.com/googleapis/python-bigtable/pull/1072
-        expected_headers = {
-            "name": "projects/sample1/instances/sample2",
-            "app_profile_id": "",
-        }
+        expected_headers = {"name": "projects/sample1/instances/sample2"}
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )

--- a/tests/unit/gapic/bigtable_v2/test_bigtable.py
+++ b/tests/unit/gapic/bigtable_v2/test_bigtable.py
@@ -6851,7 +6851,8 @@ def test_read_rows_routing_parameters_request_1_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -6909,7 +6910,8 @@ def test_read_rows_routing_parameters_request_3_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -6939,7 +6941,8 @@ def test_sample_row_keys_routing_parameters_request_1_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -6997,7 +7000,8 @@ def test_sample_row_keys_routing_parameters_request_3_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7027,7 +7031,8 @@ def test_mutate_row_routing_parameters_request_1_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7085,7 +7090,8 @@ def test_mutate_row_routing_parameters_request_3_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7115,7 +7121,8 @@ def test_mutate_rows_routing_parameters_request_1_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7173,7 +7180,8 @@ def test_mutate_rows_routing_parameters_request_3_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7205,7 +7213,8 @@ def test_check_and_mutate_row_routing_parameters_request_1_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7267,7 +7276,8 @@ def test_check_and_mutate_row_routing_parameters_request_3_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7294,7 +7304,10 @@ def test_ping_and_warm_routing_parameters_request_1_grpc():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -7349,7 +7362,8 @@ def test_read_modify_write_row_routing_parameters_request_1_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7413,7 +7427,8 @@ def test_read_modify_write_row_routing_parameters_request_3_grpc():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7442,7 +7457,10 @@ def test_prepare_query_routing_parameters_request_1_grpc():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -7494,7 +7512,10 @@ def test_execute_query_routing_parameters_request_1_grpc():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -7859,7 +7880,8 @@ async def test_read_rows_routing_parameters_request_1_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7927,7 +7949,8 @@ async def test_read_rows_routing_parameters_request_3_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -7962,7 +7985,8 @@ async def test_sample_row_keys_routing_parameters_request_1_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8030,7 +8054,8 @@ async def test_sample_row_keys_routing_parameters_request_3_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8064,7 +8089,8 @@ async def test_mutate_row_routing_parameters_request_1_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8130,7 +8156,8 @@ async def test_mutate_row_routing_parameters_request_3_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8165,7 +8192,8 @@ async def test_mutate_rows_routing_parameters_request_1_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8233,7 +8261,8 @@ async def test_mutate_rows_routing_parameters_request_3_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8271,7 +8300,8 @@ async def test_check_and_mutate_row_routing_parameters_request_1_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8345,7 +8375,8 @@ async def test_check_and_mutate_row_routing_parameters_request_3_grpc_asyncio():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8378,7 +8409,10 @@ async def test_ping_and_warm_routing_parameters_request_1_grpc_asyncio():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -8441,7 +8475,8 @@ async def test_read_modify_write_row_routing_parameters_request_1_grpc_asyncio()
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8513,7 +8548,8 @@ async def test_read_modify_write_row_routing_parameters_request_3_grpc_asyncio()
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -8548,7 +8584,10 @@ async def test_prepare_query_routing_parameters_request_1_grpc_asyncio():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -8611,7 +8650,10 @@ async def test_execute_query_routing_parameters_request_1_grpc_asyncio():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -10291,7 +10333,8 @@ def test_read_rows_routing_parameters_request_1_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10347,7 +10390,8 @@ def test_read_rows_routing_parameters_request_3_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10376,7 +10420,8 @@ def test_sample_row_keys_routing_parameters_request_1_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10432,7 +10477,8 @@ def test_sample_row_keys_routing_parameters_request_3_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10461,7 +10507,8 @@ def test_mutate_row_routing_parameters_request_1_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10517,7 +10564,8 @@ def test_mutate_row_routing_parameters_request_3_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10546,7 +10594,8 @@ def test_mutate_rows_routing_parameters_request_1_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10602,7 +10651,8 @@ def test_mutate_rows_routing_parameters_request_3_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10633,7 +10683,8 @@ def test_check_and_mutate_row_routing_parameters_request_1_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10693,7 +10744,8 @@ def test_check_and_mutate_row_routing_parameters_request_3_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10719,7 +10771,10 @@ def test_ping_and_warm_routing_parameters_request_1_rest():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -10772,7 +10827,8 @@ def test_read_modify_write_row_routing_parameters_request_1_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "table_name": "projects/sample1/instances/sample2/tables/sample3"
+            "table_name": "projects/sample1/instances/sample2/tables/sample3",
+            "app_profile_id": "",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10834,7 +10890,8 @@ def test_read_modify_write_row_routing_parameters_request_3_rest():
         assert args[0] == request_msg
 
         expected_headers = {
-            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4"
+            "app_profile_id": "",
+            "authorized_view_name": "projects/sample1/instances/sample2/tables/sample3/authorizedViews/sample4",
         }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
@@ -10862,7 +10919,10 @@ def test_prepare_query_routing_parameters_request_1_rest():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )
@@ -10912,7 +10972,10 @@ def test_execute_query_routing_parameters_request_1_rest():
 
         assert args[0] == request_msg
 
-        expected_headers = {"name": "projects/sample1/instances/sample2"}
+        expected_headers = {
+            "name": "projects/sample1/instances/sample2",
+            "app_profile_id": "",
+        }
         assert (
             gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw["metadata"]
         )


### PR DESCRIPTION
We've [previously added](https://github.com/googleapis/python-bigtable/pull/1109) temporary changes to attach empty string app_profile_id routing headers. This PR makes a change to owlbot.py to ensure the change persists between gapic changes

This is only strictly needed for execute_query and prepare_query, but for simplicity I made the change across all rpcs

Long term, the backend should change, since empty string routing headers is out of spec