### PR TITLE
chore: remove 3.9 tests from kokoro

### DIFF
--- a/.kokoro/presubmit/system.cfg
+++ b/.kokoro/presubmit/system.cfg
@@ -3,5 +3,5 @@
 # Only run this nox session.
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.9"
+    value: "system-3.10"
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -63,7 +63,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.9", "3.14"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10", "3.14"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",
@@ -83,7 +83,6 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 # 'docfx' is excluded since it only needs to run in 'docs-presubmit'
 nox.options.sessions = [
-    "unit-3.9",
     "unit-3.10",
     "unit-3.11",
     "unit-3.12",


### PR DESCRIPTION
3.9 has been removed from the kokoro base image, so we should remove the tests from our configs

3.9 is still tested in GitHub Actions
