### PR TITLE
fix: async client uses fixed grace period

### DIFF
--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -480,7 +480,9 @@ class BigtableDataClientAsync(ClientWithProject):
             old_channel = super_channel.swap_channel(new_channel)
             self._invalidate_channel_stubs()
             # give old_channel a chance to complete existing rpcs
-            await CrossSync.event_wait(self._is_closed, grace_period, async_break_early=False)
+            await CrossSync.event_wait(
+                self._is_closed, grace_period, async_break_early=False
+            )
             await old_channel.close()
             # subtract the time spent waiting for the channel to be replaced
             next_refresh = random.uniform(refresh_interval_min, refresh_interval_max)

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -480,9 +480,10 @@ class BigtableDataClientAsync(ClientWithProject):
             old_channel = super_channel.swap_channel(new_channel)
             self._invalidate_channel_stubs()
             # give old_channel a chance to complete existing rpcs
-            await CrossSync.event_wait(
-                self._is_closed, grace_period, async_break_early=False
-            )
+            if grace_period:
+                await CrossSync.event_wait(
+                    self._is_closed, grace_period, async_break_early=False
+                )
             await old_channel.close()
             # subtract the time spent waiting for the channel to be replaced
             next_refresh = random.uniform(refresh_interval_min, refresh_interval_max)

--- a/google/cloud/bigtable/data/_async/client.py
+++ b/google/cloud/bigtable/data/_async/client.py
@@ -480,12 +480,8 @@ class BigtableDataClientAsync(ClientWithProject):
             old_channel = super_channel.swap_channel(new_channel)
             self._invalidate_channel_stubs()
             # give old_channel a chance to complete existing rpcs
-            if CrossSync.is_async:
-                await old_channel.close(grace_period)
-            else:
-                if grace_period:
-                    self._is_closed.wait(grace_period)  # type: ignore
-                old_channel.close()  # type: ignore
+            await CrossSync.event_wait(self._is_closed, grace_period, async_break_early=False)
+            await old_channel.close()
             # subtract the time spent waiting for the channel to be replaced
             next_refresh = random.uniform(refresh_interval_min, refresh_interval_max)
             next_sleep = max(next_refresh - (time.monotonic() - start_timestamp), 0)

--- a/google/cloud/bigtable/data/_sync_autogen/client.py
+++ b/google/cloud/bigtable/data/_sync_autogen/client.py
@@ -363,9 +363,10 @@ class BigtableDataClient(ClientWithProject):
             self._ping_and_warm_instances(channel=new_channel)
             old_channel = super_channel.swap_channel(new_channel)
             self._invalidate_channel_stubs()
-            CrossSync._Sync_Impl.event_wait(
-                self._is_closed, grace_period, async_break_early=False
-            )
+            if grace_period:
+                CrossSync._Sync_Impl.event_wait(
+                    self._is_closed, grace_period, async_break_early=False
+                )
             old_channel.close()
             next_refresh = random.uniform(refresh_interval_min, refresh_interval_max)
             next_sleep = max(next_refresh - (time.monotonic() - start_timestamp), 0)

--- a/google/cloud/bigtable/data/_sync_autogen/client.py
+++ b/google/cloud/bigtable/data/_sync_autogen/client.py
@@ -363,8 +363,9 @@ class BigtableDataClient(ClientWithProject):
             self._ping_and_warm_instances(channel=new_channel)
             old_channel = super_channel.swap_channel(new_channel)
             self._invalidate_channel_stubs()
-            if grace_period:
-                self._is_closed.wait(grace_period)
+            CrossSync._Sync_Impl.event_wait(
+                self._is_closed, grace_period, async_break_early=False
+            )
             old_channel.close()
             next_refresh = random.uniform(refresh_interval_min, refresh_interval_max)
             next_sleep = max(next_refresh - (time.monotonic() - start_timestamp), 0)

--- a/tests/system/data/test_system_async.py
+++ b/tests/system/data/test_system_async.py
@@ -266,8 +266,8 @@ class TestSystemAsync:
     @CrossSync.pytest
     async def test_channel_refresh(self, table_id, instance_id, temp_rows):
         """
-        change grpc channel to refresh after 0.1 second. Schedule a read_rows call after refresh,
-        to ensure new channel works
+        change grpc channel to refresh quickly, then schedule a read_rows call after refresh
+        to ensure new channel is in place and works
         """
         await temp_rows.add_row(b"row_key_1")
         await temp_rows.add_row(b"row_key_2")
