### PR TITLE
chore: Rerouted legacy client row filters to data client row filters.

### DIFF
--- a/google/cloud/bigtable/row.py
+++ b/google/cloud/bigtable/row.py
@@ -230,7 +230,7 @@ class _SetDeleteRow(Row):
         else:
             delete_kwargs = {}
             if time_range is not None:
-                delete_kwargs["time_range"] = time_range.to_pb()
+                delete_kwargs["time_range"] = time_range._to_pb()
 
             to_append = []
             for column in columns:
@@ -601,7 +601,7 @@ class ConditionalRow(_SetDeleteRow):
         resp = data_client.check_and_mutate_row(
             table_name=self._table.name,
             row_key=self._row_key,
-            predicate_filter=self._filter.to_pb(),
+            predicate_filter=self._filter._to_pb(),
             app_profile_id=self._table._app_profile_id,
             true_mutations=true_mutations,
             false_mutations=false_mutations,

--- a/google/cloud/bigtable/row_filters.py
+++ b/google/cloud/bigtable/row_filters.py
@@ -17,100 +17,56 @@
 import struct
 
 
-from google.cloud._helpers import _microseconds_from_datetime  # type: ignore
-from google.cloud._helpers import _to_bytes  # type: ignore
-from google.cloud.bigtable_v2.types import data as data_v2_pb2
+from google.cloud.bigtable.data.row_filters import (
+    RowFilter,
+    SinkFilter,
+    _BoolFilter as _BaseBoolFilter,
+    PassAllFilter,
+    BlockAllFilter,
+    _RegexFilter as _BaseRegexFilter,
+    RowKeyRegexFilter,
+    RowSampleFilter,
+    FamilyNameRegexFilter,
+    ColumnQualifierRegexFilter,
+    TimestampRange,
+    TimestampRangeFilter as BaseTimestampRangeFilter,
+    ColumnRangeFilter as BaseColumnRangeFilter,
+    ValueRegexFilter,
+    ValueRangeFilter,
+    _CellCountFilter as _BaseCellCountFilter,
+    CellsRowOffsetFilter,
+    CellsRowLimitFilter,
+    CellsColumnLimitFilter,
+    StripValueTransformerFilter,
+    ApplyLabelFilter,
+    _FilterCombination as _BaseFilterCombination,
+    RowFilterChain,
+    RowFilterUnion,
+    ConditionalRowFilter as BaseConditionalRowFilter,
+)
 
 _PACK_I64 = struct.Struct(">q").pack
 
+# The classes defined below are to provide constructors and members
+# that have an interface that does not match the one used by the data
+# client, for backwards compatibility purposes.
 
-class RowFilter(object):
-    """Basic filter to apply to cells in a row.
-
-    These values can be combined via :class:`RowFilterChain`,
-    :class:`RowFilterUnion` and :class:`ConditionalRowFilter`.
-
-    .. note::
-
-        This class is a do-nothing base class for all row filters.
-    """
+# Each underscored class is an ABC. Make them into classes that can be
+# instantiated with a placeholder to_dict method for consistency.
 
 
-class _BoolFilter(RowFilter):
+class _BoolFilter(_BaseBoolFilter):
     """Row filter that uses a boolean flag.
 
     :type flag: bool
     :param flag: An indicator if a setting is turned on or off.
     """
 
-    def __init__(self, flag):
-        self.flag = flag
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return other.flag == self.flag
-
-    def __ne__(self, other):
-        return not self == other
+    def _to_dict(self):
+        pass
 
 
-class SinkFilter(_BoolFilter):
-    """Advanced row filter to skip parent filters.
-
-    :type flag: bool
-    :param flag: ADVANCED USE ONLY. Hook for introspection into the row filter.
-                 Outputs all cells directly to the output of the read rather
-                 than to any parent filter. Cannot be used within the
-                 ``predicate_filter``, ``true_filter``, or ``false_filter``
-                 of a :class:`ConditionalRowFilter`.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(sink=self.flag)
-
-
-class PassAllFilter(_BoolFilter):
-    """Row filter equivalent to not filtering at all.
-
-    :type flag: bool
-    :param flag: Matches all cells, regardless of input. Functionally
-                 equivalent to leaving ``filter`` unset, but included for
-                 completeness.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(pass_all_filter=self.flag)
-
-
-class BlockAllFilter(_BoolFilter):
-    """Row filter that doesn't match any cells.
-
-    :type flag: bool
-    :param flag: Does not match any cells, regardless of input. Useful for
-                 temporarily disabling just part of a filter.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(block_all_filter=self.flag)
-
-
-class _RegexFilter(RowFilter):
+class _RegexFilter(_BaseRegexFilter):
     """Row filter that uses a regular expression.
 
     The ``regex`` must be valid RE2 patterns. See Google's
@@ -124,176 +80,11 @@ class _RegexFilter(RowFilter):
         will be encoded as ASCII.
     """
 
-    def __init__(self, regex):
-        self.regex = _to_bytes(regex)
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return other.regex == self.regex
-
-    def __ne__(self, other):
-        return not self == other
+    def _to_dict(self):
+        pass
 
 
-class RowKeyRegexFilter(_RegexFilter):
-    """Row filter for a row key regular expression.
-
-    The ``regex`` must be valid RE2 patterns. See Google's
-    `RE2 reference`_ for the accepted syntax.
-
-    .. _RE2 reference: https://github.com/google/re2/wiki/Syntax
-
-    .. note::
-
-        Special care need be used with the expression used. Since
-        each of these properties can contain arbitrary bytes, the ``\\C``
-        escape sequence must be used if a true wildcard is desired. The ``.``
-        character will not match the new line character ``\\n``, which may be
-        present in a binary value.
-
-    :type regex: bytes
-    :param regex: A regular expression (RE2) to match cells from rows with row
-                  keys that satisfy this regex. For a
-                  ``CheckAndMutateRowRequest``, this filter is unnecessary
-                  since the row key is already specified.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(row_key_regex_filter=self.regex)
-
-
-class RowSampleFilter(RowFilter):
-    """Matches all cells from a row with probability p.
-
-    :type sample: float
-    :param sample: The probability of matching a cell (must be in the
-                   interval ``(0, 1)``  The end points are excluded).
-    """
-
-    def __init__(self, sample):
-        self.sample = sample
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return other.sample == self.sample
-
-    def __ne__(self, other):
-        return not self == other
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(row_sample_filter=self.sample)
-
-
-class FamilyNameRegexFilter(_RegexFilter):
-    """Row filter for a family name regular expression.
-
-    The ``regex`` must be valid RE2 patterns. See Google's
-    `RE2 reference`_ for the accepted syntax.
-
-    .. _RE2 reference: https://github.com/google/re2/wiki/Syntax
-
-    :type regex: str
-    :param regex: A regular expression (RE2) to match cells from columns in a
-                  given column family. For technical reasons, the regex must
-                  not contain the ``':'`` character, even if it is not being
-                  used as a literal.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(family_name_regex_filter=self.regex)
-
-
-class ColumnQualifierRegexFilter(_RegexFilter):
-    """Row filter for a column qualifier regular expression.
-
-    The ``regex`` must be valid RE2 patterns. See Google's
-    `RE2 reference`_ for the accepted syntax.
-
-    .. _RE2 reference: https://github.com/google/re2/wiki/Syntax
-
-    .. note::
-
-        Special care need be used with the expression used. Since
-        each of these properties can contain arbitrary bytes, the ``\\C``
-        escape sequence must be used if a true wildcard is desired. The ``.``
-        character will not match the new line character ``\\n``, which may be
-        present in a binary value.
-
-    :type regex: bytes
-    :param regex: A regular expression (RE2) to match cells from column that
-                  match this regex (irrespective of column family).
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(column_qualifier_regex_filter=self.regex)
-
-
-class TimestampRange(object):
-    """Range of time with inclusive lower and exclusive upper bounds.
-
-    :type start: :class:`datetime.datetime`
-    :param start: (Optional) The (inclusive) lower bound of the timestamp
-                  range. If omitted, defaults to Unix epoch.
-
-    :type end: :class:`datetime.datetime`
-    :param end: (Optional) The (exclusive) upper bound of the timestamp
-                range. If omitted, no upper bound is used.
-    """
-
-    def __init__(self, start=None, end=None):
-        self.start = start
-        self.end = end
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return other.start == self.start and other.end == self.end
-
-    def __ne__(self, other):
-        return not self == other
-
-    def to_pb(self):
-        """Converts the :class:`TimestampRange` to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.TimestampRange`
-        :returns: The converted current object.
-        """
-        timestamp_range_kwargs = {}
-        if self.start is not None:
-            timestamp_range_kwargs["start_timestamp_micros"] = (
-                _microseconds_from_datetime(self.start) // 1000 * 1000
-            )
-        if self.end is not None:
-            end_time = _microseconds_from_datetime(self.end)
-            if end_time % 1000 != 0:
-                end_time = end_time // 1000 * 1000 + 1000
-            timestamp_range_kwargs["end_timestamp_micros"] = end_time
-        return data_v2_pb2.TimestampRange(**timestamp_range_kwargs)
-
-
-class TimestampRangeFilter(RowFilter):
+class TimestampRangeFilter(BaseTimestampRangeFilter):
     """Row filter that limits cells to a range of time.
 
     :type range_: :class:`TimestampRange`
@@ -303,27 +94,38 @@ class TimestampRangeFilter(RowFilter):
     def __init__(self, range_):
         self.range_ = range_
 
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return other.range_ == self.range_
 
-    def __ne__(self, other):
-        return not self == other
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        First converts the ``range_`` on the current object to a protobuf and
-        then uses it in the ``timestamp_range_filter`` field.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(timestamp_range_filter=self.range_.to_pb())
+class ExactValueFilter(ValueRegexFilter):
+    """Row filter for an exact value.
 
 
-class ColumnRangeFilter(RowFilter):
+    :type value: bytes or str or int
+    :param value:
+        a literal string encodable as ASCII, or the
+        equivalent bytes, or an integer (which will be packed into 8-bytes).
+    """
+
+    def __init__(self, value):
+        if isinstance(value, int):
+            value = _PACK_I64(value)
+        super(ExactValueFilter, self).__init__(value)
+
+
+class _CellCountFilter(_BaseCellCountFilter):
+    """Row filter that uses an integer count of cells.
+
+    The cell count is used as an offset or a limit for the number
+    of results returned.
+
+    :type num_cells: int
+    :param num_cells: An integer count / offset / limit.
+    """
+
+    def _to_dict(self):
+        pass
+
+
+class ColumnRangeFilter(BaseColumnRangeFilter):
     """A row filter to restrict to a range of columns.
 
     Both the start and end column can be included or excluded in the range.
@@ -368,342 +170,40 @@ class ColumnRangeFilter(RowFilter):
         inclusive_start=None,
         inclusive_end=None,
     ):
