### PR TITLE
[DRAFT] feat: use RetryInfo metadata from retryable exceptions

### DIFF
--- a/google/cloud/bigtable/data/_helpers.py
+++ b/google/cloud/bigtable/data/_helpers.py
@@ -25,7 +25,6 @@ from google.cloud.bigtable.data.read_rows_query import ReadRowsQuery
 from google.api_core import exceptions as core_exceptions
 from google.api_core.retry import exponential_sleep_generator
 from google.api_core.retry import RetryFailureReason
-from google.rpc.error_details_pb2 import RetryInfo
 from google.cloud.bigtable.data.exceptions import RetryExceptionGroup
 
 if TYPE_CHECKING:
@@ -308,15 +307,3 @@ class TrackedBackoffGenerator:
         if attempt_idx < 0:
             raise IndexError("received negative attempt number")
         return self.history[attempt_idx]
-
-    def set_from_exception_info(self, retry_info: RetryInfo):
-        """
-        Use a RetryInfo object to set the next sleep time.
-
-        If a problem is encountered, this method does nothing.
-        """
-        try:
-            retry_seconds = retry_info.retry_delay.ToTimedelta().total_seconds()
-            self.set_next(retry_seconds)
-        except Exception:
-            pass

--- a/google/cloud/bigtable/data/_metrics/tracked_retry.py
+++ b/google/cloud/bigtable/data/_metrics/tracked_retry.py
@@ -67,7 +67,9 @@ def _track_retryable_error(
                 if exc.details:
                     info = next((field for field in exc.details if isinstance(field, RetryInfo)), None)
                     if info:
-                        operation.backoff_generator.set_from_exception_info(info)
+                        # override next backoff with server-provided value
+                        retry_seconds = info.retry_delay.ToTimedelta().total_seconds()
+                        operation.backoff_generator.set_next(retry_seconds)
         except Exception:
             # ignore errors in metadata collection
             pass


### PR DESCRIPTION
Proof of concept of the RetryInfo feature. Allows the backend to set retry backoff settings

TODO: 
- the python backoff method [uses truncated backoff](https://github.com/googleapis/python-api-core/blob/a6a5b6fe788610a9fe00a276615f3f7d3d8be7ce/google/api_core/retry/retry_base.py#L100), but the conformance tests enforce a minimum value. This is causing one of the conformance tests to be flaky
- Do we only need the first retry info? Or do we expect multiple?
- Feature flags?
- implement disable feature
- tests