@@ -314,6 +314,7 @@ class TestSystemAsync:
         While swapping channels, consistently hit it with reads. Make sure no failures are found
         """
         import time
+
         await temp_rows.add_row(b"test_row")
         async with self._make_client() as client:
             client._channel_refresh_task.cancel()

--- a/tests/system/data/test_system_async.py
+++ b/tests/system/data/test_system_async.py
@@ -266,75 +266,49 @@ class TestSystemAsync:
     @CrossSync.pytest
     async def test_channel_refresh(self, table_id, instance_id, temp_rows):
         """
-        change grpc channel to refresh quickly, then schedule a read_rows call after refresh
-        to ensure new channel is in place and works
-        """
-        await temp_rows.add_row(b"row_key_1")
-        await temp_rows.add_row(b"row_key_2")
-        async with self._make_client() as client:
-            # start custom refresh task
-            client._channel_refresh_task.cancel()
-            client._channel_refresh_task = CrossSync.create_task(
-                client._manage_channel,
-                refresh_interval_min=0.25,
-                refresh_interval_max=0.25,
-                sync_executor=client._executor,
-            )
-            # let task run
-            await CrossSync.yield_to_event_loop()
-            async with client.get_table(instance_id, table_id) as table:
-                rows = await table.read_rows({})
-                channel_wrapper = client.transport.grpc_channel
-                first_channel = channel_wrapper._channel
-                assert len(rows) == 2
-                await CrossSync.sleep(0.5)
-                rows_after_refresh = await table.read_rows({})
-                assert len(rows_after_refresh) == 2
-                assert client.transport.grpc_channel is channel_wrapper
-                updated_channel = channel_wrapper._channel
-                assert updated_channel is not first_channel
-                # ensure interceptors are kept (gapic's logging interceptor, and metric interceptor)
-                if CrossSync.is_async:
-                    unary_interceptors = updated_channel._unary_unary_interceptors
-                    assert len(unary_interceptors) == 2
-                    assert GapicInterceptor in [type(i) for i in unary_interceptors]
-                    assert client._metrics_interceptor in unary_interceptors
-                    stream_interceptors = updated_channel._unary_stream_interceptors
-                    assert len(stream_interceptors) == 1
-                    assert client._metrics_interceptor in stream_interceptors
-                else:
-                    assert isinstance(
-                        client.transport._logged_channel._interceptor, GapicInterceptor
-                    )
-                    assert updated_channel._interceptor == client._metrics_interceptor
-
-    @CrossSync.pytest
-    async def test_channel_refresh_stress_test(self, table_id, instance_id, temp_rows):
-        """
-        While swapping channels, consistently hit it with reads. Make sure no failures are found
+        perform requests while swapping out the grpc channel. Requests should continue without error
         """
         import time
 
         await temp_rows.add_row(b"test_row")
         async with self._make_client() as client:
             client._channel_refresh_task.cancel()
+            channel_wrapper = client.transport.grpc_channel
+            first_channel = channel_wrapper._channel
             # swap channels frequently, with large grace windows
             client._channel_refresh_task = CrossSync.create_task(
                 client._manage_channel,
                 refresh_interval_min=0.1,
                 refresh_interval_max=0.1,
-                grace_period=0.2,
+                grace_period=1,
                 sync_executor=client._executor,
             )
 
             # hit channels with frequent requests
-            end_time = time.monotonic() + 1
+            end_time = time.monotonic() + 3
             async with client.get_table(instance_id, table_id) as table:
                 while time.monotonic() < end_time:
                     # we expect a CancelledError if a channel is closed before completion
                     rows = await table.read_rows({})
                     assert len(rows) == 1
                     await CrossSync.yield_to_event_loop()
+            # ensure channel was updated
+            updated_channel = channel_wrapper._channel
+            assert updated_channel is not first_channel
+            # ensure interceptors are kept (gapic's logging interceptor, and metric interceptor)
+            if CrossSync.is_async:
+                unary_interceptors = updated_channel._unary_unary_interceptors
+                assert len(unary_interceptors) == 2
+                assert GapicInterceptor in [type(i) for i in unary_interceptors]
+                assert client._metrics_interceptor in unary_interceptors
+                stream_interceptors = updated_channel._unary_stream_interceptors
+                assert len(stream_interceptors) == 1
+                assert client._metrics_interceptor in stream_interceptors
+            else:
+                assert isinstance(
+                    client.transport._logged_channel._interceptor, GapicInterceptor
+                )
+                assert updated_channel._interceptor == client._metrics_interceptor
 
     @CrossSync.pytest
     @pytest.mark.usefixtures("target")

--- a/tests/system/data/test_system_autogen.py
+++ b/tests/system/data/test_system_autogen.py
@@ -221,55 +221,33 @@ class TestSystem:
         reason="emulator mode doesn't refresh channel",
     )
     def test_channel_refresh(self, table_id, instance_id, temp_rows):
-        """change grpc channel to refresh quickly, then schedule a read_rows call after refresh
-        to ensure new channel is in place and works"""
-        temp_rows.add_row(b"row_key_1")
-        temp_rows.add_row(b"row_key_2")
-        with self._make_client() as client:
-            client._channel_refresh_task.cancel()
-            client._channel_refresh_task = CrossSync._Sync_Impl.create_task(
-                client._manage_channel,
-                refresh_interval_min=0.25,
-                refresh_interval_max=0.25,
-                sync_executor=client._executor,
-            )
-            CrossSync._Sync_Impl.yield_to_event_loop()
-            with client.get_table(instance_id, table_id) as table:
-                rows = table.read_rows({})
-                channel_wrapper = client.transport.grpc_channel
-                first_channel = channel_wrapper._channel
-                assert len(rows) == 2
-                CrossSync._Sync_Impl.sleep(0.5)
-                rows_after_refresh = table.read_rows({})
-                assert len(rows_after_refresh) == 2
-                assert client.transport.grpc_channel is channel_wrapper
-                updated_channel = channel_wrapper._channel
-                assert updated_channel is not first_channel
-                assert isinstance(
-                    client.transport._logged_channel._interceptor, GapicInterceptor
-                )
-                assert updated_channel._interceptor == client._metrics_interceptor
-
-    def test_channel_refresh_stress_test(self, table_id, instance_id, temp_rows):
-        """While swapping channels, consistently hit it with reads. Make sure no failures are found"""
+        """perform requests while swapping out the grpc channel. Requests should continue without error"""
         import time
 
         temp_rows.add_row(b"test_row")
         with self._make_client() as client:
             client._channel_refresh_task.cancel()
+            channel_wrapper = client.transport.grpc_channel
+            first_channel = channel_wrapper._channel
             client._channel_refresh_task = CrossSync._Sync_Impl.create_task(
                 client._manage_channel,
                 refresh_interval_min=0.1,
                 refresh_interval_max=0.1,
-                grace_period=0.2,
+                grace_period=1,
                 sync_executor=client._executor,
             )
-            end_time = time.monotonic() + 1
+            end_time = time.monotonic() + 3
             with client.get_table(instance_id, table_id) as table:
                 while time.monotonic() < end_time:
                     rows = table.read_rows({})
                     assert len(rows) == 1
                     CrossSync._Sync_Impl.yield_to_event_loop()
+            updated_channel = channel_wrapper._channel
+            assert updated_channel is not first_channel
+            assert isinstance(
+                client.transport._logged_channel._interceptor, GapicInterceptor
+            )
+            assert updated_channel._interceptor == client._metrics_interceptor
 
     @pytest.mark.usefixtures("target")
     @CrossSync._Sync_Impl.Retry(


### PR DESCRIPTION
Previously, when a channel refresh occurs, the async client would use `channel.close()` with a grace parameter to allow previous channels to keep serving old requests for a time. We were seeing flakes in our tests, showing that `channel.close()` isn't reliable, and can sometimes cancel ongoing requests before the grace period ends

This PR fixes this by using a fixed sleep time before calling close in the async client, like the sync client already does. This should remove the potential for cancelled requests before the grace period ends, and improve test flakiness

I also updated the system test to fully capture this problematic state, instead of encountering it in a random race condition