-        self.column_family_id = column_family_id
-
-        if inclusive_start is None:
-            inclusive_start = True
-        elif start_column is None:
-            raise ValueError(
-                "Inclusive start was specified but no " "start column was given."
-            )
-        self.start_column = start_column
-        self.inclusive_start = inclusive_start
-
-        if inclusive_end is None:
-            inclusive_end = True
-        elif end_column is None:
-            raise ValueError(
-                "Inclusive end was specified but no " "end column was given."
-            )
-        self.end_column = end_column
-        self.inclusive_end = inclusive_end
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return (
-            other.column_family_id == self.column_family_id
-            and other.start_column == self.start_column
-            and other.end_column == self.end_column
-            and other.inclusive_start == self.inclusive_start
-            and other.inclusive_end == self.inclusive_end
+        super(ColumnRangeFilter, self).__init__(
+            family_id=column_family_id,
+            start_qualifier=start_column,
+            end_qualifier=end_column,
+            inclusive_start=inclusive_start,
+            inclusive_end=inclusive_end,
         )
 
-    def __ne__(self, other):
-        return not self == other
+    @property
+    def column_family_id(self):
+        return self.family_id
 
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
+    @column_family_id.setter
+    def column_family_id(self, column_family_id):
+        self.family_id = column_family_id
 
-        First converts to a :class:`.data_v2_pb2.ColumnRange` and then uses it
-        in the ``column_range_filter`` field.
+    @property
+    def start_column(self):
+        return self.start_qualifier
 
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        column_range_kwargs = {"family_name": self.column_family_id}
-        if self.start_column is not None:
-            if self.inclusive_start:
-                key = "start_qualifier_closed"
-            else:
-                key = "start_qualifier_open"
-            column_range_kwargs[key] = _to_bytes(self.start_column)
-        if self.end_column is not None:
-            if self.inclusive_end:
-                key = "end_qualifier_closed"
-            else:
-                key = "end_qualifier_open"
-            column_range_kwargs[key] = _to_bytes(self.end_column)
+    @start_column.setter
+    def start_column(self, start_column):
+        self.start_qualifier = start_column
 
-        column_range = data_v2_pb2.ColumnRange(**column_range_kwargs)
-        return data_v2_pb2.RowFilter(column_range_filter=column_range)
+    @property
+    def end_column(self):
+        return self.end_qualifier
 
+    @end_column.setter
+    def end_column(self, end_column):
+        self.end_qualifier = end_column
 
-class ValueRegexFilter(_RegexFilter):
-    """Row filter for a value regular expression.
 
-    The ``regex`` must be valid RE2 patterns. See Google's
-    `RE2 reference`_ for the accepted syntax.
-
-    .. _RE2 reference: https://github.com/google/re2/wiki/Syntax
-
-    .. note::
-
-        Special care need be used with the expression used. Since
-        each of these properties can contain arbitrary bytes, the ``\\C``
-        escape sequence must be used if a true wildcard is desired. The ``.``
-        character will not match the new line character ``\\n``, which may be
-        present in a binary value.
-
-    :type regex: bytes or str
-    :param regex: A regular expression (RE2) to match cells with values that
-                  match this regex.  String values will be encoded as ASCII.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(value_regex_filter=self.regex)
-
-
-class ExactValueFilter(ValueRegexFilter):
-    """Row filter for an exact value.
-
-
-    :type value: bytes or str or int
-    :param value:
-        a literal string encodable as ASCII, or the
-        equivalent bytes, or an integer (which will be packed into 8-bytes).
-    """
-
-    def __init__(self, value):
-        if isinstance(value, int):
-            value = _PACK_I64(value)
-        super(ExactValueFilter, self).__init__(value)
-
-
-class ValueRangeFilter(RowFilter):
-    """A range of values to restrict to in a row filter.
-
-    Will only match cells that have values in this range.
-
-    Both the start and end value can be included or excluded in the range.
-    By default, we include them both, but this can be changed with optional
-    flags.
-
-    :type start_value: bytes
-    :param start_value: The start of the range of values. If no value is used,
-                        the backend applies no lower bound to the values.
-
-    :type end_value: bytes
-    :param end_value: The end of the range of values. If no value is used,
-                      the backend applies no upper bound to the values.
-
-    :type inclusive_start: bool
-    :param inclusive_start: Boolean indicating if the start value should be
-                            included in the range (or excluded). Defaults
-                            to :data:`True` if ``start_value`` is passed and
-                            no ``inclusive_start`` was given.
-
-    :type inclusive_end: bool
-    :param inclusive_end: Boolean indicating if the end value should be
-                          included in the range (or excluded). Defaults
-                          to :data:`True` if ``end_value`` is passed and
-                          no ``inclusive_end`` was given.
-
-    :raises: :class:`ValueError <exceptions.ValueError>` if ``inclusive_start``
-             is set but no ``start_value`` is given or if ``inclusive_end``
-             is set but no ``end_value`` is given
-    """
-
-    def __init__(
-        self, start_value=None, end_value=None, inclusive_start=None, inclusive_end=None
-    ):
-        if inclusive_start is None:
-            inclusive_start = True
-        elif start_value is None:
-            raise ValueError(
-                "Inclusive start was specified but no " "start value was given."
-            )
-        if isinstance(start_value, int):
-            start_value = _PACK_I64(start_value)
-        self.start_value = start_value
-        self.inclusive_start = inclusive_start
-
-        if inclusive_end is None:
-            inclusive_end = True
-        elif end_value is None:
-            raise ValueError(
-                "Inclusive end was specified but no " "end value was given."
-            )
-        if isinstance(end_value, int):
-            end_value = _PACK_I64(end_value)
-        self.end_value = end_value
-        self.inclusive_end = inclusive_end
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return (
-            other.start_value == self.start_value
-            and other.end_value == self.end_value
-            and other.inclusive_start == self.inclusive_start
-            and other.inclusive_end == self.inclusive_end
-        )
-
-    def __ne__(self, other):
-        return not self == other
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        First converts to a :class:`.data_v2_pb2.ValueRange` and then uses
-        it to create a row filter protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        value_range_kwargs = {}
-        if self.start_value is not None:
-            if self.inclusive_start:
-                key = "start_value_closed"
-            else:
-                key = "start_value_open"
-            value_range_kwargs[key] = _to_bytes(self.start_value)
-        if self.end_value is not None:
-            if self.inclusive_end:
-                key = "end_value_closed"
-            else:
-                key = "end_value_open"
-            value_range_kwargs[key] = _to_bytes(self.end_value)
-
-        value_range = data_v2_pb2.ValueRange(**value_range_kwargs)
-        return data_v2_pb2.RowFilter(value_range_filter=value_range)
-
-
-class _CellCountFilter(RowFilter):
-    """Row filter that uses an integer count of cells.
-
-    The cell count is used as an offset or a limit for the number
-    of results returned.
-
-    :type num_cells: int
-    :param num_cells: An integer count / offset / limit.
-    """
-
-    def __init__(self, num_cells):
-        self.num_cells = num_cells
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return other.num_cells == self.num_cells
-
-    def __ne__(self, other):
-        return not self == other
-
-
-class CellsRowOffsetFilter(_CellCountFilter):
-    """Row filter to skip cells in a row.
-
-    :type num_cells: int
-    :param num_cells: Skips the first N cells of the row.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(cells_per_row_offset_filter=self.num_cells)
-
-
-class CellsRowLimitFilter(_CellCountFilter):
-    """Row filter to limit cells in a row.
-
-    :type num_cells: int
-    :param num_cells: Matches only the first N cells of the row.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(cells_per_row_limit_filter=self.num_cells)
-
-
-class CellsColumnLimitFilter(_CellCountFilter):
-    """Row filter to limit cells in a column.
-
-    :type num_cells: int
-    :param num_cells: Matches only the most recent N cells within each column.
-                      This filters a (family name, column) pair, based on
-                      timestamps of each cell.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(cells_per_column_limit_filter=self.num_cells)
-
-
-class StripValueTransformerFilter(_BoolFilter):
-    """Row filter that transforms cells into empty string (0 bytes).
-
-    :type flag: bool
-    :param flag: If :data:`True`, replaces each cell's value with the empty
-                 string. As the name indicates, this is more useful as a
-                 transformer than a generic query / filter.
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(strip_value_transformer=self.flag)
-
-
-class ApplyLabelFilter(RowFilter):
-    """Filter to apply labels to cells.
-
-    Intended to be used as an intermediate filter on a pre-existing filtered
-    result set. This way if two sets are combined, the label can tell where
-    the cell(s) originated.This allows the client to determine which results
-    were produced from which part of the filter.
-
-    .. note::
-
-        Due to a technical limitation of the backend, it is not currently
-        possible to apply multiple labels to a cell.
-
-    :type label: str
-    :param label: Label to apply to cells in the output row. Values must be
-                  at most 15 characters long, and match the pattern
-                  ``[a-z0-9\\-]+``.
-    """
-
-    def __init__(self, label):
-        self.label = label
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return other.label == self.label
-
-    def __ne__(self, other):
-        return not self == other
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        return data_v2_pb2.RowFilter(apply_label_transformer=self.label)
-
-
-class _FilterCombination(RowFilter):
+class _FilterCombination(_BaseFilterCombination):
     """Chain of row filters.
 
     Sends rows through several filters in sequence. The filters are "chained"
@@ -714,69 +214,11 @@ class _FilterCombination(RowFilter):
     :param filters: List of :class:`RowFilter`
     """
 
-    def __init__(self, filters=None):
-        if filters is None:
-            filters = []
-        self.filters = filters
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return other.filters == self.filters
-
-    def __ne__(self, other):
-        return not self == other
+    def _to_dict(self):
+        pass
 
 
-class RowFilterChain(_FilterCombination):
-    """Chain of row filters.
-
-    Sends rows through several filters in sequence. The filters are "chained"
-    together to process a row. After the first filter is applied, the second
-    is applied to the filtered output and so on for subsequent filters.
-
-    :type filters: list
-    :param filters: List of :class:`RowFilter`
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        chain = data_v2_pb2.RowFilter.Chain(
-            filters=[row_filter.to_pb() for row_filter in self.filters]
-        )
-        return data_v2_pb2.RowFilter(chain=chain)
-
-
-class RowFilterUnion(_FilterCombination):
-    """Union of row filters.
-
-    Sends rows through several filters simultaneously, then
-    merges / interleaves all the filtered results together.
-
-    If multiple cells are produced with the same column and timestamp,
-    they will all appear in the output row in an unspecified mutual order.
-
-    :type filters: list
-    :param filters: List of :class:`RowFilter`
-    """
-
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        interleave = data_v2_pb2.RowFilter.Interleave(
-            filters=[row_filter.to_pb() for row_filter in self.filters]
-        )
-        return data_v2_pb2.RowFilter(interleave=interleave)
-
-
-class ConditionalRowFilter(RowFilter):
+class ConditionalRowFilter(BaseConditionalRowFilter):
     """Conditional row filter which exhibits ternary behavior.
 
     Executes one of two filters based on another filter. If the ``base_filter``
@@ -806,33 +248,36 @@ class ConditionalRowFilter(RowFilter):
                          will be returned in the false case.
     """
 
-    def __init__(self, base_filter, true_filter=None, false_filter=None):
-        self.base_filter = base_filter
-        self.true_filter = true_filter
-        self.false_filter = false_filter
+    @property
+    def base_filter(self):
+        return self.predicate_filter
 
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return (
-            other.base_filter == self.base_filter
-            and other.true_filter == self.true_filter
-            and other.false_filter == self.false_filter
-        )
+    @base_filter.setter
+    def base_filter(self, value: RowFilter):
+        self.predicate_filter = value
 
-    def __ne__(self, other):
-        return not self == other
 
-    def to_pb(self):
-        """Converts the row filter to a protobuf.
-
-        :rtype: :class:`.data_v2_pb2.RowFilter`
-        :returns: The converted current object.
-        """
-        condition_kwargs = {"predicate_filter": self.base_filter.to_pb()}
-        if self.true_filter is not None:
-            condition_kwargs["true_filter"] = self.true_filter.to_pb()
-        if self.false_filter is not None:
-            condition_kwargs["false_filter"] = self.false_filter.to_pb()
-        condition = data_v2_pb2.RowFilter.Condition(**condition_kwargs)
-        return data_v2_pb2.RowFilter(condition=condition)
+__all__ = (
+    RowFilter,
+    SinkFilter,
+    PassAllFilter,
+    BlockAllFilter,
+    RowKeyRegexFilter,
+    RowSampleFilter,
+    FamilyNameRegexFilter,
+    ColumnQualifierRegexFilter,
+    TimestampRange,
+    TimestampRangeFilter,
+    ColumnRangeFilter,
+    ValueRegexFilter,
+    ExactValueFilter,
+    ValueRangeFilter,
+    CellsRowOffsetFilter,
+    CellsRowLimitFilter,
+    CellsColumnLimitFilter,
+    StripValueTransformerFilter,
+    ApplyLabelFilter,
+    RowFilterChain,
+    RowFilterUnion,
+    ConditionalRowFilter,
+)

--- a/google/cloud/bigtable/table.py
+++ b/google/cloud/bigtable/table.py
@@ -1327,7 +1327,7 @@ def _create_row_request(
         raise ValueError("Row range and row set cannot be " "set simultaneously")
 
     if filter_ is not None:
-        request_kwargs["filter"] = filter_.to_pb()
+        request_kwargs["filter"] = filter_._to_pb()
     if limit is not None:
         request_kwargs["rows_limit"] = limit
     if app_profile_id is not None:

--- a/tests/unit/v2_client/test_row.py
+++ b/tests/unit/v2_client/test_row.py
@@ -282,7 +282,7 @@ def _delete_cells_helper(time_range=None):
         )
     )
     if time_range is not None:
