### PR TITLE
fix: ensure gRPC channel options preserved during channel refresh

### DIFF
--- a/google/cloud/bigtable_v2/services/bigtable/transports/grpc.py
+++ b/google/cloud/bigtable_v2/services/bigtable/transports/grpc.py
@@ -42,6 +42,11 @@ except ImportError:  # pragma: NO COVER
 
 _LOGGER = std_logging.getLogger(__name__)
 
+# Allow for large rows in responses.
+GRPC_CLIENT_OPTIONS = [
+    ("grpc.max_send_message_length", -1),
+    ("grpc.max_receive_message_length", -1),
+]
 
 class _LoggingClientInterceptor(grpc.UnaryUnaryClientInterceptor):  # pragma: NO COVER
     def intercept_unary_unary(self, continuation, client_call_details, request):
@@ -256,10 +261,6 @@ class BigtableGrpcTransport(BigtableTransport):
                 scopes=self._scopes,
                 ssl_credentials=self._ssl_channel_credentials,
                 quota_project_id=quota_project_id,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
             )
 
         self._interceptor = _LoggingClientInterceptor()
@@ -307,6 +308,9 @@ class BigtableGrpcTransport(BigtableTransport):
               and ``credentials_file`` are passed.
         """
 
+        if "options" not in kwargs:
+            kwargs["options"] = GRPC_CLIENT_OPTIONS
+
         return grpc_helpers.create_channel(
             host,
             credentials=credentials,
@@ -315,6 +319,7 @@ class BigtableGrpcTransport(BigtableTransport):
             default_scopes=cls.AUTH_SCOPES,
             scopes=scopes,
             default_host=cls.DEFAULT_HOST,
+            options=GRPC_CLIENT_OPTIONS,
             **kwargs,
         )
 

--- a/google/cloud/bigtable_v2/services/bigtable/transports/grpc_asyncio.py
+++ b/google/cloud/bigtable_v2/services/bigtable/transports/grpc_asyncio.py
@@ -35,7 +35,7 @@ from grpc.experimental import aio  # type: ignore
 
 from google.cloud.bigtable_v2.types import bigtable
 from .base import BigtableTransport, DEFAULT_CLIENT_INFO
-from .grpc import BigtableGrpcTransport
+from .grpc import BigtableGrpcTransport, GRPC_CLIENT_OPTIONS
 
 try:
     from google.api_core import client_logging  # type: ignore
@@ -162,6 +162,9 @@ class BigtableGrpcAsyncIOTransport(BigtableTransport):
         Returns:
             aio.Channel: A gRPC AsyncIO channel object.
         """
+
+        if "options" not in kwargs:
+            kwargs["options"] = GRPC_CLIENT_OPTIONS
 
         return grpc_helpers_async.create_channel(
             host,
@@ -306,10 +309,6 @@ class BigtableGrpcAsyncIOTransport(BigtableTransport):
                 scopes=self._scopes,
                 ssl_credentials=self._ssl_channel_credentials,
                 quota_project_id=quota_project_id,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
             )
 
         self._interceptor = _LoggingClientAIOInterceptor()


### PR DESCRIPTION
The BigtableDataClient periodically refreshes its gRPC channel. However, when create_channel() is called during the refresh process, it doesn't include the unlimited message size options that are set during initial channel creation in __init__. This causes responses larger than 4 MB to fail with a ResourceExhausted error post-channel-refresh.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1240 🦕
