### PR TITLE
chore(tests): Use latest conformance test version and exclude unsupported features

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -24,17 +24,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-version: [ "v0.0.2" ]
+        test-version: [ "v0.0.4" ]
         py-version: [ 3.8 ]
-        client-type: [ "async", "sync", "legacy" ]
+        client-type: [ "async", "sync"]
+        # None of the clients currently support reverse scans, execute query plan refresh, retry info, or routing cookie
         include:
+          - client-type: "async"
+            test_args: "-skip \"PlanRefresh|_Reverse|_WithRetryInfo|_WithRoutingCookie\""
           - client-type: "sync"
-            # sync client does not support concurrent streams
-            test_args: "-skip _Generic_MultiStream"
-          - client-type: "legacy"
-            # legacy client is synchronous and does not support concurrent streams
-            # legacy client does not expose mutate_row. Disable those tests
-            test_args: "-skip _Generic_MultiStream -skip TestMutateRow_"
+            test_args: "-skip \"PlanRefresh|_Reverse|_WithRetryInfo|_WithRoutingCookie|_Generic_MultiStream\""
       fail-fast: false
     name: "${{ matrix.client-type }} client / python ${{ matrix.py-version }} / test tag ${{ matrix.test-version }}"
     steps:

--- a/google/cloud/bigtable/data/exceptions.py
+++ b/google/cloud/bigtable/data/exceptions.py
@@ -331,6 +331,9 @@ class FailedQueryShardError(Exception):
 class InvalidExecuteQueryResponse(core_exceptions.GoogleAPICallError):
     """Exception raised to invalid query response data from back-end."""
 
+    # Set to internal. This is representative of an internal error.
+    code = 13
+
 
 class ParameterTypeInferenceFailed(ValueError):
     """Exception raised when query parameter types were not provided and cannot be inferred."""

--- a/test_proxy/handlers/client_handler_data_async.py
+++ b/test_proxy/handlers/client_handler_data_async.py
@@ -276,7 +276,7 @@ class TestProxyClientHandlerAsync:
                 prepare_operation_timeout=operation_timeout,
             )
         )
-        rows = [r async for r in result]
+        rows = CrossSync.rm_aio([r async for r in result])
         md = result.metadata
         proto_rows = []
         for r in rows:

--- a/test_proxy/handlers/client_handler_data_sync_autogen.py
+++ b/test_proxy/handlers/client_handler_data_sync_autogen.py
@@ -205,7 +205,7 @@ class TestProxyClientHandler:
             operation_timeout=operation_timeout,
             prepare_operation_timeout=operation_timeout,
         )
-        rows = [r async for r in result]
+        rows = [r for r in result]
         md = result.metadata
         proto_rows = []
         for r in rows:


### PR DESCRIPTION
This updates the testproxy to match the MutateRows error handling change in https://github.com/googleapis/cloud-bigtable-clients-test/commit/826dfa6ceba80cb16e546944059ee5034a7992d5

Additionally, there are new deadline_exceeded tests that require adjusting the errors within the test proxy. There is a race that can cause deadline exceeded to manifest as either cancelled or deadline_exceeded in the client. See the comments for rationale on handling this

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