-        expected_pb.delete_from_column.time_range._pb.CopyFrom(time_range.to_pb()._pb)
+        expected_pb.delete_from_column.time_range._pb.CopyFrom(time_range._to_pb()._pb)
     assert row._pb_mutations == [expected_pb]
 
 

--- a/tests/unit/v2_client/test_row_data.py
+++ b/tests/unit/v2_client/test_row_data.py
@@ -928,7 +928,7 @@ def test_RRRM_build_updated_request(rrrm_data):
     row_filter = RowSampleFilter(0.33)
     last_scanned_key = b"row_key25"
     request = _ReadRowsRequestPB(
-        filter=row_filter.to_pb(),
+        filter=row_filter._to_pb(),
         rows_limit=8,
         table_name=TABLE_NAME,
         app_profile_id="app-profile-id-1",
@@ -941,7 +941,7 @@ def test_RRRM_build_updated_request(rrrm_data):
 
     expected_result = _ReadRowsRequestPB(
         table_name=TABLE_NAME,
-        filter=row_filter.to_pb(),
+        filter=row_filter._to_pb(),
         rows_limit=6,
         app_profile_id="app-profile-id-1",
     )
@@ -976,7 +976,7 @@ def test_RRRM_build_updated_request_no_start_key():
     row_filter = RowSampleFilter(0.33)
     last_scanned_key = b"row_key25"
     request = _ReadRowsRequestPB(
-        filter=row_filter.to_pb(), rows_limit=8, table_name=TABLE_NAME
+        filter=row_filter._to_pb(), rows_limit=8, table_name=TABLE_NAME
     )
     row_range1 = types.RowRange(end_key_open=b"row_key29")
     request.rows.row_ranges.append(row_range1)
@@ -986,7 +986,7 @@ def test_RRRM_build_updated_request_no_start_key():
     result = request_manager.build_updated_request()
 
     expected_result = _ReadRowsRequestPB(
-        table_name=TABLE_NAME, filter=row_filter.to_pb(), rows_limit=6
+        table_name=TABLE_NAME, filter=row_filter._to_pb(), rows_limit=6
     )
 
     row_range2 = types.RowRange(
@@ -1004,7 +1004,7 @@ def test_RRRM_build_updated_request_no_end_key():
     row_filter = RowSampleFilter(0.33)
     last_scanned_key = b"row_key25"
     request = _ReadRowsRequestPB(
-        filter=row_filter.to_pb(), rows_limit=8, table_name=TABLE_NAME
+        filter=row_filter._to_pb(), rows_limit=8, table_name=TABLE_NAME
     )
 
     row_range1 = types.RowRange(start_key_closed=b"row_key20")
@@ -1015,7 +1015,7 @@ def test_RRRM_build_updated_request_no_end_key():
     result = request_manager.build_updated_request()
 
     expected_result = _ReadRowsRequestPB(
-        table_name=TABLE_NAME, filter=row_filter.to_pb(), rows_limit=6
+        table_name=TABLE_NAME, filter=row_filter._to_pb(), rows_limit=6
     )
     row_range2 = types.RowRange(start_key_open=last_scanned_key)
     expected_result.rows.row_ranges.append(row_range2)
@@ -1029,7 +1029,7 @@ def test_RRRM_build_updated_request_rows():
     row_filter = RowSampleFilter(0.33)
     last_scanned_key = b"row_key4"
     request = _ReadRowsRequestPB(
-        filter=row_filter.to_pb(), rows_limit=5, table_name=TABLE_NAME
+        filter=row_filter._to_pb(), rows_limit=5, table_name=TABLE_NAME
     )
     request.rows.row_keys.extend(
         [b"row_key1", b"row_key2", b"row_key4", b"row_key5", b"row_key7", b"row_key9"]
@@ -1040,7 +1040,7 @@ def test_RRRM_build_updated_request_rows():
     result = request_manager.build_updated_request()
 
     expected_result = _ReadRowsRequestPB(
-        table_name=TABLE_NAME, filter=row_filter.to_pb(), rows_limit=2
+        table_name=TABLE_NAME, filter=row_filter._to_pb(), rows_limit=2
     )
     expected_result.rows.row_keys.extend([b"row_key5", b"row_key7", b"row_key9"])
 

--- a/tests/unit/v2_client/test_row_filters.py
+++ b/tests/unit/v2_client/test_row_filters.py
@@ -15,18 +15,21 @@
 
 import pytest
 
+from google.cloud.bigtable.row_filters import (
+    _BoolFilter as _BaseBoolFilter,
+    _RegexFilter as _BaseRegexFilter,
+    _CellCountFilter as _BaseCellCountFilter,
+    _FilterCombination as _BaseFilterCombination,
+)
+
 
 def test_bool_filter_constructor():
-    from google.cloud.bigtable.row_filters import _BoolFilter
-
     flag = object()
     row_filter = _BoolFilter(flag)
     assert row_filter.flag is flag
 
 
 def test_bool_filter___eq__type_differ():
-    from google.cloud.bigtable.row_filters import _BoolFilter
-
     flag = object()
     row_filter1 = _BoolFilter(flag)
     row_filter2 = object()
@@ -34,8 +37,6 @@ def test_bool_filter___eq__type_differ():
 
 
 def test_bool_filter___eq__same_value():
-    from google.cloud.bigtable.row_filters import _BoolFilter
-
     flag = object()
     row_filter1 = _BoolFilter(flag)
     row_filter2 = _BoolFilter(flag)
@@ -43,8 +44,6 @@ def test_bool_filter___eq__same_value():
 
 
 def test_bool_filter___ne__same_value():
-    from google.cloud.bigtable.row_filters import _BoolFilter
-
     flag = object()
     row_filter1 = _BoolFilter(flag)
     row_filter2 = _BoolFilter(flag)
@@ -82,24 +81,18 @@ def test_block_all_filter_to_pb():
 
 
 def test_regex_filterconstructor():
-    from google.cloud.bigtable.row_filters import _RegexFilter
-
     regex = b"abc"
     row_filter = _RegexFilter(regex)
     assert row_filter.regex is regex
 
 
 def test_regex_filterconstructor_non_bytes():
-    from google.cloud.bigtable.row_filters import _RegexFilter
-
     regex = "abc"
     row_filter = _RegexFilter(regex)
     assert row_filter.regex == b"abc"
 
 
 def test_regex_filter__eq__type_differ():
-    from google.cloud.bigtable.row_filters import _RegexFilter
-
     regex = b"def-rgx"
     row_filter1 = _RegexFilter(regex)
     row_filter2 = object()
@@ -107,8 +100,6 @@ def test_regex_filter__eq__type_differ():
 
 
 def test_regex_filter__eq__same_value():
-    from google.cloud.bigtable.row_filters import _RegexFilter
-
     regex = b"trex-regex"
     row_filter1 = _RegexFilter(regex)
     row_filter2 = _RegexFilter(regex)
@@ -116,8 +107,6 @@ def test_regex_filter__eq__same_value():
 
 
 def test_regex_filter__ne__same_value():
-    from google.cloud.bigtable.row_filters import _RegexFilter
-
     regex = b"abc"
     row_filter1 = _RegexFilter(regex)
     row_filter2 = _RegexFilter(regex)
@@ -733,16 +722,12 @@ def test_value_range_filter_to_pb_exclusive_end():
 
 
 def test_cell_count_constructor():
-    from google.cloud.bigtable.row_filters import _CellCountFilter
-
     num_cells = object()
     row_filter = _CellCountFilter(num_cells)
     assert row_filter.num_cells is num_cells
 
 
 def test_cell_count___eq__type_differ():
-    from google.cloud.bigtable.row_filters import _CellCountFilter
-
     num_cells = object()
     row_filter1 = _CellCountFilter(num_cells)
     row_filter2 = object()
@@ -750,8 +735,6 @@ def test_cell_count___eq__type_differ():
 
 
 def test_cell_count___eq__same_value():
-    from google.cloud.bigtable.row_filters import _CellCountFilter
-
     num_cells = object()
     row_filter1 = _CellCountFilter(num_cells)
     row_filter2 = _CellCountFilter(num_cells)
@@ -759,8 +742,6 @@ def test_cell_count___eq__same_value():
 
 
 def test_cell_count___ne__same_value():
-    from google.cloud.bigtable.row_filters import _CellCountFilter
-
     num_cells = object()
     row_filter1 = _CellCountFilter(num_cells)
     row_filter2 = _CellCountFilter(num_cells)
@@ -854,23 +835,17 @@ def test_apply_label_filter_to_pb():
 
 
 def test_filter_combination_constructor_defaults():
-    from google.cloud.bigtable.row_filters import _FilterCombination
-
     row_filter = _FilterCombination()
     assert row_filter.filters == []
 
 
 def test_filter_combination_constructor_explicit():
-    from google.cloud.bigtable.row_filters import _FilterCombination
-
     filters = object()
     row_filter = _FilterCombination(filters=filters)
     assert row_filter.filters is filters
 
 
 def test_filter_combination___eq__():
-    from google.cloud.bigtable.row_filters import _FilterCombination
-
     filters = object()
     row_filter1 = _FilterCombination(filters=filters)
     row_filter2 = _FilterCombination(filters=filters)
@@ -878,8 +853,6 @@ def test_filter_combination___eq__():
 
 
 def test_filter_combination___eq__type_differ():
-    from google.cloud.bigtable.row_filters import _FilterCombination
-
     filters = object()
     row_filter1 = _FilterCombination(filters=filters)
     row_filter2 = object()
@@ -887,8 +860,6 @@ def test_filter_combination___eq__type_differ():
 
 
 def test_filter_combination___ne__():
-    from google.cloud.bigtable.row_filters import _FilterCombination
-
     filters = object()
     other_filters = object()
     row_filter1 = _FilterCombination(filters=filters)
@@ -1114,6 +1085,26 @@ def test_conditional_row_filter_to_pb_false_only():
         )
     )
     assert filter_pb == expected_pb
+
+
+class _BoolFilter(_BaseBoolFilter):
+    def _to_dict(self):
+        pass
+
+
+class _RegexFilter(_BaseRegexFilter):
+    def _to_dict(self):
+        pass
+
+
+class _CellCountFilter(_BaseCellCountFilter):
+    def _to_dict(self):
+        pass
+
+
+class _FilterCombination(_BaseFilterCombination):
+    def _to_dict(self):
+        pass
 
 
 def _ColumnRangePB(*args, **kw):

--- a/tests/unit/v2_client/test_row_filters.py
+++ b/tests/unit/v2_client/test_row_filters.py
@@ -56,7 +56,7 @@ def test_sink_filter_to_pb():
 
     flag = True
     row_filter = SinkFilter(flag)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(sink=flag)
     assert pb_val == expected_pb
 
@@ -66,7 +66,7 @@ def test_pass_all_filter_to_pb():
 
     flag = True
     row_filter = PassAllFilter(flag)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(pass_all_filter=flag)
     assert pb_val == expected_pb
 
@@ -76,7 +76,7 @@ def test_block_all_filter_to_pb():
 
     flag = True
     row_filter = BlockAllFilter(flag)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(block_all_filter=flag)
     assert pb_val == expected_pb
 
@@ -129,7 +129,7 @@ def test_row_key_regex_filter_to_pb():
 
     regex = b"row-key-regex"
     row_filter = RowKeyRegexFilter(regex)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(row_key_regex_filter=regex)
     assert pb_val == expected_pb
 
@@ -175,7 +175,7 @@ def test_row_sample_filter_to_pb():
 
     sample = 0.25
     row_filter = RowSampleFilter(sample)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(row_sample_filter=sample)
     assert pb_val == expected_pb
 
@@ -185,7 +185,7 @@ def test_family_name_regex_filter_to_pb():
 
     regex = "family-regex"
     row_filter = FamilyNameRegexFilter(regex)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(family_name_regex_filter=regex)
     assert pb_val == expected_pb
 
@@ -195,7 +195,7 @@ def test_column_qualifier_regext_filter_to_pb():
 
     regex = b"column-regex"
     row_filter = ColumnQualifierRegexFilter(regex)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(column_qualifier_regex_filter=regex)
     assert pb_val == expected_pb
 
@@ -251,7 +251,7 @@ def _timestamp_range_to_pb_helper(pb_kwargs, start=None, end=None):
         end = _EPOCH + datetime.timedelta(microseconds=end)
     time_range = TimestampRange(start=start, end=end)
     expected_pb = _TimestampRangePB(**pb_kwargs)
-    time_pb = time_range.to_pb()
+    time_pb = time_range._to_pb()
     assert time_pb.start_timestamp_micros == expected_pb.start_timestamp_micros
     assert time_pb.end_timestamp_micros == expected_pb.end_timestamp_micros
     assert time_pb == expected_pb
@@ -332,7 +332,7 @@ def test_timestamp_range_filter_to_pb():
 
     range_ = TimestampRange()
     row_filter = TimestampRangeFilter(range_)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(timestamp_range_filter=_TimestampRangePB())
     assert pb_val == expected_pb
 
@@ -454,7 +454,7 @@ def test_column_range_filter_to_pb():
     row_filter = ColumnRangeFilter(column_family_id)
     col_range_pb = _ColumnRangePB(family_name=column_family_id)
     expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_column_range_filter_to_pb_inclusive_start():
@@ -467,7 +467,7 @@ def test_column_range_filter_to_pb_inclusive_start():
         family_name=column_family_id, start_qualifier_closed=column
     )
     expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_column_range_filter_to_pb_exclusive_start():
