### PR TITLE
chore: remove releases.md

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -1,1 +1,0 @@
-../../bigtable/CHANGELOG.md


### PR DESCRIPTION
Remove [releases.md](https://github.com/googleapis/python-bigtable/blob/main/releases.md) which is unused. This points to CHANGELOG.md at `../../bigtable/CHANGELOG.md` which doesn't exist