### PR TITLE
test: Unskipped wait_for_consistency system tests in emulator

### DIFF
--- a/tests/system/admin_overlay/test_system_async.py
+++ b/tests/system/admin_overlay/test_system_async.py
@@ -279,6 +279,10 @@ async def assert_table_cell_value_equal_to(
     }
 )
 @CrossSync.pytest
+@pytest.mark.skipif(
+    os.getenv(BIGTABLE_EMULATOR),
+    reason="Backups are not supported in the Bigtable emulator",
+)
 @pytest.mark.parametrize(
     "second_instance_storage_type,expect_optimize_operation",
     [
@@ -296,11 +300,6 @@ async def test_optimize_restored_table(
     second_instance_storage_type,
     expect_optimize_operation,
 ):
-    if os.getenv(BIGTABLE_EMULATOR):
-        pytest.skip(
-            reason="Backups are not supported in the Bigtable emulator",
-        )
-
     # Create two instances. We backup a table from the first instance to a new table in the
     # second instance. This is to test whether or not different scenarios trigger an
     # optimize_restored_table operation

--- a/tests/system/admin_overlay/test_system_async.py
+++ b/tests/system/admin_overlay/test_system_async.py
@@ -145,7 +145,6 @@ async def create_instance(
 
     # Instance and cluster creation are currently unsupported in the Bigtable emulator
     if os.getenv(BIGTABLE_EMULATOR):
-
         # All we need for system tests so far is the instance name.
         instance = admin_v2.Instance(
             name=instance_admin_client.instance_path(project_id, instance_id),

--- a/tests/system/admin_overlay/test_system_autogen.py
+++ b/tests/system/admin_overlay/test_system_autogen.py
@@ -206,6 +206,10 @@ def assert_table_cell_value_equal_to(
         assert latest_cell.value.decode("utf-8") == value
 
 
+@pytest.mark.skipif(
+    os.getenv(BIGTABLE_EMULATOR),
+    reason="Backups are not supported in the Bigtable emulator",
+)
 @pytest.mark.parametrize(
     "second_instance_storage_type,expect_optimize_operation",
     [(admin_v2.StorageType.HDD, False), (admin_v2.StorageType.SSD, True)],
@@ -220,8 +224,6 @@ def test_optimize_restored_table(
     second_instance_storage_type,
     expect_optimize_operation,
 ):
-    if os.getenv(BIGTABLE_EMULATOR):
-        pytest.skip(reason="Backups are not supported in the Bigtable emulator")
     (instance_with_backup, table_to_backup) = create_instance(
         instance_admin_client,
         table_admin_client,

--- a/tests/system/admin_overlay/test_system_autogen.py
+++ b/tests/system/admin_overlay/test_system_autogen.py
@@ -215,7 +215,7 @@ def test_optimize_restored_table(
     second_instance_storage_type,
     expect_optimize_operation,
 ):
-    instance_with_backup, table_to_backup = create_instance(
+    (instance_with_backup, table_to_backup) = create_instance(
         instance_admin_client,
         table_admin_client,
         data_client,
@@ -223,7 +223,7 @@ def test_optimize_restored_table(
         instances_to_delete,
         admin_v2.StorageType.HDD,
     )
-    instance_to_restore, _ = create_instance(
+    (instance_to_restore, _) = create_instance(
         instance_admin_client,
         table_admin_client,
         data_client,
@@ -273,7 +273,7 @@ def test_wait_for_consistency(
     instances_to_delete,
     admin_overlay_project_id,
 ):
-    instance, table = create_instance(
+    (instance, table) = create_instance(
         instance_admin_client,
         table_admin_client,
         data_client,


### PR DESCRIPTION
Backups are not supported in the Bigtable emulator right now, but GenerateConsistencyToken/CheckConsistency are, so I am testing `wait_for_consistency` in the emulator.