@@ -482,7 +482,7 @@ def test_column_range_filter_to_pb_exclusive_start():
         family_name=column_family_id, start_qualifier_open=column
     )
     expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_column_range_filter_to_pb_inclusive_end():
@@ -495,7 +495,7 @@ def test_column_range_filter_to_pb_inclusive_end():
         family_name=column_family_id, end_qualifier_closed=column
     )
     expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_column_range_filter_to_pb_exclusive_end():
@@ -510,7 +510,7 @@ def test_column_range_filter_to_pb_exclusive_end():
         family_name=column_family_id, end_qualifier_open=column
     )
     expected_pb = _RowFilterPB(column_range_filter=col_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_value_regex_filter_to_pb_w_bytes():
@@ -518,7 +518,7 @@ def test_value_regex_filter_to_pb_w_bytes():
 
     value = regex = b"value-regex"
     row_filter = ValueRegexFilter(value)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(value_regex_filter=regex)
     assert pb_val == expected_pb
 
@@ -529,7 +529,7 @@ def test_value_regex_filter_to_pb_w_str():
     value = "value-regex"
     regex = value.encode("ascii")
     row_filter = ValueRegexFilter(value)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(value_regex_filter=regex)
     assert pb_val == expected_pb
 
@@ -539,7 +539,7 @@ def test_exact_value_filter_to_pb_w_bytes():
 
     value = regex = b"value-regex"
     row_filter = ExactValueFilter(value)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(value_regex_filter=regex)
     assert pb_val == expected_pb
 
@@ -550,7 +550,7 @@ def test_exact_value_filter_to_pb_w_str():
     value = "value-regex"
     regex = value.encode("ascii")
     row_filter = ExactValueFilter(value)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(value_regex_filter=regex)
     assert pb_val == expected_pb
 
@@ -562,7 +562,7 @@ def test_exact_value_filter_to_pb_w_int():
     value = 1
     regex = struct.Struct(">q").pack(value)
     row_filter = ExactValueFilter(value)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(value_regex_filter=regex)
     assert pb_val == expected_pb
 
@@ -689,7 +689,7 @@ def test_value_range_filter_to_pb():
 
     row_filter = ValueRangeFilter()
     expected_pb = _RowFilterPB(value_range_filter=_ValueRangePB())
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_value_range_filter_to_pb_inclusive_start():
@@ -699,7 +699,7 @@ def test_value_range_filter_to_pb_inclusive_start():
     row_filter = ValueRangeFilter(start_value=value)
     val_range_pb = _ValueRangePB(start_value_closed=value)
     expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_value_range_filter_to_pb_exclusive_start():
@@ -709,7 +709,7 @@ def test_value_range_filter_to_pb_exclusive_start():
     row_filter = ValueRangeFilter(start_value=value, inclusive_start=False)
     val_range_pb = _ValueRangePB(start_value_open=value)
     expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_value_range_filter_to_pb_inclusive_end():
@@ -719,7 +719,7 @@ def test_value_range_filter_to_pb_inclusive_end():
     row_filter = ValueRangeFilter(end_value=value)
     val_range_pb = _ValueRangePB(end_value_closed=value)
     expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_value_range_filter_to_pb_exclusive_end():
@@ -729,7 +729,7 @@ def test_value_range_filter_to_pb_exclusive_end():
     row_filter = ValueRangeFilter(end_value=value, inclusive_end=False)
     val_range_pb = _ValueRangePB(end_value_open=value)
     expected_pb = _RowFilterPB(value_range_filter=val_range_pb)
-    assert row_filter.to_pb() == expected_pb
+    assert row_filter._to_pb() == expected_pb
 
 
 def test_cell_count_constructor():
@@ -772,7 +772,7 @@ def test_cells_row_offset_filter_to_pb():
 
     num_cells = 76
     row_filter = CellsRowOffsetFilter(num_cells)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(cells_per_row_offset_filter=num_cells)
     assert pb_val == expected_pb
 
@@ -782,7 +782,7 @@ def test_cells_row_limit_filter_to_pb():
 
     num_cells = 189
     row_filter = CellsRowLimitFilter(num_cells)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(cells_per_row_limit_filter=num_cells)
     assert pb_val == expected_pb
 
@@ -792,7 +792,7 @@ def test_cells_column_limit_filter_to_pb():
 
     num_cells = 10
     row_filter = CellsColumnLimitFilter(num_cells)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(cells_per_column_limit_filter=num_cells)
     assert pb_val == expected_pb
 
@@ -802,7 +802,7 @@ def test_strip_value_transformer_filter_to_pb():
 
     flag = True
     row_filter = StripValueTransformerFilter(flag)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(strip_value_transformer=flag)
     assert pb_val == expected_pb
 
@@ -848,7 +848,7 @@ def test_apply_label_filter_to_pb():
 
     label = "label"
     row_filter = ApplyLabelFilter(label)
-    pb_val = row_filter.to_pb()
+    pb_val = row_filter._to_pb()
     expected_pb = _RowFilterPB(apply_label_transformer=label)
     assert pb_val == expected_pb
 
@@ -902,13 +902,13 @@ def test_row_filter_chain_to_pb():
     from google.cloud.bigtable.row_filters import StripValueTransformerFilter
 
     row_filter1 = StripValueTransformerFilter(True)
-    row_filter1_pb = row_filter1.to_pb()
+    row_filter1_pb = row_filter1._to_pb()
 
     row_filter2 = RowSampleFilter(0.25)
-    row_filter2_pb = row_filter2.to_pb()
+    row_filter2_pb = row_filter2._to_pb()
 
     row_filter3 = RowFilterChain(filters=[row_filter1, row_filter2])
-    filter_pb = row_filter3.to_pb()
+    filter_pb = row_filter3._to_pb()
 
     expected_pb = _RowFilterPB(
         chain=_RowFilterChainPB(filters=[row_filter1_pb, row_filter2_pb])
@@ -926,13 +926,13 @@ def test_row_filter_chain_to_pb_nested():
     row_filter2 = RowSampleFilter(0.25)
 
     row_filter3 = RowFilterChain(filters=[row_filter1, row_filter2])
-    row_filter3_pb = row_filter3.to_pb()
+    row_filter3_pb = row_filter3._to_pb()
 
     row_filter4 = CellsRowLimitFilter(11)
-    row_filter4_pb = row_filter4.to_pb()
+    row_filter4_pb = row_filter4._to_pb()
 
     row_filter5 = RowFilterChain(filters=[row_filter3, row_filter4])
-    filter_pb = row_filter5.to_pb()
+    filter_pb = row_filter5._to_pb()
 
     expected_pb = _RowFilterPB(
         chain=_RowFilterChainPB(filters=[row_filter3_pb, row_filter4_pb])
@@ -946,13 +946,13 @@ def test_row_filter_union_to_pb():
     from google.cloud.bigtable.row_filters import StripValueTransformerFilter
 
     row_filter1 = StripValueTransformerFilter(True)
-    row_filter1_pb = row_filter1.to_pb()
+    row_filter1_pb = row_filter1._to_pb()
 
     row_filter2 = RowSampleFilter(0.25)
-    row_filter2_pb = row_filter2.to_pb()
+    row_filter2_pb = row_filter2._to_pb()
 
     row_filter3 = RowFilterUnion(filters=[row_filter1, row_filter2])
-    filter_pb = row_filter3.to_pb()
+    filter_pb = row_filter3._to_pb()
 
     expected_pb = _RowFilterPB(
         interleave=_RowFilterInterleavePB(filters=[row_filter1_pb, row_filter2_pb])
@@ -970,13 +970,13 @@ def test_row_filter_union_to_pb_nested():
     row_filter2 = RowSampleFilter(0.25)
 
     row_filter3 = RowFilterUnion(filters=[row_filter1, row_filter2])
-    row_filter3_pb = row_filter3.to_pb()
+    row_filter3_pb = row_filter3._to_pb()
 
     row_filter4 = CellsRowLimitFilter(11)
-    row_filter4_pb = row_filter4.to_pb()
+    row_filter4_pb = row_filter4._to_pb()
 
     row_filter5 = RowFilterUnion(filters=[row_filter3, row_filter4])
-    filter_pb = row_filter5.to_pb()
+    filter_pb = row_filter5._to_pb()
 
     expected_pb = _RowFilterPB(
         interleave=_RowFilterInterleavePB(filters=[row_filter3_pb, row_filter4_pb])
@@ -1049,18 +1049,18 @@ def test_conditional_row_filter_to_pb():
     from google.cloud.bigtable.row_filters import StripValueTransformerFilter
 
     row_filter1 = StripValueTransformerFilter(True)
-    row_filter1_pb = row_filter1.to_pb()
+    row_filter1_pb = row_filter1._to_pb()
 
     row_filter2 = RowSampleFilter(0.25)
-    row_filter2_pb = row_filter2.to_pb()
+    row_filter2_pb = row_filter2._to_pb()
 
     row_filter3 = CellsRowOffsetFilter(11)
-    row_filter3_pb = row_filter3.to_pb()
+    row_filter3_pb = row_filter3._to_pb()
 
     row_filter4 = ConditionalRowFilter(
         row_filter1, true_filter=row_filter2, false_filter=row_filter3
     )
-    filter_pb = row_filter4.to_pb()
+    filter_pb = row_filter4._to_pb()
 
     expected_pb = _RowFilterPB(
         condition=_RowFilterConditionPB(
@@ -1078,13 +1078,13 @@ def test_conditional_row_filter_to_pb_true_only():
     from google.cloud.bigtable.row_filters import StripValueTransformerFilter
 
     row_filter1 = StripValueTransformerFilter(True)
-    row_filter1_pb = row_filter1.to_pb()
+    row_filter1_pb = row_filter1._to_pb()
 
     row_filter2 = RowSampleFilter(0.25)
-    row_filter2_pb = row_filter2.to_pb()
+    row_filter2_pb = row_filter2._to_pb()
 
     row_filter3 = ConditionalRowFilter(row_filter1, true_filter=row_filter2)
-    filter_pb = row_filter3.to_pb()
+    filter_pb = row_filter3._to_pb()
 
     expected_pb = _RowFilterPB(
         condition=_RowFilterConditionPB(
@@ -1100,13 +1100,13 @@ def test_conditional_row_filter_to_pb_false_only():
     from google.cloud.bigtable.row_filters import StripValueTransformerFilter
 
     row_filter1 = StripValueTransformerFilter(True)
-    row_filter1_pb = row_filter1.to_pb()
+    row_filter1_pb = row_filter1._to_pb()
 
     row_filter2 = RowSampleFilter(0.25)
-    row_filter2_pb = row_filter2.to_pb()
+    row_filter2_pb = row_filter2._to_pb()
 
     row_filter3 = ConditionalRowFilter(row_filter1, false_filter=row_filter2)
-    filter_pb = row_filter3.to_pb()
+    filter_pb = row_filter3._to_pb()
 
     expected_pb = _RowFilterPB(
         condition=_RowFilterConditionPB(

--- a/tests/unit/v2_client/test_table.py
+++ b/tests/unit/v2_client/test_table.py
@@ -2133,7 +2133,7 @@ def test__create_row_request_with_filter():
     row_filter = RowSampleFilter(0.33)
     result = _create_row_request(table_name, filter_=row_filter)
     expected_result = _ReadRowsRequestPB(
-        table_name=table_name, filter=row_filter.to_pb()
+        table_name=table_name, filter=row_filter._to_pb()
     )
     assert result == expected_result
 


### PR DESCRIPTION
**Changes made:**
- Used import aliasing to remove most of the legacy client row filter code and use the data client row filter code in its place.
- Some of the data client row filter classes had to be slightly modified for backwards compatibility with the legacy client row filter classes' interface.
- As part of this move, `to_pb` has been replaced with `_to_pb`, and I have adjusted references to `<RowFilter>.to_pb` in the libraries and unit tests.

This is for eventually shimming up `CheckAndMutateRows`, and other row mutation operations as well.
